### PR TITLE
fix(ci): exclude e2e from vitest, pass-with-no-tests for scaffold phase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - run: npm ci
       - run: npx tsc --noEmit
       - run: npx eslint src --max-warnings 0
-      - run: npx vitest run --coverage
+      - run: npx vitest run --coverage --passWithNoTests
       - run: npx playwright install --with-deps chromium
       - run: npx playwright test
       - name: Bundle budget check

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -4,5 +4,5 @@ import { test, expect } from "@playwright/test";
 // Expanded in Phase 3 (auth flows) and Phase 5 (player).
 test("homepage loads", async ({ page }) => {
   await page.goto("/");
-  await expect(page).toHaveTitle(/Vite \+ React/);
+  await expect(page).toHaveTitle(/streamvault-v3-frontend/);
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./src/test-setup.ts"],
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    exclude: ["tests/e2e/**", "node_modules/**"],
     coverage: {
       provider: "v8",
       include: ["src/primitives/**", "src/api/**"],


### PR DESCRIPTION
## Summary
- Vitest was picking up tests/e2e/smoke.spec.ts (Playwright) and failing on the Playwright test() API
- Added explicit include/exclude patterns to vite.config.ts test config
- Added --passWithNoTests to vitest CI step (no unit tests exist at Phase 0 scaffold)
- Fixed smoke.spec.ts title assertion to match actual page title (streamvault-v3-frontend, not Vite + React)

## Test plan
- [ ] CI passes on this PR