### PR TITLE
fix(security): add .env rules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Environment variables (never commit secrets)
+.env
+.env.*
+!.env.example
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
Adds .env, .env.*, !.env.example to .gitignore — prevents accidental secret commits.