### PR TITLE
feat(primitives): Button — primary/outlined/ghost, focus-ring, accessible

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,8 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./brand/tokens.css";
-import "./primitives/focus-ring.css";
 import "./index.css";
+import "./primitives/index.css"; // aggregator — all primitive stylesheets
 import App from "./App.tsx";
 
 createRoot(document.getElementById("root")!).render(

--- a/src/primitives/Button.test.tsx
+++ b/src/primitives/Button.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Button primitive — TDD tests (Task 1.4)
+ *
+ * RED first: Button does not exist yet. All tests must fail.
+ * GREEN: implement Button.tsx to pass all 5 assertions.
+ *
+ * Spec: plan Task 1.4 Step 1 + design spec §8 focus ring.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { Button } from "./Button";
+
+describe("Button", () => {
+  it("renders label", () => {
+    render(<Button>Play</Button>);
+    expect(screen.getByRole("button", { name: "Play" })).toBeInTheDocument();
+  });
+
+  it("calls onClick when pressed", async () => {
+    const handler = vi.fn();
+    render(<Button onClick={handler}>Play</Button>);
+    await userEvent.click(screen.getByRole("button"));
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("is disabled when disabled prop set", () => {
+    render(<Button disabled>Play</Button>);
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("renders copper-bordered variant", () => {
+    render(<Button variant="outlined">Back</Button>);
+    expect(screen.getByRole("button").className).toContain("outlined");
+  });
+
+  it("has visible text label (no icon-only without aria-label)", () => {
+    render(<Button>Play</Button>);
+    expect(screen.getByRole("button")).toHaveTextContent("Play");
+  });
+
+  it("does NOT fire onClick when disabled", async () => {
+    const handler = vi.fn();
+    render(
+      <Button disabled onClick={handler}>
+        Play
+      </Button>,
+    );
+    await userEvent.click(screen.getByRole("button"));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("applies focus-ring class on every variant", () => {
+    const { rerender } = render(<Button variant="primary">P</Button>);
+    expect(screen.getByRole("button").className).toContain("focus-ring");
+
+    rerender(<Button variant="outlined">O</Button>);
+    expect(screen.getByRole("button").className).toContain("focus-ring");
+
+    rerender(<Button variant="ghost">G</Button>);
+    expect(screen.getByRole("button").className).toContain("focus-ring");
+  });
+
+  it("defaults to type=button to prevent accidental form submission", () => {
+    render(<Button>Submit</Button>);
+    expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+  });
+});

--- a/src/primitives/Button.test.tsx
+++ b/src/primitives/Button.test.tsx
@@ -31,7 +31,7 @@ describe("Button", () => {
 
   it("renders copper-bordered variant", () => {
     render(<Button variant="outlined">Back</Button>);
-    expect(screen.getByRole("button").className).toContain("outlined");
+    expect(screen.getByRole("button").className).toContain("btn--outlined");
   });
 
   it("has visible text label (no icon-only without aria-label)", () => {

--- a/src/primitives/Button.tsx
+++ b/src/primitives/Button.tsx
@@ -34,7 +34,7 @@ export interface ButtonProps extends Omit<
 
 const variantClass: Record<NonNullable<ButtonProps["variant"]>, string> = {
   primary: "btn--primary",
-  outlined: "btn--outlined outlined",
+  outlined: "btn--outlined",
   ghost: "btn--ghost",
 };
 

--- a/src/primitives/Button.tsx
+++ b/src/primitives/Button.tsx
@@ -1,0 +1,70 @@
+/**
+ * Button — Oxide button primitive (Task 1.4)
+ *
+ * Variants: primary (default) | outlined | ghost
+ * Sizes:    sm | md (default) | lg
+ *
+ * Design decisions:
+ * - Native <button> for semantics and keyboard focus out-of-the-box.
+ * - `type="button"` default prevents accidental form submission on TV remote OK.
+ * - `focus-ring` class injected directly (no FocusRing wrapper) — avoids cloneElement
+ *   overhead and keeps the DOM ref chain clean for norigin-spatial-navigation.
+ * - All colours via CSS custom properties only (no hardcoded hex).
+ * - CSS lives in src/primitives/button.css (aggregated via primitives/index.css).
+ *
+ * Spec: plan Task 1.4 + design spec §8 focus ring.
+ */
+import React from "react";
+import "./button.css";
+
+export interface ButtonProps extends Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "type"
+> {
+  /** Visual style — defaults to "primary". */
+  variant?: "primary" | "outlined" | "ghost";
+  /** Padding + font-size scale — defaults to "md". */
+  size?: "sm" | "md" | "lg";
+  /**
+   * Forward the HTML `type` attribute. Defaults to "button" (not "submit")
+   * so TV remote OK press never triggers accidental form submissions.
+   */
+  type?: "button" | "submit" | "reset";
+}
+
+const variantClass: Record<NonNullable<ButtonProps["variant"]>, string> = {
+  primary: "btn--primary",
+  outlined: "btn--outlined outlined",
+  ghost: "btn--ghost",
+};
+
+const sizeClass: Record<NonNullable<ButtonProps["size"]>, string> = {
+  sm: "btn--sm",
+  md: "btn--md",
+  lg: "btn--lg",
+};
+
+export function Button({
+  variant = "primary",
+  size = "md",
+  type = "button",
+  className,
+  children,
+  ...rest
+}: ButtonProps): React.ReactElement {
+  const classes = [
+    "btn",
+    "focus-ring",
+    variantClass[variant],
+    sizeClass[size],
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <button type={type} className={classes} {...rest}>
+      {children}
+    </button>
+  );
+}

--- a/src/primitives/button.css
+++ b/src/primitives/button.css
@@ -1,0 +1,115 @@
+/**
+ * Oxide Button — primitive CSS (Task 1.4)
+ *
+ * Three variants: primary | outlined | ghost
+ * Three sizes:    sm | md | lg
+ *
+ * All colour values reference Oxide tokens from src/brand/tokens.css.
+ * No hardcoded hex — CSS custom properties only.
+ *
+ * Spec: plan Task 1.4 + design spec §6 Spacing / Radius / Motion.
+ */
+
+/* ─────────────────────────────────────────────────────
+   Base
+   ───────────────────────────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-ui);
+  font-weight: 500;
+  border-radius: var(--radius-sm); /* buttons = 8px per spec §6 Radius */
+  border: 1.5px solid transparent;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background var(--motion-focus),
+    color var(--motion-focus),
+    border-color var(--motion-focus),
+    filter var(--motion-focus);
+  /* focus-ring class handles :focus-visible outline via focus-ring.css */
+}
+
+.btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none; /* belt + suspenders — keyboard events still fire via native disabled */
+}
+
+/* ─────────────────────────────────────────────────────
+   Variants
+   ───────────────────────────────────────────────────── */
+
+/* Primary — copper fill */
+.btn--primary {
+  background: var(--accent-copper);
+  color: var(--bg-base);
+  border-color: transparent;
+}
+
+.btn--primary:hover:not(:disabled) {
+  filter: brightness(0.92);
+}
+
+.btn--primary:active:not(:disabled) {
+  filter: brightness(0.84);
+}
+
+/* Outlined — copper border, transparent fill */
+.btn--outlined {
+  background: transparent;
+  color: var(--accent-copper);
+  border-color: var(--accent-copper);
+}
+
+.btn--outlined:hover:not(:disabled) {
+  background: var(--bg-elevated);
+}
+
+.btn--outlined:active:not(:disabled) {
+  background: var(--bg-surface);
+}
+
+/* Ghost — no border, muted text */
+.btn--ghost {
+  background: transparent;
+  color: var(--text-secondary);
+  border-color: transparent;
+}
+
+.btn--ghost:hover:not(:disabled) {
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+}
+
+.btn--ghost:active:not(:disabled) {
+  background: var(--bg-surface);
+}
+
+/* ─────────────────────────────────────────────────────
+   Sizes — padding + font-size
+   Spec §6 Spacing + Typography scale
+   TV minimum: 14px text (design spec §6 Typography note)
+   ───────────────────────────────────────────────────── */
+
+/* sm — 14px text, 6px/12px padding */
+.btn--sm {
+  font-size: var(--text-label-size); /* 14px */
+  line-height: var(--text-label-line);
+  padding: 6px 12px;
+}
+
+/* md — 16px text (caption scale), 8px/16px padding */
+.btn--md {
+  font-size: var(--text-caption-size); /* 16px */
+  line-height: var(--text-caption-line);
+  padding: 8px 16px;
+}
+
+/* lg — 20px text (body scale), 12px/24px padding */
+.btn--lg {
+  font-size: var(--text-body-size); /* 20px */
+  line-height: var(--text-body-line);
+  padding: 12px 24px;
+}

--- a/src/primitives/button.css
+++ b/src/primitives/button.css
@@ -34,7 +34,6 @@
 .btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
-  pointer-events: none; /* belt + suspenders — keyboard events still fire via native disabled */
 }
 
 /* ─────────────────────────────────────────────────────

--- a/src/primitives/index.css
+++ b/src/primitives/index.css
@@ -1,0 +1,11 @@
+/**
+ * Oxide Primitives — CSS aggregator (Task 1.4)
+ *
+ * Import this single file from src/main.tsx instead of individual
+ * primitive stylesheets. Each new primitive adds one @import here —
+ * main.tsx stays stable.
+ *
+ * Order matters: focus-ring first (other primitives reference .focus-ring class).
+ */
+@import "./focus-ring.css";
+@import "./button.css";


### PR DESCRIPTION
## Summary
Phase 1 / Task 1.4 — Button primitive with three variants (primary/outlined/ghost) and three sizes (sm/md/lg). Native `<button>`, focus-ring applied on all variants, disabled honoured (no click fire), type=button default.

Also lands the CSS aggregator pattern (`primitives/index.css`) so `main.tsx` stops growing per primitive.

## Spec
- Plan: docs/superpowers/plans/2026-04-15-streamvault-v3-implementation.md (Task 1.4)
- Design: docs/superpowers/specs/2026-04-15-streamvault-v3-design.md (button section)

## Changes
| File | Lines | Purpose |
|------|-------|---------|
| `src/primitives/Button.tsx` | +70 | Button component — 3 variants, 3 sizes, focus-ring, type=button default |
| `src/primitives/Button.test.tsx` | +66 | 8 TDD tests (RED → GREEN verified) |
| `src/primitives/button.css` | +95 | CSS vars only — primary/outlined/ghost styles + sm/md/lg sizes |
| `src/primitives/index.css` | +10 | CSS aggregator — @imports focus-ring.css + button.css |
| `src/main.tsx` | ±1 | Swapped direct focus-ring.css import → primitives/index.css aggregator |

## Test plan
- [x] `npm test` — 8 new Button tests + 10 existing = 18 total green
- [x] `npm run typecheck` — clean (exactOptionalPropertyTypes + noUncheckedIndexedAccess)
- [x] `npm run build` — 59.95 KB gzip (budget: 800 KB)
- [x] Disabled button does NOT fire onClick (explicit test)
- [x] focus-ring class present on all 3 variants (explicit test)
- [x] type="button" default prevents accidental form submission (explicit test)
- [x] main.tsx uses primitives/index.css aggregator — no longer imports focus-ring.css directly
- [x] No hardcoded hex — CSS custom properties only

## TDD evidence
RED: `Error: Failed to resolve import "./Button"` — correct failure (module missing, not typo)
GREEN: 8/8 Button tests pass; 18/18 total project tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)