### PR TITLE
feat(primitives): Card + Skeleton + cx helper; adopt in Button/FocusRing

### DIFF
--- a/src/primitives/Button.tsx
+++ b/src/primitives/Button.tsx
@@ -15,6 +15,7 @@
  * Spec: plan Task 1.4 + design spec §8 focus ring.
  */
 import React from "react";
+import { cx } from "./cx";
 import "./button.css";
 
 export interface ButtonProps extends Omit<
@@ -52,15 +53,13 @@ export function Button({
   children,
   ...rest
 }: ButtonProps): React.ReactElement {
-  const classes = [
+  const classes = cx(
     "btn",
     "focus-ring",
     variantClass[variant],
     sizeClass[size],
     className,
-  ]
-    .filter(Boolean)
-    .join(" ");
+  );
 
   return (
     <button type={type} className={classes} {...rest}>

--- a/src/primitives/Card.test.tsx
+++ b/src/primitives/Card.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * Card primitive — TDD tests (Task 1.5)
+ *
+ * RED first: Card stub returns null. Tests must fail on assertion mismatches.
+ * GREEN: implement Card.tsx to pass all 3 assertions.
+ *
+ * Spec: plan Task 1.5 + design spec §card.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Card } from "./Card";
+
+describe("Card", () => {
+  it("renders children", () => {
+    render(<Card>Content</Card>);
+    expect(screen.getByText("Content")).toBeInTheDocument();
+  });
+
+  it("has bg-surface background by default", () => {
+    const { container } = render(<Card>X</Card>);
+    expect(container.firstChild).toHaveStyle("background: var(--bg-surface)");
+  });
+
+  it("applies focus-ring class and renders as button when focusable", () => {
+    const { container } = render(<Card focusable>X</Card>);
+    expect((container.firstChild as HTMLElement).className).toContain(
+      "focus-ring",
+    );
+    expect(container.firstChild?.nodeName.toLowerCase()).toBe("button");
+  });
+});

--- a/src/primitives/Card.tsx
+++ b/src/primitives/Card.tsx
@@ -5,6 +5,9 @@
  *   <div>   — default, non-interactive surface
  *   <button> — when focusable={true}, enables keyboard + TV-remote focus
  *
+ * Focusable Card renders as native `<button type="button">` — prevents accidental
+ * form submission on TV OK-press. Mirrors Button primitive's guard.
+ *
  * Props:
  *   focusable    — renders as <button> with focus-ring; false = <div>
  *   aspectRatio  — "2/3" | "16/9" | "1/1" via CSS class (not inline style)
@@ -57,11 +60,18 @@ export function Card({
     className,
   );
 
+  // When rendered as <button>, explicitly set type="button" to prevent
+  // accidental form submission on TV OK-press (mirrors Button primitive).
+  // Conditional spread keeps `exactOptionalPropertyTypes` happy — we never
+  // pass `type` to a <div>.
+  const typeAttr = focusable ? ({ type: "button" as const } as const) : {};
+
   return (
     <Tag
       className={classes}
       style={{ background: "var(--bg-surface)" }}
       onClick={onClick}
+      {...typeAttr}
     >
       {children}
     </Tag>

--- a/src/primitives/Card.tsx
+++ b/src/primitives/Card.tsx
@@ -1,0 +1,69 @@
+/**
+ * Card — Oxide card primitive (Task 1.5)
+ *
+ * Renders as:
+ *   <div>   — default, non-interactive surface
+ *   <button> — when focusable={true}, enables keyboard + TV-remote focus
+ *
+ * Props:
+ *   focusable    — renders as <button> with focus-ring; false = <div>
+ *   aspectRatio  — "2/3" | "16/9" | "1/1" via CSS class (not inline style)
+ *   className    — merged via cx(), forwarded to root element
+ *   onClick      — click handler (only meaningful when focusable=true)
+ *
+ * TS note: `focusable` without `onClick` is valid — TV D-pad focus doesn't
+ * always need a click handler (spatial nav handles selection). Kept lenient
+ * rather than compile-time error; documented here as accepted spec ambiguity.
+ *
+ * CSS lives in src/primitives/card.css (aggregated via primitives/index.css).
+ * Spec: plan Task 1.5 + design spec §card.
+ */
+import React from "react";
+import { cx } from "./cx";
+import "./card.css";
+
+export interface CardProps {
+  children?: React.ReactNode;
+  /** When true renders as <button> with focus-ring and hover lift. */
+  focusable?: boolean;
+  /** Applies an aspect-ratio CSS class for common TV artwork ratios. */
+  aspectRatio?: "2/3" | "16/9" | "1/1";
+  /** Extra classes merged via cx() onto the root element. */
+  className?: string;
+  /** Click/OK-press handler (most useful with focusable=true). */
+  onClick?: () => void;
+}
+
+const aspectClass: Record<NonNullable<CardProps["aspectRatio"]>, string> = {
+  "2/3": "card--ar-poster",
+  "16/9": "card--ar-backdrop",
+  "1/1": "card--ar-square",
+};
+
+export function Card({
+  children,
+  focusable = false,
+  aspectRatio,
+  className,
+  onClick,
+}: CardProps): React.ReactElement {
+  const Tag = focusable ? "button" : "div";
+
+  const classes = cx(
+    "card",
+    focusable && "card--focusable",
+    focusable && "focus-ring",
+    aspectRatio ? aspectClass[aspectRatio] : undefined,
+    className,
+  );
+
+  return (
+    <Tag
+      className={classes}
+      style={{ background: "var(--bg-surface)" }}
+      onClick={onClick}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/src/primitives/FocusRing.tsx
+++ b/src/primitives/FocusRing.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { cx } from "./cx";
 
 export interface FocusRingProps {
   children: React.ReactElement<{ className?: string }>;
@@ -30,14 +31,12 @@ export function FocusRing({
   const child = React.Children.only(children);
   const existingClass = child.props.className ?? "";
 
-  const classes = [
+  const classes = cx(
     existingClass,
     "focus-ring",
-    variant === "imagery" ? "focus-ring--imagery" : "",
+    variant === "imagery" ? "focus-ring--imagery" : false,
     className,
-  ]
-    .filter(Boolean)
-    .join(" ");
+  );
 
   return React.cloneElement(child, { className: classes });
 }

--- a/src/primitives/Skeleton.test.tsx
+++ b/src/primitives/Skeleton.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * Skeleton primitive — TDD tests (Task 1.5)
+ *
+ * RED first: Skeleton stub returns null. Tests must fail on assertion mismatches.
+ * GREEN: implement Skeleton.tsx to pass all 2 assertions.
+ *
+ * Spec: plan Task 1.5 + design spec §skeleton.
+ */
+import { render } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Skeleton } from "./Skeleton";
+
+describe("Skeleton", () => {
+  it("renders without crashing", () => {
+    const { container } = render(<Skeleton width="100%" height={200} />);
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it("has aria-hidden true (decorative)", () => {
+    const { container } = render(<Skeleton width={100} height={20} />);
+    expect(container.firstChild).toHaveAttribute("aria-hidden", "true");
+  });
+});

--- a/src/primitives/Skeleton.tsx
+++ b/src/primitives/Skeleton.tsx
@@ -1,0 +1,41 @@
+/**
+ * Skeleton — decorative loading placeholder (Task 1.5)
+ *
+ * Renders a pulsing <div> to indicate in-flight data.
+ *
+ * Accessibility:
+ *   - aria-hidden="true" — screen readers skip it (decorative)
+ *   - Animation respects prefers-reduced-motion via CSS media query
+ *
+ * Sizing: consumers set width/height via className or inline style.
+ * The `width` and `height` props map to inline style for convenience.
+ *
+ * CSS lives in src/primitives/skeleton.css (aggregated via primitives/index.css).
+ * Spec: plan Task 1.5 + design spec §skeleton.
+ */
+import React from "react";
+import { cx } from "./cx";
+import "./skeleton.css";
+
+export interface SkeletonProps {
+  /** Width as px number or CSS string (e.g. "100%", "200px"). */
+  width: number | string;
+  /** Height as px number or CSS string. */
+  height: number | string;
+  /** Extra classes for layout / border-radius overrides from parent. */
+  className?: string;
+}
+
+export function Skeleton({
+  width,
+  height,
+  className,
+}: SkeletonProps): React.ReactElement {
+  return (
+    <div
+      aria-hidden="true"
+      className={cx("skeleton", className)}
+      style={{ width, height }}
+    />
+  );
+}

--- a/src/primitives/card.css
+++ b/src/primitives/card.css
@@ -1,0 +1,61 @@
+/**
+ * Oxide Card — primitive CSS (Task 1.5)
+ *
+ * Variants:
+ *   .card                — base surface card (div or button)
+ *   .card--focusable     — pointer cursor + hover lift (only when rendered as button)
+ *   .card--ar-poster     — 2:3 aspect ratio (poster artwork)
+ *   .card--ar-backdrop   — 16:9 aspect ratio (widescreen backdrop)
+ *   .card--ar-square     — 1:1 aspect ratio (avatar / square tile)
+ *
+ * All colour values reference Oxide tokens from src/brand/tokens.css.
+ * No hardcoded hex — CSS custom properties only.
+ *
+ * Spec: plan Task 1.5 + design spec §card.
+ */
+
+/* ─────────────────────────────────────────────────────
+   Base
+   ───────────────────────────────────────────────────── */
+.card {
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  transition: transform var(--motion-focus) ease-out;
+}
+
+/* ─────────────────────────────────────────────────────
+   Focusable (rendered as <button>)
+   ───────────────────────────────────────────────────── */
+.card--focusable {
+  cursor: pointer;
+  /* Reset browser default button styles */
+  border: none;
+  padding: 0;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  width: 100%;
+  display: block;
+}
+
+.card--focusable:hover {
+  transform: translateY(-2px);
+}
+
+/* focus-visible handled by .focus-ring class from focus-ring.css */
+
+/* ─────────────────────────────────────────────────────
+   Aspect Ratio variants
+   ───────────────────────────────────────────────────── */
+.card--ar-poster {
+  aspect-ratio: 2 / 3;
+}
+
+.card--ar-backdrop {
+  aspect-ratio: 16 / 9;
+}
+
+.card--ar-square {
+  aspect-ratio: 1 / 1;
+}

--- a/src/primitives/cx.test.ts
+++ b/src/primitives/cx.test.ts
@@ -1,0 +1,27 @@
+/**
+ * cx() utility — TDD tests (Task 1.5)
+ *
+ * RED first: cx stub returns empty string. Tests must fail on assertions.
+ * GREEN: implement cx() to join, dedupe, and drop falsy values.
+ */
+import { describe, it, expect } from "vitest";
+import { cx } from "./cx";
+
+describe("cx", () => {
+  it("joins two truthy strings with a space", () => {
+    expect(cx("foo", "bar")).toBe("foo bar");
+  });
+
+  it("drops null, undefined, and false", () => {
+    expect(cx("foo", null, undefined, false, "bar")).toBe("foo bar");
+  });
+
+  it("deduplicates repeated tokens", () => {
+    expect(cx("btn", "focus-ring", "btn")).toBe("btn focus-ring");
+  });
+
+  it("splits multi-token strings and deduplicates across them", () => {
+    // "btn focus-ring" contains two tokens; "btn" is a dupe
+    expect(cx("btn focus-ring", "btn")).toBe("btn focus-ring");
+  });
+});

--- a/src/primitives/cx.ts
+++ b/src/primitives/cx.ts
@@ -1,0 +1,21 @@
+/**
+ * cx — compose className strings safely (Task 1.5)
+ *
+ * Joins truthy string parts, splits multi-token strings, deduplicates tokens,
+ * drops nullish/empty/false values. Exists so primitives can merge variant +
+ * size + focus-ring + user className without collisions or stray whitespace.
+ *
+ * Usage:
+ *   cx("btn", variant, size, className)
+ *   // → "btn btn--primary btn--md my-class"
+ */
+export function cx(...parts: Array<string | false | null | undefined>): string {
+  const seen = new Set<string>();
+  for (const part of parts) {
+    if (typeof part !== "string") continue;
+    for (const tok of part.split(/\s+/)) {
+      if (tok.length > 0) seen.add(tok);
+    }
+  }
+  return Array.from(seen).join(" ");
+}

--- a/src/primitives/index.css
+++ b/src/primitives/index.css
@@ -9,3 +9,5 @@
  */
 @import "./focus-ring.css";
 @import "./button.css";
+@import "./card.css";
+@import "./skeleton.css";

--- a/src/primitives/index.ts
+++ b/src/primitives/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Oxide Primitives — barrel export (Task 1.5)
+ *
+ * Import from here in application code:
+ *   import { Button, Card, Skeleton, cx } from "@/primitives";
+ *
+ * Task 1.7 requires this barrel — landing it here avoids churn later.
+ */
+export { Button, type ButtonProps } from "./Button";
+export { Card, type CardProps } from "./Card";
+export { FocusRing, type FocusRingProps } from "./FocusRing";
+export { Skeleton, type SkeletonProps } from "./Skeleton";
+export { cx } from "./cx";

--- a/src/primitives/skeleton.css
+++ b/src/primitives/skeleton.css
@@ -1,0 +1,45 @@
+/**
+ * Oxide Skeleton — decorative loading placeholder CSS (Task 1.5)
+ *
+ * .skeleton — pulsing placeholder block
+ *
+ * All colour values reference Oxide tokens from src/brand/tokens.css.
+ * No hardcoded hex — CSS custom properties only.
+ *
+ * Accessibility: always rendered with aria-hidden="true" in Skeleton.tsx.
+ * Motion: animation is disabled for users who prefer reduced motion.
+ *
+ * Spec: plan Task 1.5 + design spec §skeleton.
+ */
+
+/* ─────────────────────────────────────────────────────
+   Keyframes
+   ───────────────────────────────────────────────────── */
+@keyframes skeleton-pulse {
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+/* ─────────────────────────────────────────────────────
+   Base
+   ───────────────────────────────────────────────────── */
+.skeleton {
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+  animation: skeleton-pulse 1.8s ease-in-out infinite;
+}
+
+/* ─────────────────────────────────────────────────────
+   Reduced motion — respect user preference
+   ───────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+    opacity: 0.7;
+  }
+}


### PR DESCRIPTION
## Summary
Phase 1 / Task 1.5 — Card (optionally focusable) + Skeleton (decorative, aria-hidden, reduced-motion aware). Also lifts the \`cx()\` className utility flagged in Task 1.4 review, adopts it in Button and FocusRing, and lands the primitives barrel (Task 1.7 prerequisite).

**New primitives:**
- \`cx()\` — joins, splits multi-token strings, deduplicates tokens, drops falsy values
- \`Card\` — renders as \`<div>\` by default, \`<button>\` when \`focusable={true}\`; aspect-ratio variants (poster/backdrop/square); all colours via CSS vars
- \`Skeleton\` — decorative pulse with \`aria-hidden="true"\`; \`prefers-reduced-motion\` safe; \`--bg-elevated\` token

**Refactors:**
- \`Button.tsx\` — adopts \`cx()\` (replaces \`.filter(Boolean).join(" ")\`)
- \`FocusRing.tsx\` — adopts \`cx()\` (same pattern)

**Infrastructure:**
- \`src/primitives/index.ts\` barrel — exports Button/Card/FocusRing/Skeleton/cx (Task 1.7 prerequisite, no churn later)
- \`src/primitives/index.css\` aggregator updated with card.css + skeleton.css imports
- \`main.tsx\` untouched

## Spec
- Plan: docs/superpowers/plans/2026-04-15-streamvault-v3-implementation.md (Task 1.5)
- Design: docs/superpowers/specs/2026-04-15-streamvault-v3-design.md (card + skeleton sections)

## TDD Evidence

**RED output** (9 behavioural assertion failures, not module errors):
- Card: "Unable to find element with text: Content" / "received value must be HTMLElement, Received: null" / "Cannot read properties of null (reading 'className')"
- Skeleton: "expected null to be truthy" / "received value must be HTMLElement, Received: null"
- cx: "expected '' to be 'foo bar'" (4 assertions)

**GREEN output:** 27 tests passed (6 test files)

## Test plan
- [ ] \`npm test\` — 27 tests green (9 new: 4 cx + 3 Card + 2 Skeleton)
- [ ] \`npm run typecheck\` — clean (zero \`any\`, no unsafe casts)
- [ ] \`npm run build\` — 59.95 KB gzip (well under 800 KB Phase 1 budget)
- [ ] Skeleton has \`aria-hidden="true"\` verified in test
- [ ] Skeleton \`prefers-reduced-motion\` handled in skeleton.css (\`animation: none; opacity: 0.7\`)
- [ ] Card \`focusable=true\` renders as \`<button>\` verified in test
- [ ] Card \`focusable=false\` (default) renders as \`<div>\` (no role=button on div)
- [ ] cx() deduplicates, drops nullish, splits multi-token strings — 4 assertions
- [ ] All 18 pre-existing tests still green (Button + FocusRing unaffected by cx() adoption)

## Spec ambiguity — Card focusable typing

The task spec considered a compile-time error for \`focusable\` without \`onClick\`. Decision: kept lenient. Rationale — TV D-pad focus via norigin-spatial-navigation fires selection events directly on the focused element without needing a React \`onClick\` prop; requiring one would force dummy handlers across the grid. Documented in Card.tsx JSDoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)