### PR TITLE
feat(primitives): ErrorShell — role=alert, Retry autoFocus, per spec §7.5

### DIFF
--- a/src/primitives/ErrorShell.test.tsx
+++ b/src/primitives/ErrorShell.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * ErrorShell primitive — TDD tests (Task 1.6)
+ *
+ * RED first: ErrorShell.tsx returns null. All tests must fail.
+ * GREEN: implement ErrorShell.tsx to pass all 4 assertions.
+ *
+ * Spec: plan Task 1.6 Step 1 + design spec §7.5 (D-pad default focus).
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { ErrorShell } from "./ErrorShell";
+
+describe("ErrorShell", () => {
+  it("renders title and subtext", () => {
+    render(
+      <ErrorShell
+        title="Can't load channels"
+        subtext="Check your connection"
+        onRetry={() => {}}
+      />,
+    );
+    expect(screen.getByText("Can't load channels")).toBeInTheDocument();
+    expect(screen.getByText("Check your connection")).toBeInTheDocument();
+  });
+
+  it("Retry button is default focus and calls onRetry", async () => {
+    const retry = vi.fn();
+    render(<ErrorShell title="Error" subtext="Try again" onRetry={retry} />);
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(retry).toHaveBeenCalledOnce();
+  });
+
+  it("renders Back button when onBack provided", () => {
+    render(
+      <ErrorShell
+        title="Not found"
+        subtext="Go back"
+        onRetry={() => {}}
+        onBack={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /back/i })).toBeInTheDocument();
+  });
+
+  it("has role=alert for screen readers", () => {
+    render(<ErrorShell title="Error" subtext="msg" onRetry={() => {}} />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+});

--- a/src/primitives/ErrorShell.tsx
+++ b/src/primitives/ErrorShell.tsx
@@ -1,0 +1,119 @@
+/**
+ * ErrorShell — Oxide error state primitive (Task 1.6)
+ *
+ * Full-page / full-section error display with:
+ *   - role="alert" for screen-reader announcement
+ *   - Icon (64px copper, aria-hidden) for visual context
+ *   - h2 title + optional p subtext
+ *   - Retry button (outlined variant, autoFocus) — D-pad default per spec §7.5
+ *   - Optional Back button (ghost variant)
+ *   - Optional Report button (ghost variant)
+ *
+ * All colour values reference Oxide tokens only (no hardcoded hex).
+ * Reuses <Button> primitive — no duplicated styles.
+ * cx() for all className composition.
+ *
+ * CSS lives in src/primitives/error-shell.css (aggregated via primitives/index.css).
+ * Spec: plan Task 1.6 + design spec §7.5 (D-pad default focus).
+ */
+import React from "react";
+import { Button } from "./Button";
+import { cx } from "./cx";
+import "./error-shell.css";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** Icon variant shown above the title. */
+export type ErrorIcon = "warning" | "network" | "empty";
+
+export interface ErrorShellProps {
+  /** Primary heading — shown as <h2>. Required. */
+  title: string;
+  /** Supporting paragraph below the title. */
+  subtext?: string;
+  /** Icon variant. Defaults to "warning". */
+  icon?: ErrorIcon;
+  /** Called when user presses Retry. Required. */
+  onRetry: () => void;
+  /** When provided, renders a Back button (ghost). */
+  onBack?: () => void;
+  /** When provided, renders a Report button (ghost). */
+  onReport?: () => void;
+  /** Override Retry button label. Defaults to "Retry". */
+  retryLabel?: string;
+  /** Override Back button label. Defaults to "Back". */
+  backLabel?: string;
+  /** Extra classes merged onto the root element via cx(). */
+  className?: string;
+}
+
+// ─── Icon glyphs ─────────────────────────────────────────────────────────────
+// Unicode symbols — aria-hidden so screen readers skip them (the title
+// already conveys the error state via role="alert").
+
+const ICONS: Record<ErrorIcon, string> = {
+  warning: "⚠",
+  network: "📡",
+  empty: "○",
+};
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function ErrorShell({
+  title,
+  subtext,
+  icon = "warning",
+  onRetry,
+  onBack,
+  onReport,
+  retryLabel = "Retry",
+  backLabel = "Back",
+  className,
+}: ErrorShellProps): React.ReactElement {
+  return (
+    <div role="alert" className={cx("error-shell", className)}>
+      {/* Icon — aria-hidden; role="alert" + h2 carry the semantic load */}
+      <span className="error-shell__icon" aria-hidden="true">
+        {ICONS[icon]}
+      </span>
+
+      {/* Title */}
+      <h2 className="error-shell__title">{title}</h2>
+
+      {/* Subtext */}
+      {subtext !== undefined && (
+        <p className="error-shell__subtext">{subtext}</p>
+      )}
+
+      {/* Action row — Retry first (autoFocus = D-pad default per spec §7.5) */}
+      <div className="error-shell__actions">
+        <Button
+          variant="outlined"
+          onClick={onRetry}
+          // autoFocus: first element spatial nav lands on per spec §7.5
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus
+        >
+          {retryLabel}
+        </Button>
+
+        {onBack !== undefined && (
+          <Button variant="ghost" onClick={onBack}>
+            {backLabel}
+          </Button>
+        )}
+      </div>
+
+      {/* Report — secondary, ghost, below main actions */}
+      {onReport !== undefined && (
+        <Button
+          variant="ghost"
+          className="error-shell__report"
+          onClick={onReport}
+        >
+          Report issue
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/primitives/error-shell.css
+++ b/src/primitives/error-shell.css
@@ -1,0 +1,82 @@
+/**
+ * Oxide ErrorShell — primitive CSS (Task 1.6)
+ *
+ * Full-page / full-section error state layout.
+ *
+ * All colour values reference Oxide tokens from src/brand/tokens.css.
+ * No hardcoded hex — CSS custom properties only.
+ *
+ * Spec: plan Task 1.6 + design spec §7.5 (D-pad default focus).
+ */
+
+/* ─────────────────────────────────────────────────────
+   Root container
+   ───────────────────────────────────────────────────── */
+.error-shell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 400px;
+  padding: var(--gutter-tv);
+  gap: var(--space-4);
+  background: var(--bg-base);
+  color: var(--text-primary);
+  text-align: center;
+}
+
+/* ─────────────────────────────────────────────────────
+   Icon — 64px copper, aria-hidden (decorative)
+   ───────────────────────────────────────────────────── */
+.error-shell__icon {
+  display: block;
+  font-size: 64px;
+  line-height: 1;
+  color: var(--accent-copper);
+  /* Prevent icon from shrinking on very small containers */
+  flex-shrink: 0;
+}
+
+/* ─────────────────────────────────────────────────────
+   Title — h2, title scale
+   ───────────────────────────────────────────────────── */
+.error-shell__title {
+  margin: 0;
+  font-size: var(--text-title-size);
+  line-height: var(--text-title-line);
+  font-weight: var(--text-title-weight);
+  color: var(--text-primary);
+  max-width: 560px;
+}
+
+/* ─────────────────────────────────────────────────────
+   Subtext — body scale, secondary colour
+   ───────────────────────────────────────────────────── */
+.error-shell__subtext {
+  margin: 0;
+  font-size: var(--text-body-size);
+  line-height: var(--text-body-line);
+  color: var(--text-secondary);
+  max-width: 480px;
+}
+
+/* ─────────────────────────────────────────────────────
+   Action row — Retry (outlined, autoFocus) + optional Back (ghost)
+   ───────────────────────────────────────────────────── */
+.error-shell__actions {
+  display: flex;
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+  align-items: center;
+  justify-content: center;
+}
+
+/* ─────────────────────────────────────────────────────
+   Report button — below main actions, caption scale
+   ───────────────────────────────────────────────────── */
+.error-shell__report {
+  margin-top: var(--space-2);
+  font-size: var(--text-caption-size) !important;
+  color: var(--text-tertiary) !important;
+}

--- a/src/primitives/index.css
+++ b/src/primitives/index.css
@@ -11,3 +11,4 @@
 @import "./button.css";
 @import "./card.css";
 @import "./skeleton.css";
+@import "./error-shell.css";

--- a/src/primitives/index.ts
+++ b/src/primitives/index.ts
@@ -8,6 +8,7 @@
  */
 export { Button, type ButtonProps } from "./Button";
 export { Card, type CardProps } from "./Card";
+export { ErrorShell, type ErrorShellProps, type ErrorIcon } from "./ErrorShell";
 export { FocusRing, type FocusRingProps } from "./FocusRing";
 export { Skeleton, type SkeletonProps } from "./Skeleton";
 export { cx } from "./cx";


### PR DESCRIPTION
## Summary
Phase 1 / Task 1.6 — ErrorShell with role=alert container, Retry autoFocus (D-pad default per spec §7.5), optional Back/Report buttons. Reuses Button primitive.

- `src/primitives/ErrorShell.tsx` — role=alert container, icon (64px copper, aria-hidden), h2 title, p subtext, Retry (outlined, autoFocus), optional Back (ghost), optional Report (ghost). Props: title, subtext?, icon? (warning|network|empty), onRetry, onBack?, onReport?, retryLabel?, backLabel?.
- `src/primitives/ErrorShell.test.tsx` — 4 TDD assertions (RED→GREEN verified)
- `src/primitives/error-shell.css` — layout, icon sizing, token colors only
- `src/primitives/index.css` — `@import "./error-shell.css"` added
- `src/primitives/index.ts` — ErrorShell + ErrorShellProps + ErrorIcon exported

## Test plan
- [ ] `npm test` — 31/31 green (27 existing + 4 new)
- [ ] `npm run typecheck` — clean (0 errors)
- [ ] `npm run build` — 59.95 KB gzip (under 800 KB cap)
- [ ] role=alert verified (test 4 asserts getByRole("alert"))
- [ ] Retry autoFocus verified (autoFocus prop on Button variant="outlined")

🤖 Generated with [Claude Code](https://claude.com/claude-code)