### PR TITLE
feat(a11y): axe-core Playwright gate + jsx-a11y strict — Phase 1 close

### DIFF
--- a/scripts/check-bundle-budget.js
+++ b/scripts/check-bundle-budget.js
@@ -14,7 +14,7 @@ import { join, extname } from "node:path";
 import zlib from "node:zlib";
 
 const DIST = "dist/assets";
-const TOTAL_LIMIT_KB = 1500; // Phase 0 cap — tighten per schedule above.
+const TOTAL_LIMIT_KB = 800; // Phase 1 cap — primitives landed (Task 1.7 DoD requirement).
 
 if (!existsSync(DIST)) {
   console.error(`dist/ missing — run 'npm run build' first.`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,18 @@
+/**
+ * App — root component (Task 1.7)
+ *
+ * Path-switches on window.location.pathname:
+ *   /test-primitives  → TestPrimitivesRoute (dev-time axe/visual fixture)
+ *   *                 → placeholder (Phase 2 adds real router + Dock)
+ *
+ * The /test-primitives route is permanent — it is the Playwright axe target and
+ * future visual-regression baseline. It is not reachable at "/" in production.
+ */
+import { TestPrimitivesRoute } from "./routes";
+
 export default function App() {
+  if (window.location.pathname === "/test-primitives") {
+    return <TestPrimitivesRoute />;
+  }
   return null;
 }

--- a/src/primitives/error-shell.css
+++ b/src/primitives/error-shell.css
@@ -78,5 +78,7 @@
 .error-shell__report {
   margin-top: var(--space-2);
   font-size: var(--text-caption-size) !important;
-  color: var(--text-tertiary) !important;
+  /* FIX T1.7: was var(--text-tertiary) at 40% opacity → 3.28:1 contrast (WCAG fail).
+     Using var(--text-secondary) at 80% opacity → ≥9.76:1 on --bg-base (WCAG AAA). */
+  color: var(--text-secondary) !important;
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,0 +1,229 @@
+/**
+ * TestPrimitivesRoute — dev-time fixture for axe-core and visual regression (Task 1.7)
+ *
+ * Renders every Oxide primitive at all supported variants / sizes so that:
+ *   - axe-core Playwright tests can audit WCAG contrast on the full matrix
+ *   - Visual-regression screenshots capture baseline appearance
+ *   - Manual QA can inspect focus-ring, hover, and motion states
+ *
+ * This route is NOT ephemeral — it stays in the repo as the primitive fixture.
+ * In production the root App.tsx path-guard means it is unreachable at "/".
+ *
+ * Route: /test-primitives (path-switched in App.tsx)
+ */
+import React from "react";
+import { Button, Card, Skeleton, FocusRing, ErrorShell } from "../primitives";
+
+const sectionStyle: React.CSSProperties = {
+  marginBottom: "var(--space-12, 48px)",
+};
+
+const headingStyle: React.CSSProperties = {
+  color: "var(--text-secondary)",
+  fontSize: "var(--text-label-size, 14px)",
+  letterSpacing: "var(--text-label-tracking, 1.5px)",
+  textTransform: "uppercase",
+  marginBottom: "var(--space-4, 16px)",
+  fontFamily: "var(--font-ui)",
+};
+
+const rowStyle: React.CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "var(--space-4, 16px)",
+  alignItems: "flex-start",
+};
+
+export function TestPrimitivesRoute(): React.ReactElement {
+  return (
+    <div
+      style={{
+        background: "var(--bg-base)",
+        minHeight: "100vh",
+        padding: "var(--space-12, 48px)",
+        fontFamily: "var(--font-ui)",
+      }}
+    >
+      <h1
+        style={{
+          color: "var(--text-primary)",
+          fontSize: "var(--text-title-size, 32px)",
+          marginBottom: "var(--space-12, 48px)",
+        }}
+      >
+        Oxide Primitives — Phase 1 Fixture
+      </h1>
+
+      {/* ── Button — variants ──────────────────────────────────────────── */}
+      <section aria-labelledby="btn-variants-heading" style={sectionStyle}>
+        <h2 id="btn-variants-heading" style={headingStyle}>
+          Button — Variants
+        </h2>
+        <div style={rowStyle}>
+          <Button variant="primary">Primary</Button>
+          <Button variant="outlined">Outlined</Button>
+          <Button variant="ghost">Ghost</Button>
+        </div>
+      </section>
+
+      {/* ── Button — sizes ────────────────────────────────────────────── */}
+      <section aria-labelledby="btn-sizes-heading" style={sectionStyle}>
+        <h2 id="btn-sizes-heading" style={headingStyle}>
+          Button — Sizes
+        </h2>
+        <div style={rowStyle}>
+          <Button variant="primary" size="sm">
+            Small
+          </Button>
+          <Button variant="primary" size="md">
+            Medium
+          </Button>
+          <Button variant="primary" size="lg">
+            Large
+          </Button>
+          <Button variant="outlined" size="sm">
+            Outlined sm
+          </Button>
+          <Button variant="outlined" size="md">
+            Outlined md
+          </Button>
+          <Button variant="outlined" size="lg">
+            Outlined lg
+          </Button>
+          <Button variant="ghost" size="sm">
+            Ghost sm
+          </Button>
+          <Button variant="ghost" size="md">
+            Ghost md
+          </Button>
+          <Button variant="ghost" size="lg">
+            Ghost lg
+          </Button>
+        </div>
+      </section>
+
+      {/* ── Card — focusable + non-focusable ──────────────────────────── */}
+      <section aria-labelledby="card-heading" style={sectionStyle}>
+        <h2 id="card-heading" style={headingStyle}>
+          Card
+        </h2>
+        <div style={rowStyle}>
+          {/* Card doesn't accept style prop — wrap in a sized div */}
+          <div style={{ width: 160, height: 100 }}>
+            <Card className="h-full">
+              <span style={{ color: "var(--text-primary)", padding: "8px" }}>
+                Non-focusable
+              </span>
+            </Card>
+          </div>
+          <div style={{ width: 160, height: 100 }}>
+            <Card focusable aria-label="Focusable card" className="h-full">
+              <span style={{ color: "var(--text-primary)", padding: "8px" }}>
+                Focusable
+              </span>
+            </Card>
+          </div>
+          <div style={{ width: 200 }}>
+            <Card aspectRatio="16/9">
+              <span style={{ color: "var(--text-primary)", padding: "8px" }}>
+                16/9
+              </span>
+            </Card>
+          </div>
+          <div style={{ width: 120 }}>
+            <Card aspectRatio="2/3">
+              <span style={{ color: "var(--text-primary)", padding: "8px" }}>
+                2/3
+              </span>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Skeleton ──────────────────────────────────────────────────── */}
+      <section aria-labelledby="skeleton-heading" style={sectionStyle}>
+        <h2 id="skeleton-heading" style={headingStyle}>
+          Skeleton
+        </h2>
+        <div style={rowStyle}>
+          <Skeleton width={200} height={20} />
+          <Skeleton width={160} height={20} />
+          <Skeleton width={120} height={20} />
+          <Skeleton width={200} height={120} />
+        </div>
+      </section>
+
+      {/* ── FocusRing (wrapping a button) ─────────────────────────────── */}
+      <section aria-labelledby="focusring-heading" style={sectionStyle}>
+        <h2 id="focusring-heading" style={headingStyle}>
+          FocusRing
+        </h2>
+        <div style={rowStyle}>
+          <FocusRing variant="standard">
+            <button
+              type="button"
+              style={{
+                color: "var(--text-primary)",
+                background: "var(--bg-surface)",
+                border: "none",
+                padding: "8px 16px",
+                borderRadius: "8px",
+              }}
+            >
+              Standard ring
+            </button>
+          </FocusRing>
+          <FocusRing variant="imagery">
+            <button
+              type="button"
+              style={{
+                color: "var(--text-primary)",
+                background: "var(--bg-elevated)",
+                border: "none",
+                padding: "8px 16px",
+                borderRadius: "8px",
+              }}
+            >
+              Imagery ring
+            </button>
+          </FocusRing>
+        </div>
+      </section>
+
+      {/* ── ErrorShell — all button configs ───────────────────────────── */}
+      <section aria-labelledby="error-heading" style={sectionStyle}>
+        <h2 id="error-heading" style={headingStyle}>
+          ErrorShell
+        </h2>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "var(--space-8, 32px)",
+          }}
+        >
+          <ErrorShell
+            title="Playback error"
+            subtext="Unable to load stream. Check your connection and try again."
+            icon="warning"
+            onRetry={() => undefined}
+          />
+          <ErrorShell
+            title="Network unavailable"
+            icon="network"
+            onRetry={() => undefined}
+            onBack={() => undefined}
+          />
+          <ErrorShell
+            title="Nothing here"
+            subtext="This section is empty."
+            icon="empty"
+            onRetry={() => undefined}
+            onBack={() => undefined}
+            onReport={() => undefined}
+          />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/tests/e2e/axe-primitives.spec.ts
+++ b/tests/e2e/axe-primitives.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * axe-primitives.spec.ts — WCAG contrast gate for Oxide primitives (Task 1.7)
+ *
+ * Navigates to the /test-primitives dev fixture and runs axe-core against
+ * wcag2a, wcag2aa, wcag21aa rule sets. The only hard gate for Phase 1 is
+ * zero color-contrast violations — all other violations are also asserted
+ * to zero since the primitive set is small and fully controlled.
+ *
+ * This test must stay green on CI. Never downgrade to "warn" on contrast.
+ */
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+test.describe("Oxide primitives — WCAG a11y gate", () => {
+  test("0 color-contrast violations on /test-primitives", async ({ page }) => {
+    await page.goto("/test-primitives");
+
+    // Wait for primitives to render (fonts + CSS vars resolve)
+    await page.waitForLoadState("networkidle");
+
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21aa"])
+      .analyze();
+
+    const contrastViolations = results.violations.filter(
+      (v) => v.id === "color-contrast",
+    );
+
+    // Hard gate: zero color-contrast violations (Phase 1 DoD)
+    expect(
+      contrastViolations,
+      `color-contrast violations found:\n${JSON.stringify(contrastViolations, null, 2)}`,
+    ).toHaveLength(0);
+
+    // Full gate: zero violations total (primitives are fully controlled)
+    expect(
+      results.violations,
+      `axe violations found:\n${JSON.stringify(results.violations, null, 2)}`,
+    ).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 closing task (Task 1.7) — locks the Phase 1 Definition of Done.

- **`/test-primitives` route** (`src/routes/index.tsx`): permanent dev-time fixture rendering all 5 primitives × all variants/sizes. Serves as the axe-core scan target and future visual-regression baseline.
- **Playwright axe test** (`tests/e2e/axe-primitives.spec.ts`): scans `/test-primitives` with `wcag2a`, `wcag2aa`, `wcag21aa` tags; asserts 0 color-contrast violations AND 0 total violations.
- **Contrast bug fixed** (`src/primitives/error-shell.css`): `.error-shell__report` was using `var(--text-tertiary)` at 40% opacity → 3.28:1 ratio on `--bg-base` (WCAG AA fail). Changed to `var(--text-secondary)` at 80% opacity → 9.76:1 (WCAG AAA pass).
- **Bundle budget tightened** (`scripts/check-bundle-budget.js`): 1500 KB → 800 KB per Phase 1 DoD schedule. Actual bundle: 60 KB gzip.
- **`jsx-a11y/strict`** already configured in `eslint.config.js` (Task 0.4); confirmed `npx eslint src --max-warnings 0` passes.

## Test plan

- [ ] `npm test` — 31/31 Vitest unit tests green, 93.93% branch coverage (>80%)
- [ ] `npx tsc --noEmit` — TypeScript strict clean
- [ ] `npx eslint src --max-warnings 0` — 0 warnings
- [ ] `npx playwright test tests/e2e/axe-primitives.spec.ts` — 0 axe violations
- [ ] `npx playwright test` — both e2e tests pass (smoke + axe)
- [ ] `npm run build && node scripts/check-bundle-budget.js` — 60 KB / 800 KB PASS
- [ ] `grep -r 'prefers-reduced-motion' dist/` — ≥1 match confirmed

## Phase 1 DoD — all gates ticked

- [x] Vitest unit tests pass; coverage 93.93% (≥80%)
- [x] Inter Display typography gate logged in `docs/DECISIONS.md` (Task 1.2)
- [x] axe-core: 0 color-contrast violations on /test-primitives
- [x] eslint-plugin-jsx-a11y strict: `npx eslint src --max-warnings 0` passes
- [x] `@media (prefers-reduced-motion: reduce)` in built CSS (confirmed via grep dist/)
- [x] All Oxide tokens in `src/brand/tokens.css` (Task 1.1)
- [x] All 5 primitives exported: Button, Card, Skeleton, FocusRing, ErrorShell
- [x] ErrorShell: role=alert, Retry autoFocus, copper icon, Back+Report optional
- [x] Bundle budget tightened to 800 KB; 60 KB actual (PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)