### PR TITLE
feat(nav): Task 2.2 — BottomDock (5-item tablist, copper active state)

### DIFF
--- a/src/nav/BottomDock.test.tsx
+++ b/src/nav/BottomDock.test.tsx
@@ -1,0 +1,49 @@
+// FIX: m4 — mock norigin in jsdom. useFocusable expects a real focus manager + native
+// focus support that jsdom doesn't fully provide. Unit tests only assert ARIA + render;
+// D-pad behaviour is covered by the Silk probe + BottomDock D-pad E2E tests.
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import React from "react";
+
+vi.mock("@noriginmedia/norigin-spatial-navigation", () => ({
+  init: vi.fn(),
+  useFocusable: (opts?: { focusKey?: string; onEnterPress?: () => void }) => ({
+    ref: { current: null },
+    focusKey: opts?.focusKey ?? "MOCK_KEY",
+    focused: false,
+    focusSelf: vi.fn(),
+  }),
+  FocusContext: {
+    Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  },
+  setFocus: vi.fn(),
+}));
+
+import { BottomDock } from "./BottomDock";
+
+describe("BottomDock", () => {
+  it("renders all 5 nav items", () => {
+    render(<BottomDock activeItem="live" onNavigate={() => {}} />);
+    expect(screen.getByRole("tab", { name: /live/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /movies/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /series/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /search/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /settings/i })).toBeInTheDocument();
+  });
+  it('active item has aria-selected="true"', () => {
+    render(<BottomDock activeItem="live" onNavigate={() => {}} />);
+    const liveTab = screen.getByRole("tab", { name: /live/i });
+    expect(liveTab).toHaveAttribute("aria-selected", "true");
+  });
+  it('inactive items have aria-selected="false"', () => {
+    render(<BottomDock activeItem="live" onNavigate={() => {}} />);
+    expect(screen.getByRole("tab", { name: /movies/i })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+  });
+  it("has tablist role", () => {
+    render(<BottomDock activeItem="live" onNavigate={() => {}} />);
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+  });
+});

--- a/src/nav/BottomDock.tsx
+++ b/src/nav/BottomDock.tsx
@@ -1,0 +1,131 @@
+// FIX: M1 — scoped import; FocusContext is a separate named export (not returned by useFocusable).
+import {
+  useFocusable,
+  FocusContext,
+} from "@noriginmedia/norigin-spatial-navigation";
+
+export type DockItem = "live" | "movies" | "series" | "search" | "settings";
+
+const DOCK_ITEMS: { id: DockItem; label: string; icon: string }[] = [
+  { id: "live", label: "Live", icon: "●" },
+  { id: "movies", label: "Movies", icon: "▶" },
+  { id: "series", label: "Series", icon: "⊞" },
+  { id: "search", label: "Search", icon: "⌕" },
+  { id: "settings", label: "Settings", icon: "⚙" },
+];
+
+interface BottomDockProps {
+  activeItem: DockItem;
+  onNavigate: (item: DockItem) => void;
+  hidden?: boolean;
+}
+
+export function BottomDock({
+  activeItem,
+  onNavigate,
+  hidden = false,
+}: BottomDockProps) {
+  // FIX: M1 — useFocusable returns { ref, focusKey, focused, focusSelf, ... };
+  // pass focusKey (a string) to FocusContext.Provider value.
+  const { ref, focusKey } = useFocusable({ focusKey: "DOCK" });
+
+  return (
+    <FocusContext.Provider value={focusKey}>
+      <nav
+        ref={ref}
+        aria-label="Main navigation"
+        style={{
+          position: "fixed",
+          bottom: "var(--space-6)",
+          left: "var(--safe-inset)",
+          right: "var(--safe-inset)",
+          height: "var(--dock-height)",
+          background: "var(--bg-surface)",
+          backdropFilter: "blur(12px)",
+          borderRadius: "var(--radius-pill)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-around",
+          padding: "0 var(--space-8)",
+          opacity: hidden ? 0 : 1,
+          pointerEvents: hidden ? "none" : "auto",
+          transition: "opacity var(--motion-dock)",
+          zIndex: 100,
+        }}
+      >
+        <div
+          role="tablist"
+          aria-label="Navigation"
+          style={{
+            display: "flex",
+            gap: "var(--space-4)",
+            width: "100%",
+            justifyContent: "space-around",
+          }}
+        >
+          {DOCK_ITEMS.map((item) => (
+            <DockTab
+              key={item.id}
+              item={item}
+              isActive={activeItem === item.id}
+              onSelect={() => onNavigate(item.id)}
+            />
+          ))}
+        </div>
+      </nav>
+    </FocusContext.Provider>
+  );
+}
+
+function DockTab({
+  item,
+  isActive,
+  onSelect,
+}: {
+  item: (typeof DOCK_ITEMS)[0];
+  isActive: boolean;
+  onSelect: () => void;
+}) {
+  const { ref, focused } = useFocusable({ onEnterPress: onSelect });
+  const active = isActive || focused;
+
+  return (
+    <button
+      ref={ref as React.RefObject<HTMLButtonElement>}
+      role="tab"
+      aria-selected={isActive}
+      aria-label={item.label}
+      onClick={onSelect}
+      className="focus-ring"
+      style={{
+        background: active ? "var(--accent-copper)" : "transparent",
+        color: active ? "var(--bg-base)" : "var(--text-secondary)",
+        border: "none",
+        borderRadius: "var(--radius-sm)",
+        padding: "var(--space-2) var(--space-4)",
+        cursor: "pointer",
+        fontSize: "var(--text-body-size)",
+        fontWeight: active ? 600 : 400,
+        transition: "background var(--motion-focus), color var(--motion-focus)",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "4px",
+        minWidth: "80px",
+      }}
+    >
+      <span aria-hidden="true" style={{ fontSize: "20px" }}>
+        {item.icon}
+      </span>
+      <span
+        style={{
+          fontSize: "var(--text-label-size)",
+          letterSpacing: "var(--text-label-tracking)",
+          textTransform: "uppercase",
+        }}
+      >
+        {item.label}
+      </span>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

- **Task 2.2** from [Phase 2 plan](https://github.com/srinivas-kotha/claude-dotfiles/blob/main/docs/superpowers/plans/2026-04-15-streamvault-v3-implementation.md) (lines 1517–1724)
- Implements `BottomDock` — fixed bottom navigation bar with 5 items: Live / Movies / Series / Search / Settings
- `DockTab` sub-component uses `useFocusable({ onEnterPress })` for D-pad support (wired, tested in Task 2.4 E2E)
- `FocusContext.Provider` wraps the nav with `focusKey="DOCK"` for norigin focus tree
- Copper active state via `var(--accent-copper)` Oxide token; `hidden` prop controls opacity/pointer-events
- NOT wired into App.tsx — routing happens in Task 2.3

## TDD Cycle

- RED: test written first → `Failed to resolve import "./BottomDock"` (confirmed fail)
- GREEN: implementation written → 4/4 tests pass
- REFACTOR: none needed (implementation matched plan spec exactly)

## Test Plan

- [x] `npx vitest run src/nav/BottomDock` → 4 passing
- [x] `npx vitest run` → 43/43 passing (no regressions from 39 pre-task)
- [x] `npm run build` → 77.83 KB gzip (unchanged; component not yet imported by App)
- [x] `npx tsc --noEmit` → clean (TS strict: noUncheckedIndexedAccess + exactOptionalPropertyTypes)
- [x] No hardcoded colors — all Oxide CSS vars
- [x] ARIA: `role="tablist"`, `role="tab"`, `aria-selected="true/false"`, `aria-label` on each tab

## Files Changed

- `src/nav/BottomDock.tsx` — component (131 lines)
- `src/nav/BottomDock.test.tsx` — 4 unit tests with norigin vi.mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)