### PR TITLE
test(nav): Task 2.4 — BottomDock D-pad E2E + norigin focusKey fix

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -92,3 +92,22 @@ Installed `react-router-dom@6`. Added 5 route shells under `src/routes/` (Live/M
 3. **Deferred**: Unit test for `AppShell`'s URL→DockItem derivation edge cases (`/unknown`, `/test-primitives`, bare `/`). Current E2E coverage proves the golden path; a fast vitest spec would catch regressions cheaper than Playwright.
 
 Follow-ups deferred: (2) + (3) above. Both tracked here only — not urgent enough for KNOWN-RISK.md.
+
+## 2026-04-21 — Task 2.4: BottomDock D-pad E2E + norigin focusKey + test-only setFocus hook
+
+Shipped `tests/e2e/dock-nav.spec.ts` with 4 Playwright tests: ArrowRight moves focus Live→Movies, Enter on a dock item navigates via React Router, dock visibility on content routes, dock hidden on `/test-primitives` + `/silk-probe`.
+
+**Root cause found during test debugging**: DockTab's `useFocusable` was missing `focusKey`, so norigin couldn't uniquely identify siblings under DOCK — ArrowRight was a no-op because norigin had no current focus to navigate FROM. Additional finding: DOM focus (via `.click()` or `.focus()`) does NOT sync norigin's internal `lastFocused` pointer. Only `setFocus("key")` or `focusSelf()` primes norigin's focus tree.
+
+**Fixes**:
+1. `src/nav/BottomDock.tsx` — DockTab now uses `useFocusable({ focusKey: \`DOCK_${item.id.toUpperCase()}\`, onEnterPress })`. Keys: `DOCK_LIVE`, `DOCK_MOVIES`, `DOCK_SERIES`, `DOCK_SEARCH`, `DOCK_SETTINGS`.
+2. `src/main.tsx` — dev/test-only `window.__svSetFocus = setFocus` (gated by `import.meta.env.DEV`). Lets Playwright prime norigin the same way a first remote-button press does on a real TV.
+
+**Test pattern** (dock-nav.spec.ts): `page.evaluate(() => window.__svSetFocus("DOCK_LIVE"))` → `waitForFunction(activeElement.aria-label === "Live")` → `keyboard.press("ArrowRight")` → `waitForFunction(aria-label === "Movies")`.
+
+**All gates green**: tsc clean, vitest 43/43, Playwright chromium 7/7 (3 routing + 4 dock-nav), build 85.59 KB gzip (unchanged).
+
+**Expert-Level Clause** (3 senior additions):
+1. **Shipped**: Dev-only `window.__svSetFocus` — future E2E tests of dock + content-focus handoffs will need this same priming pattern.
+2. **Deferred**: WebKit-project run for dock-nav (Desktop Safari + iPad Pro 11). Silk-probe already validates norigin on WebKit; dock-nav will ride the next CI run which includes webkit by default.
+3. **Deferred**: Unit test for DockTab's focusKey derivation. Current E2E proves the spatial-nav wiring — a jsdom test can't verify norigin focus anyway.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { setFocus } from "@noriginmedia/norigin-spatial-navigation";
 import "./brand/tokens.css";
 import "./index.css";
 import "./primitives/index.css"; // aggregator — all primitive stylesheets
@@ -8,6 +9,15 @@ import { initSpatialNav } from "./nav/spatialNav";
 
 // Must run before createRoot so norigin is ready when React mounts.
 initSpatialNav();
+
+// Task 2.4: expose setFocus on window in dev/test builds so Playwright can
+// prime norigin's focus tree (DOM focus alone doesn't update norigin's internal
+// lastFocused pointer). Guarded by import.meta.env.DEV so prod bundles
+// don't carry the handle.
+if (import.meta.env.DEV) {
+  (window as unknown as { __svSetFocus: typeof setFocus }).__svSetFocus =
+    setFocus;
+}
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/src/nav/BottomDock.tsx
+++ b/src/nav/BottomDock.tsx
@@ -88,7 +88,13 @@ function DockTab({
   isActive: boolean;
   onSelect: () => void;
 }) {
-  const { ref, focused } = useFocusable({ onEnterPress: onSelect });
+  // Task 2.4: explicit focusKey per tab. Without this, norigin can't uniquely
+  // identify siblings under DOCK, so ArrowRight can't route spatial focus —
+  // verified via E2E debug (pre-fix, ArrowRight stayed on the initial tab).
+  const { ref, focused } = useFocusable({
+    focusKey: `DOCK_${item.id.toUpperCase()}`,
+    onEnterPress: onSelect,
+  });
   const active = isActive || focused;
 
   return (

--- a/tests/e2e/dock-nav.spec.ts
+++ b/tests/e2e/dock-nav.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * BottomDock D-pad navigation E2E (Task 2.4).
+ *
+ * Proves norigin@2.1.0 D-pad handlers wire through to the dock + React Router:
+ *   - setFocus("DOCK_LIVE") primes norigin focus tree
+ *   - ArrowRight → norigin routes spatial focus to DOCK_MOVIES (sibling)
+ *   - Enter → DockTab.onEnterPress fires → useNavigate("/movies")
+ *
+ * **Why setFocus priming:** norigin tracks its own focus tree independently
+ * of DOM `document.activeElement`. Clicking a button or pressing Tab only
+ * updates DOM focus — it does NOT update norigin's internal `lastFocused`
+ * pointer (verified via Task 2.4 debug session 2026-04-21). So ArrowRight
+ * has nothing to navigate FROM and is a no-op.
+ *
+ * The app exposes `window.__svSetFocus` only in dev/test builds (main.tsx,
+ * gated by `import.meta.env.DEV`) so Playwright can prime the focus tree
+ * the same way a real user's first remote button press primes it on a TV.
+ */
+test.describe("BottomDock D-pad navigation", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/live");
+    // Wait for norigin init + App mount + BottomDock DockTabs registered.
+    await page.waitForTimeout(300);
+  });
+
+  test("ArrowRight moves focus from Live to Movies in dock", async ({
+    page,
+  }) => {
+    await page.evaluate(() =>
+      (
+        window as unknown as { __svSetFocus: (key: string) => void }
+      ).__svSetFocus("DOCK_LIVE"),
+    );
+    await page.waitForFunction(
+      () => document.activeElement?.getAttribute("aria-label") === "Live",
+      { timeout: 2000 },
+    );
+
+    await page.keyboard.press("ArrowRight");
+    await page.waitForFunction(
+      () => document.activeElement?.getAttribute("aria-label") === "Movies",
+      { timeout: 2000 },
+    );
+    expect(
+      await page.evaluate(() =>
+        document.activeElement?.getAttribute("aria-label"),
+      ),
+    ).toBe("Movies");
+  });
+
+  test("Enter on dock item navigates to that route", async ({ page }) => {
+    await page.evaluate(() =>
+      (
+        window as unknown as { __svSetFocus: (key: string) => void }
+      ).__svSetFocus("DOCK_LIVE"),
+    );
+    await page.waitForFunction(
+      () => document.activeElement?.getAttribute("aria-label") === "Live",
+      { timeout: 2000 },
+    );
+    await page.keyboard.press("ArrowRight");
+    await page.waitForFunction(
+      () => document.activeElement?.getAttribute("aria-label") === "Movies",
+      { timeout: 2000 },
+    );
+    await page.keyboard.press("Enter");
+    await expect(page).toHaveURL(/\/movies/);
+    await expect(page.locator('[data-page="movies"]')).toBeVisible();
+  });
+
+  test("dock is visible on /live and /movies", async ({ page }) => {
+    await expect(
+      page.locator('nav[aria-label="Main navigation"]'),
+    ).toBeVisible();
+    await page.goto("/movies");
+    await expect(
+      page.locator('nav[aria-label="Main navigation"]'),
+    ).toBeVisible();
+  });
+
+  test("dock is hidden on dev-time probe routes (/test-primitives, /silk-probe)", async ({
+    page,
+  }) => {
+    await page.goto("/test-primitives");
+    await expect(page.locator('nav[aria-label="Main navigation"]')).toHaveCSS(
+      "opacity",
+      "0",
+    );
+    await page.goto("/silk-probe");
+    await expect(page.locator('nav[aria-label="Main navigation"]')).toHaveCSS(
+      "opacity",
+      "0",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- **Task 2.4** from [Phase 2 plan](https://github.com/srinivas-kotha/claude-dotfiles/blob/main/docs/superpowers/plans/2026-04-15-streamvault-v3-implementation.md) lines 1821–1886
- `tests/e2e/dock-nav.spec.ts` — 4 Playwright tests proving ArrowRight moves focus, Enter navigates, dock visibility on content routes, dock hidden on probe routes
- **Root cause found + fixed**: DockTab's `useFocusable` was missing `focusKey` → norigin couldn't route spatial focus. Added `DOCK_LIVE`/`MOVIES`/`SERIES`/`SEARCH`/`SETTINGS` keys.
- **Dev-only test hook**: `window.__svSetFocus` exposed in dev/test builds (`import.meta.env.DEV` gated) — lets Playwright prime norigin the way a real remote button press does on a TV.

## Why the test hook is needed
norigin tracks focus in its own internal tree. DOM focus (`.click()` / `.focus()` / `Tab`) does NOT sync norigin's `lastFocused` pointer — only `setFocus` / `focusSelf` does. Without priming, ArrowRight is a no-op because norigin has nothing to navigate FROM. On a real TV, the first remote button press primes norigin via its key handler. In Playwright, we fast-forward that priming via the dev hook.

## TDD Cycle
- RED: `tests/e2e/dock-nav.spec.ts` written first, 2/4 failing (D-pad priming issue discovered)
- DEBUG: isolated issue to missing focusKey + DOM-focus doesn't sync norigin
- GREEN: focusKey fix + `__svSetFocus` hook → 4/4 passing

## Test Plan
- [x] `npx tsc --noEmit` → clean
- [x] `npx vitest run` → 43/43 passing
- [x] `npx playwright test tests/e2e/dock-nav.spec.ts --project=chromium` → 4/4 passing
- [x] `npx playwright test tests/e2e/routing.spec.ts tests/e2e/dock-nav.spec.ts --project=chromium` → 7/7 passing
- [x] `npm run build` → 85.59 KB gzip (Phase 2 cap 800 KB, unchanged)
- [x] WebKit project (iPad Pro + Desktop Safari) runs automatically on CI — no local run possible (GTK4 libs missing on VPS)

## Files Changed
- `tests/e2e/dock-nav.spec.ts` (new) — 4 D-pad navigation tests
- `src/nav/BottomDock.tsx` — explicit `focusKey: \`DOCK_${item.id.toUpperCase()}\`` per tab
- `src/main.tsx` — dev-only `window.__svSetFocus = setFocus`
- `docs/DECISIONS.md` — Task 2.4 entry

## Phase 2 Definition of Done — closes out
- [x] Silk compatibility probe: norigin@2.1.0 on WebKit ✅ (Task 2.1)
- [x] BottomDock: 5 items, role=tablist/tab, aria-selected, copper active ✅ (Task 2.2)
- [x] Dock D-pad E2E passes: ArrowRight moves focus, Enter navigates ✅ (this PR)
- [x] Dock is visible on all non-player routes ✅
- [x] React Router 6 wired: `/` → `/live`, 5 route shells ✅ (Task 2.3)
- [ ] CI green on main — pending this PR's CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)