### PR TITLE
docs: Task 3.0 BLOCKED — change-password endpoint missing (KR-CHANGEPW)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -111,3 +111,21 @@ Shipped `tests/e2e/dock-nav.spec.ts` with 4 Playwright tests: ArrowRight moves f
 1. **Shipped**: Dev-only `window.__svSetFocus` — future E2E tests of dock + content-focus handoffs will need this same priming pattern.
 2. **Deferred**: WebKit-project run for dock-nav (Desktop Safari + iPad Pro 11). Silk-probe already validates norigin on WebKit; dock-nav will ride the next CI run which includes webkit by default.
 3. **Deferred**: Unit test for DockTab's focusKey derivation. Current E2E proves the spatial-nav wiring — a jsdom test can't verify norigin focus anyway.
+
+## 2026-04-21 — Task 3.0 pre-check: change-password endpoint MISSING → Phase 3 BLOCKED
+
+Probed `http://localhost:3001/api/auth/change-password` per plan Task 3.0 Step 1:
+
+- `POST` with placeholder Bearer token + `{"currentPassword":"x","newPassword":"y"}` → HTTP 403 `{"error":"Forbidden","message":"CSRF token mismatch"}`
+- `POST` with no Authorization header → same 403 CSRF response (CSRF middleware fires before auth middleware)
+- `GET /api/auth/change-password` → HTTP 501 `{"error":"Not Implemented","message":"Not implemented yet — coming in Phase 2/3"}` — strong signal the endpoint is known-and-planned but not yet wired
+- `grep -rn "change-password|changePassword" /home/crawler/streamvault-backend/src/` → 0 hits
+
+**Endpoint MISSING. Per plan: Phase 3 BLOCKED** until a backend PR lands on `streamvault-backend`. Full resume plan + operational constraints captured in `docs/KNOWN-RISK.md` entry `KR-CHANGEPW`.
+
+This session did NOT auto-build the backend endpoint because:
+1. Auth-sensitive changes (bcrypt, refresh-token revocation, CSRF) should not ship unsupervised.
+2. `streamvault-backend` CI has been red since 2026-03-14 — changes cannot be automatically validated.
+3. The plan's Task 3.0 gate explicitly says "escalate; do not proceed" when the endpoint is missing.
+
+Next session: write + review + merge the backend PR (or establish a manual-deploy path given the CI outage), then re-probe, tick the plan checkbox, and begin Task 3.1 (Zod schemas).

--- a/docs/KNOWN-RISK.md
+++ b/docs/KNOWN-RISK.md
@@ -35,3 +35,30 @@ Apple TV and Roku platform conventions):
 Status: mitigated at design time; verify on real Fire TV hardware in Phase 8
 smoke checklist (alongside KR-02). If memory pressure still observed, fall back
 to poster-only SplitGuide preview (revert Task 5a.7).
+
+## KR-CHANGEPW: Phase 3 blocked — change-password endpoint missing
+
+**Status (2026-04-21): 🔴 BLOCKING — Phase 3 cannot begin until backend PR lands.**
+
+Plan Task 3.0 pre-check ran 2026-04-21 against `http://localhost:3001`:
+- `POST /api/auth/change-password` → 403 "CSRF token mismatch" (placeholder token rejected)
+- `GET /api/auth/change-password` → 501 "Not Implemented — coming in Phase 2/3"
+- `grep -rn "change-password|changePassword" streamvault-backend/src/` → 0 hits
+
+Per the v3 plan, Phase 3 cannot begin until a backend PR on `streamvault-backend` adds `POST /api/auth/change-password` with refresh-token purge. Estimate ~4h:
+
+1. Route in `src/routers/auth.router.ts` — Zod-validate body, verify current password with bcrypt, hash new password, UPDATE `sv_users`, DELETE refresh-token rows for the user, return 204.
+2. Auth middleware on the route (Bearer JWT).
+3. CSRF token flow — current backend enforces CSRF on mutating endpoints (our probe confirmed 403 CSRF on POST even with an auth token placeholder). Either add a `GET /api/auth/csrf` endpoint that issues a token or document how the frontend fetches one before POSTing.
+4. Unit test under `test/` or `tests/` covering: (a) wrong currentPassword → 401, (b) short newPassword → 422, (c) success → 204 + refresh tokens deleted, (d) CSRF missing → 403.
+
+**Operational constraints** that extend the timeline:
+- `streamvault-backend` CI workflows have been stuck red since 2026-03-14 (KR from plan context) — the backend PR will need the CI unblock or an agreed manual-deploy path (the 2026-04 jti fix used `docker compose up -d --build streamvault-api` as the manual fallback).
+- Solo dev — backend PR + v3 Phase 3 unblock is a single-threaded dependency.
+
+**Why this wasn't auto-fixed during the Phase 2 close session:** the session was running unattended, and building an auth-sensitive endpoint against a backend with broken CI is not the kind of change that should ship without live human review. The plan's Task 3.0 gate explicitly says "do not proceed; escalate" when the endpoint is missing.
+
+**Resume plan:**
+1. Write + merge `streamvault-backend` PR adding `POST /api/auth/change-password` (unblock CI first, or use the manual-deploy path).
+2. Re-run the probe. Expect 401 / 422 (no auth / bad payload) on a valid CSRF token request.
+3. Log the verification in `docs/DECISIONS.md` per plan Task 3.0, tick the plan checkbox, proceed to Task 3.1 Zod schemas.


### PR DESCRIPTION
## Summary
Phase 3 Task 3.0 pre-check ran 2026-04-21. Endpoint MISSING. Phase 3 BLOCKED per plan gate.

## Probe results
- `POST /api/auth/change-password` → HTTP 403 CSRF
- `GET /api/auth/change-password` → HTTP 501 'coming in Phase 2/3'
- `grep` in streamvault-backend src → 0 hits

## Files
- `docs/KNOWN-RISK.md` — new KR-CHANGEPW with ~4h backend-PR scope + operational constraints + resume plan
- `docs/DECISIONS.md` — Task 3.0 pre-check record

## Why no auto-fix
Backend auth is security-sensitive; streamvault-backend CI has been red since 2026-03-14; plan gate says escalate. Resume plan is in KNOWN-RISK.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)