### PR TITLE
feat(api): Task 3.1 — Zod API schemas

### DIFF
--- a/src/api/schemas.test.ts
+++ b/src/api/schemas.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { LoginResponseSchema, ChannelSchema } from "./schemas";
+
+describe("API Zod schemas", () => {
+  it("parses valid login response", () => {
+    const raw = {
+      accessToken: "abc.def.ghi",
+      refreshToken: "xyz",
+      expiresIn: 900,
+    };
+    expect(() => LoginResponseSchema.parse(raw)).not.toThrow();
+  });
+  it("rejects login response missing accessToken", () => {
+    expect(() => LoginResponseSchema.parse({ refreshToken: "x" })).toThrow();
+  });
+  it("parses valid channel", () => {
+    const raw = {
+      id: "1",
+      name: "BBC News",
+      categoryId: "5",
+      streamUrl: "http://x.m3u8",
+      num: 1,
+    };
+    expect(() => ChannelSchema.parse(raw)).not.toThrow();
+  });
+  it("rejects channel without streamUrl", () => {
+    expect(() =>
+      ChannelSchema.parse({ id: "1", name: "BBC", categoryId: "5", num: 1 }),
+    ).toThrow();
+  });
+});

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+
+export const LoginResponseSchema = z.object({
+  accessToken: z.string(),
+  refreshToken: z.string(),
+  expiresIn: z.number().optional(),
+});
+export type LoginResponse = z.infer<typeof LoginResponseSchema>;
+
+export const RefreshResponseSchema = z.object({
+  accessToken: z.string(),
+  refreshToken: z.string(),
+  expiresIn: z.number().optional(),
+});
+
+export const ChannelSchema = z.object({
+  id: z.string(),
+  num: z.number(),
+  name: z.string(),
+  categoryId: z.string(),
+  streamUrl: z.string().url(),
+  logo: z.string().optional(),
+  epgChannelId: z.string().optional(),
+});
+export type Channel = z.infer<typeof ChannelSchema>;
+
+export const EpgEntrySchema = z.object({
+  id: z.string(),
+  channelId: z.string(),
+  title: z.string(),
+  start: z.string().datetime(),
+  end: z.string().datetime(),
+  description: z.string().optional(),
+});
+export type EpgEntry = z.infer<typeof EpgEntrySchema>;
+
+export const VodItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  categoryId: z.string(),
+  streamUrl: z.string().url(),
+  posterUrl: z.string().optional(),
+  rating: z.number().optional(),
+  addedAt: z.string().datetime().optional(),
+});
+export type VodItem = z.infer<typeof VodItemSchema>;
+
+// Preview shape (list-view cards only). Phase 6 adds full SeriesSchema with
+// streamUrl, cover, plot, cast, genre, releaseDate, rating.
+export const SeriesPreviewSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  categoryId: z.string(),
+  posterUrl: z.string().optional(),
+  seasons: z.number().optional(),
+});
+export type SeriesPreview = z.infer<typeof SeriesPreviewSchema>;
+
+export const UserMeSchema = z.object({
+  id: z.number(),
+  username: z.string(),
+  role: z.enum(["admin", "user"]),
+});
+export type UserMe = z.infer<typeof UserMeSchema>;


### PR DESCRIPTION
## Summary
- Creates `src/api/schemas.ts` with Zod schemas for all API response types: `LoginResponse`, `RefreshResponse`, `Channel`, `EpgEntry`, `VodItem`, `SeriesPreview`, `UserMe`
- `SeriesPreviewSchema` (not `SeriesSchema`) per FIX D3 — Phase 6 adds the full `SeriesSchema` detail shape
- Creates `src/api/schemas.test.ts` with 4 schema validation tests (TDD: red → green)

## Test plan
- [x] 4 new vitest cases pass: valid login response, rejects missing accessToken, valid channel, rejects channel without streamUrl
- [x] Full suite 47/47 green (no regressions from 43 baseline)
- [x] Task 3.0 gate satisfied: `POST /api/auth/change-password` was shipped in `streamvault-backend` PR #39 (prior session — recorded in Postgres learning `streamvault,v3,phase-3,task-3.0,unblocked`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)