### PR TITLE
feat(api): Task 3.2 — ApiClient fetch wrapper + token storage

### DIFF
--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ApiClient } from "./client";
+
+describe("ApiClient", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+  });
+
+  it("adds Authorization header when token present", async () => {
+    sessionStorage.setItem("sv_access_token", "test-token");
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const client = new ApiClient("http://localhost:3001");
+    await client.get("/api/test");
+    expect(fetchSpy.mock.calls[0]?.[1]?.headers).toMatchObject({
+      Authorization: "Bearer test-token",
+    });
+  });
+
+  it("returns parsed JSON on 200", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [1, 2, 3] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const client = new ApiClient("http://localhost:3001");
+    const result = await client.get("/api/test");
+    expect(result).toEqual({ data: [1, 2, 3] });
+  });
+
+  it("throws ApiError on 401", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ message: "Unauthorized" }), {
+        status: 401,
+      }),
+    );
+    const client = new ApiClient("http://localhost:3001");
+    await expect(client.get("/api/test")).rejects.toMatchObject({
+      status: 401,
+    });
+  });
+});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,17 +2,20 @@ const ACCESS_TOKEN_KEY = "sv_access_token";
 const REFRESH_TOKEN_KEY = "sv_refresh_token";
 
 export class ApiError extends Error {
-  constructor(
-    public status: number,
-    message: string,
-  ) {
+  readonly status: number;
+  constructor(status: number, message: string) {
     super(message);
+    this.status = status;
     this.name = "ApiError";
   }
 }
 
 export class ApiClient {
-  constructor(private baseUrl: string) {}
+  private readonly baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl;
+  }
 
   private getAccessToken(): string | null {
     return sessionStorage.getItem(ACCESS_TOKEN_KEY);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,118 @@
+const ACCESS_TOKEN_KEY = "sv_access_token";
+const REFRESH_TOKEN_KEY = "sv_refresh_token";
+
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+export class ApiClient {
+  constructor(private baseUrl: string) {}
+
+  private getAccessToken(): string | null {
+    return sessionStorage.getItem(ACCESS_TOKEN_KEY);
+  }
+
+  setTokens(accessToken: string, refreshToken: string): void {
+    sessionStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+    localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+  }
+
+  clearTokens(): void {
+    sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+    localStorage.removeItem(REFRESH_TOKEN_KEY);
+  }
+
+  getRefreshToken(): string | null {
+    return localStorage.getItem(REFRESH_TOKEN_KEY);
+  }
+
+  private async request<T>(
+    path: string,
+    options: RequestInit = {},
+  ): Promise<T> {
+    const token = this.getAccessToken();
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      ...(options.headers as Record<string, string>),
+    };
+    if (token) {
+      headers["Authorization"] = `Bearer ${token}`;
+    }
+
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      ...options,
+      headers,
+    });
+
+    if (res.status === 401) {
+      const refreshed = await this.tryRefresh();
+      if (refreshed) {
+        headers["Authorization"] = `Bearer ${this.getAccessToken() ?? ""}`;
+        const retryRes = await fetch(`${this.baseUrl}${path}`, {
+          ...options,
+          headers,
+        });
+        if (!retryRes.ok)
+          throw new ApiError(retryRes.status, `API error: ${retryRes.status}`);
+        return retryRes.json() as Promise<T>;
+      }
+      throw new ApiError(401, "Unauthorized");
+    }
+
+    if (!res.ok) throw new ApiError(res.status, `API error: ${res.status}`);
+    return res.json() as Promise<T>;
+  }
+
+  private async tryRefresh(): Promise<boolean> {
+    const refreshToken = this.getRefreshToken();
+    if (!refreshToken) return false;
+    try {
+      const res = await fetch(`${this.baseUrl}/api/auth/refresh`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refreshToken }),
+      });
+      if (!res.ok) return false;
+      const data = (await res.json()) as {
+        accessToken: string;
+        refreshToken: string;
+      };
+      this.setTokens(data.accessToken, data.refreshToken);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  get<T>(path: string): Promise<T> {
+    return this.request<T>(path);
+  }
+
+  post<T>(path: string, body: unknown): Promise<T> {
+    return this.request<T>(path, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  }
+
+  patch<T>(path: string, body: unknown): Promise<T> {
+    return this.request<T>(path, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    });
+  }
+
+  delete<T>(path: string): Promise<T> {
+    return this.request<T>(path, { method: "DELETE" });
+  }
+}
+
+export const apiClient = new ApiClient(
+  import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3001",
+);


### PR DESCRIPTION
## Summary
- `src/api/client.ts` — `ApiClient` class with Bearer auth, auto-refresh on 401 via `POST /api/auth/refresh`, sessionStorage for access token, localStorage for refresh token
- `ApiError` class for non-2xx responses carrying the status code
- Singleton `apiClient` exported, using `VITE_API_BASE_URL` (default `http://localhost:3001`)
- GET/POST/PATCH/DELETE helpers

## Test plan
- [x] 3 vitest cases pass: adds Authorization header, returns parsed JSON on 200, throws ApiError on 401
- [x] Full suite 50/50 green (47 baseline + 3 new)
- [x] tsc strict — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)