### PR TITLE
feat(api): Task 4.1 — live.ts channel/EPG/category fetchers

### DIFF
--- a/src/api/live.test.ts
+++ b/src/api/live.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchChannels, fetchEpg } from "./live";
+import { apiClient } from "./client";
+
+describe("live API", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetchChannels returns typed Channel array", async () => {
+    vi.spyOn(apiClient, "get").mockResolvedValue([
+      {
+        id: "1",
+        num: 101,
+        name: "BBC",
+        categoryId: "5",
+        streamUrl: "http://x.m3u8",
+      },
+    ]);
+    const result = await fetchChannels();
+    expect(result[0]?.name).toBe("BBC");
+  });
+
+  it("fetchChannels throws on invalid API shape", async () => {
+    vi.spyOn(apiClient, "get").mockResolvedValue([{ invalid: true }]);
+    await expect(fetchChannels()).rejects.toThrow();
+  });
+
+  it("fetchEpg returns typed EpgEntry array", async () => {
+    vi.spyOn(apiClient, "get").mockResolvedValue([
+      {
+        id: "e1",
+        channelId: "1",
+        title: "News at 10",
+        start: "2026-04-21T22:00:00.000Z",
+        end: "2026-04-21T22:30:00.000Z",
+      },
+    ]);
+    const result = await fetchEpg("1");
+    expect(result[0]?.title).toBe("News at 10");
+  });
+});

--- a/src/api/live.ts
+++ b/src/api/live.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { apiClient } from "./client";
+import {
+  ChannelSchema,
+  EpgEntrySchema,
+  type Channel,
+  type EpgEntry,
+} from "./schemas";
+
+export async function fetchChannels(): Promise<Channel[]> {
+  const raw = await apiClient.get<unknown[]>("/api/live/channels");
+  return z.array(ChannelSchema).parse(raw);
+}
+
+export async function fetchChannelsByCategory(
+  categoryId: string,
+): Promise<Channel[]> {
+  const raw = await apiClient.get<unknown[]>(
+    `/api/live/channels?categoryId=${encodeURIComponent(categoryId)}`,
+  );
+  return z.array(ChannelSchema).parse(raw);
+}
+
+export async function fetchEpg(
+  channelId: string,
+  date?: string,
+): Promise<EpgEntry[]> {
+  const qs = date ? `?date=${encodeURIComponent(date)}` : "";
+  const raw = await apiClient.get<unknown[]>(
+    `/api/live/epg/${encodeURIComponent(channelId)}${qs}`,
+  );
+  return z.array(EpgEntrySchema).parse(raw);
+}
+
+export async function fetchCategories(): Promise<
+  { id: string; name: string }[]
+> {
+  const raw = await apiClient.get<{ id: string; name: string }[]>(
+    "/api/live/categories",
+  );
+  return raw;
+}


### PR DESCRIPTION
## Summary
Phase 4 Task 4.1 — typed fetchers for Live TV endpoints.

- \`fetchChannels()\` — GET /api/live/channels, Zod-parsed Channel[]
- \`fetchChannelsByCategory(id)\` — GET /api/live/channels?categoryId=...
- \`fetchEpg(channelId, date?)\` — GET /api/live/epg/:id
- \`fetchCategories()\` — GET /api/live/categories (passthrough, no Zod yet)

## Test plan
- [x] 3 new vitest cases: fetchChannels happy path, invalid shape rejection, fetchEpg happy path
- [x] Full suite 61/61 green (58 baseline + 3 new)
- [x] tsc strict clean, eslint max-warnings=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)