### PR TITLE
Task 4.3 — SplitGuide component + LiveRoute proof-of-life

### DIFF
--- a/src/features/live/SplitGuide.test.tsx
+++ b/src/features/live/SplitGuide.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * SplitGuide tests (Task 4.3)
+ *
+ * Covers:
+ *  - render with channels (preview + list regions, names present)
+ *  - empty state: role=alert + onRetry callback fires (NOT window.location.reload)
+ *  - selected-channel visual state (aria-current + "LIVE" indicator)
+ *  - D-pad focus registration: each row calls useFocusable with
+ *    focusKey: `CHANNEL_<id>` (lesson from Task 2.4 — unregistered
+ *    rows are unreachable on Fire TV remotes)
+ *  - accessibility: channel list has role=list + aria-label
+ *
+ * Mocking norigin: jsdom can't drive the native focus manager, so we
+ * spy-mock useFocusable the same way BottomDock.test.tsx does. The spy
+ * lets us assert focusKey registration without needing a real focus graph.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import type { Channel } from "../../api/schemas";
+
+const useFocusableSpy = vi.hoisted(() => vi.fn());
+vi.mock("@noriginmedia/norigin-spatial-navigation", () => ({
+  init: vi.fn(),
+  useFocusable: (opts?: {
+    focusKey?: string;
+    onEnterPress?: () => void;
+  }) => {
+    useFocusableSpy(opts);
+    return {
+      ref: { current: null },
+      focusKey: opts?.focusKey ?? "MOCK_KEY",
+      focused: false,
+      focusSelf: vi.fn(),
+    };
+  },
+  FocusContext: {
+    Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  },
+  setFocus: vi.fn(),
+}));
+
+import { SplitGuide } from "./SplitGuide";
+
+const mockChannels: Channel[] = [
+  {
+    id: "1",
+    num: 101,
+    name: "BBC News",
+    categoryId: "news",
+    streamUrl: "https://example.com/bbc.m3u8",
+  },
+  {
+    id: "2",
+    num: 202,
+    name: "CNN",
+    categoryId: "news",
+    streamUrl: "https://example.com/cnn.m3u8",
+  },
+];
+
+describe("SplitGuide", () => {
+  beforeEach(() => {
+    useFocusableSpy.mockClear();
+  });
+
+  it("renders preview region and channel list with channel names", () => {
+    render(
+      <SplitGuide
+        channels={mockChannels}
+        selectedChannelId="1"
+        onSelectChannel={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole("region", { name: /preview/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("list", { name: /channel list/i }),
+    ).toBeInTheDocument();
+    // "BBC News" appears in both the preview pane (selected) and the list row
+    expect(screen.getAllByText("BBC News").length).toBeGreaterThan(0);
+    expect(screen.getByText("CNN")).toBeInTheDocument();
+  });
+
+  it("selected channel has aria-current=true and shows LIVE indicator", () => {
+    render(
+      <SplitGuide
+        channels={mockChannels}
+        selectedChannelId="2"
+        onSelectChannel={() => {}}
+      />,
+    );
+    const cnnButton = screen.getByRole("button", { name: /channel 202: cnn/i });
+    expect(cnnButton).toHaveAttribute("aria-current", "true");
+    expect(cnnButton.textContent).toMatch(/LIVE/);
+
+    const bbcButton = screen.getByRole("button", {
+      name: /channel 101: bbc news/i,
+    });
+    expect(bbcButton).not.toHaveAttribute("aria-current", "true");
+  });
+
+  it("fires onSelectChannel when a row is clicked", async () => {
+    const onSelect = vi.fn();
+    render(
+      <SplitGuide
+        channels={mockChannels}
+        selectedChannelId="1"
+        onSelectChannel={onSelect}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /channel 202: cnn/i }),
+    );
+    expect(onSelect).toHaveBeenCalledWith("2");
+  });
+
+  it("registers each channel row with norigin via focusKey CHANNEL_<id>", () => {
+    render(
+      <SplitGuide
+        channels={mockChannels}
+        selectedChannelId="1"
+        onSelectChannel={() => {}}
+      />,
+    );
+    const focusKeys = useFocusableSpy.mock.calls
+      .map((call) => call[0]?.focusKey)
+      .filter(Boolean);
+    expect(focusKeys).toContain("CHANNEL_1");
+    expect(focusKeys).toContain("CHANNEL_2");
+  });
+
+  it("renders EPG Now/Next when provided", () => {
+    render(
+      <SplitGuide
+        channels={mockChannels}
+        selectedChannelId="1"
+        onSelectChannel={() => {}}
+        epgCurrentTitle="Morning News"
+        epgNextTitle="World Today"
+      />,
+    );
+    expect(screen.getByText(/Morning News/)).toBeInTheDocument();
+    expect(screen.getByText(/World Today/)).toBeInTheDocument();
+  });
+
+  it("empty channels shows role=alert and fires onRetry callback (NOT reload)", async () => {
+    const onRetry = vi.fn();
+    const reloadSpy = vi.fn();
+    // Guard: if implementation leaks window.location.reload, this would throw
+    // in jsdom. We also assert it was never called.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload: reloadSpy },
+    });
+
+    render(
+      <SplitGuide
+        channels={[]}
+        selectedChannelId={null}
+        onSelectChannel={() => {}}
+        onRetry={onRetry}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledOnce();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  it("shows Skeleton loading state when loading prop is true", () => {
+    const { container } = render(
+      <SplitGuide
+        channels={[]}
+        selectedChannelId={null}
+        onSelectChannel={() => {}}
+        loading
+      />,
+    );
+    // Skeleton renders aria-hidden divs with .skeleton class
+    expect(container.querySelectorAll(".skeleton").length).toBeGreaterThan(0);
+    // Must NOT show ErrorShell during loading even if channels is []
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it('falls back to "No channel selected" when selectedChannelId is null', () => {
+    render(
+      <SplitGuide
+        channels={mockChannels}
+        selectedChannelId={null}
+        onSelectChannel={() => {}}
+      />,
+    );
+    expect(screen.getByText(/No channel selected/i)).toBeInTheDocument();
+  });
+});

--- a/src/features/live/SplitGuide.tsx
+++ b/src/features/live/SplitGuide.tsx
@@ -1,0 +1,271 @@
+/**
+ * SplitGuide — Live TV channel list + preview pane (Task 4.3)
+ *
+ * Purely presentational 55/45 split layout consumed by LiveRoute.
+ *  - Left pane: static poster placeholder + selected channel name + optional
+ *    EPG "Now" / "Next" titles.
+ *  - Right pane: scrollable channel list. Each row uses `useFocusable` with
+ *    `focusKey: CHANNEL_<id>` so norigin can build a spatial graph and
+ *    D-pad Up/Down traverses the list on Fire TV. (Lesson from Task 2.4:
+ *    unregistered rows are unreachable on the remote.)
+ *
+ * Empty / error state: channels.length === 0 → <ErrorShell> with
+ * parent-provided onRetry callback. We deliberately do NOT call
+ * window.location.reload() — that causes a multi-second blank screen and
+ * re-initialises norigin on Fire TV Silk.
+ *
+ * Loading state: when `loading` is true the panes render <Skeleton>
+ * placeholders. Parent (LiveRoute) toggles this during initial fetch so
+ * the user never sees the empty-state alert mid-flight.
+ *
+ * No HLS preview in Phase 4 — live stream lands in Phase 5a (M3 decision).
+ */
+import type { RefObject } from "react";
+import { useFocusable } from "@noriginmedia/norigin-spatial-navigation";
+import { ErrorShell } from "../../primitives/ErrorShell";
+import { Skeleton } from "../../primitives/Skeleton";
+import type { Channel } from "../../api/schemas";
+
+export interface SplitGuideProps {
+  /** Channel list from fetchChannels() (parent-owned). */
+  channels: Channel[];
+  /** Currently-selected channel id (parent-owned useState). */
+  selectedChannelId: string | null;
+  /** Fired when a channel row is clicked or Enter-pressed on remote. */
+  onSelectChannel: (id: string) => void;
+  /** Title of the EPG entry currently airing on the selected channel. */
+  epgCurrentTitle?: string;
+  /** Title of the next EPG entry on the selected channel. */
+  epgNextTitle?: string;
+  /** Parent re-fetches channels when user clicks Retry on the empty state. */
+  onRetry?: () => void;
+  /** When true, render Skeleton placeholders instead of ErrorShell/list. */
+  loading?: boolean;
+}
+
+export function SplitGuide({
+  channels,
+  selectedChannelId,
+  onSelectChannel,
+  epgCurrentTitle,
+  epgNextTitle,
+  onRetry,
+  loading = false,
+}: SplitGuideProps) {
+  // ─── Loading state ─────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div style={splitGridStyle}>
+        <section
+          aria-label="Channel preview"
+          style={previewPaneStyle}
+          aria-busy="true"
+        >
+          <Skeleton width="100%" height="60%" />
+          <Skeleton width="60%" height="var(--space-6)" />
+        </section>
+        <div style={listPaneStyle} aria-busy="true">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton
+              key={i}
+              width="100%"
+              height="var(--space-10)"
+              className="split-guide__row-skeleton"
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // ─── Empty / error state ───────────────────────────────────────────────
+  if (channels.length === 0) {
+    return (
+      <ErrorShell
+        icon="network"
+        title="Can't load channels"
+        subtext="We couldn't reach the live TV service."
+        onRetry={onRetry ?? (() => {})}
+      />
+    );
+  }
+
+  // ─── Happy path ────────────────────────────────────────────────────────
+  const selected =
+    channels.find((c) => c.id === selectedChannelId) ?? null;
+
+  return (
+    <div style={splitGridStyle}>
+      {/* ── Left pane: preview ── */}
+      <section aria-label="Channel preview" style={previewPaneStyle}>
+        <div
+          aria-label="Video preview"
+          style={posterStyle}
+        >
+          <span style={posterLabelStyle}>
+            {selected ? selected.name : "No channel selected"}
+          </span>
+        </div>
+        {selected && (
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            <p style={previewTitleStyle}>{selected.name}</p>
+            {epgCurrentTitle !== undefined && (
+              <p style={epgLineStyle}>
+                <strong>Now:</strong> {epgCurrentTitle}
+              </p>
+            )}
+            {epgNextTitle !== undefined && (
+              <p style={epgLineStyle}>
+                <strong>Next:</strong> {epgNextTitle}
+              </p>
+            )}
+          </div>
+        )}
+      </section>
+
+      {/* ── Right pane: channel list ── */}
+      <ul aria-label="Channel list" style={listPaneStyle}>
+        {channels.map((channel) => (
+          <ChannelRow
+            key={channel.id}
+            channel={channel}
+            isSelected={channel.id === selectedChannelId}
+            onSelect={onSelectChannel}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// ─── ChannelRow ─────────────────────────────────────────────────────────────
+// Split out so `useFocusable` runs per-row with a stable focusKey. Without
+// per-row registration, norigin can't locate siblings under CONTENT_AREA_LIVE
+// and ArrowUp/Down on the remote would stay pinned on the first row.
+
+function ChannelRow({
+  channel,
+  isSelected,
+  onSelect,
+}: {
+  channel: Channel;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+}) {
+  const { ref, focused } = useFocusable({
+    focusKey: `CHANNEL_${channel.id}`,
+    onEnterPress: () => onSelect(channel.id),
+  });
+  const active = isSelected || focused;
+
+  return (
+    <li style={{ listStyle: "none" }}>
+      <button
+        ref={ref as RefObject<HTMLButtonElement>}
+        type="button"
+        className="focus-ring"
+        onClick={() => onSelect(channel.id)}
+        aria-label={`Channel ${channel.num}: ${channel.name}`}
+        aria-current={isSelected ? "true" : undefined}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-4)",
+          width: "100%",
+          padding: "var(--space-3) var(--space-4)",
+          background: active
+            ? "var(--accent-copper)"
+            : "var(--bg-surface)",
+          color: active ? "var(--bg-base)" : "var(--text-primary)",
+          border: "none",
+          borderRadius: "var(--radius-sm)",
+          cursor: "pointer",
+          fontSize: "var(--text-body-size)",
+          textAlign: "left",
+          transition:
+            "background var(--motion-focus), color var(--motion-focus)",
+        }}
+      >
+        <span
+          style={{
+            minWidth: "48px",
+            fontVariantNumeric: "tabular-nums",
+            opacity: 0.8,
+          }}
+        >
+          {channel.num}
+        </span>
+        <span style={{ flex: 1 }}>{channel.name}</span>
+        {isSelected && (
+          <span
+            aria-hidden="true"
+            style={{ fontSize: "var(--text-label-size)", fontWeight: 600 }}
+          >
+            ● LIVE
+          </span>
+        )}
+      </button>
+    </li>
+  );
+}
+
+// ─── Styles ─────────────────────────────────────────────────────────────────
+
+const splitGridStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "55fr 45fr",
+  gap: "var(--space-6)",
+  padding: "var(--space-6)",
+  height:
+    "calc(100vh - var(--dock-height) - var(--space-12))",
+  boxSizing: "border-box",
+};
+
+const previewPaneStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-4)",
+  padding: "var(--space-4)",
+  background: "var(--bg-surface)",
+  borderRadius: "var(--radius-md)",
+  minHeight: 0,
+};
+
+const posterStyle: React.CSSProperties = {
+  flex: 1,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  background:
+    "linear-gradient(135deg, var(--bg-elevated), var(--bg-surface))",
+  borderRadius: "var(--radius-sm)",
+  color: "var(--text-secondary)",
+  minHeight: "160px",
+};
+
+const posterLabelStyle: React.CSSProperties = {
+  fontSize: "var(--text-title-size)",
+  fontWeight: 600,
+};
+
+const previewTitleStyle: React.CSSProperties = {
+  fontSize: "var(--text-title-size)",
+  color: "var(--text-primary)",
+  margin: 0,
+};
+
+const epgLineStyle: React.CSSProperties = {
+  fontSize: "var(--text-body-size)",
+  color: "var(--text-secondary)",
+  margin: 0,
+};
+
+const listPaneStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-2)",
+  padding: 0,
+  margin: 0,
+  overflowY: "auto",
+  listStyle: "none",
+};

--- a/src/routes/LiveRoute.tsx
+++ b/src/routes/LiveRoute.tsx
@@ -1,15 +1,21 @@
 /**
- * LiveRoute — route shell for /live (Task 2.3).
+ * LiveRoute — route shell for /live.
  *
- * Minimal shell with CONTENT_AREA_LIVE focus provider so future Esc-key logic
- * can route focus out of BottomDock via setFocus("CONTENT_AREA_LIVE").
- * Phase 4 replaces the placeholder body with Live TV channel grid + EPG.
+ * Task 2.3: minimal shell + CONTENT_AREA_LIVE FocusContext provider so Esc
+ * from BottomDock can route focus back into the content area.
+ *
+ * Task 4.3 (proof-of-life only): mount <SplitGuide> with an empty channel
+ * list so the ErrorShell empty state renders. Full data wiring
+ * (fetchChannels/fetchEpg, selectedChannelId useState, retry handler) lands
+ * in Task 4.4. The empty-list ErrorShell is intentional — it proves the
+ * component mounts under CONTENT_AREA_LIVE without the rest of the wiring.
  */
 import type { RefObject } from "react";
 import {
   useFocusable,
   FocusContext,
 } from "@noriginmedia/norigin-spatial-navigation";
+import { SplitGuide } from "../features/live/SplitGuide";
 
 export function LiveRoute() {
   const { ref, focusKey } = useFocusable({ focusKey: "CONTENT_AREA_LIVE" });
@@ -24,9 +30,14 @@ export function LiveRoute() {
             "calc(var(--dock-height) + var(--space-6) + var(--space-6))",
         }}
       >
-        <p style={{ color: "var(--text-primary)", padding: "48px" }}>
-          Live TV — coming in Phase 4
-        </p>
+        {/* Task 4.3 proof-of-life: empty channels → ErrorShell renders.
+            Task 4.4 will replace these stubs with real fetch state. */}
+        <SplitGuide
+          channels={[]}
+          selectedChannelId={null}
+          onSelectChannel={() => {}}
+          onRetry={() => {}}
+        />
       </main>
     </FocusContext.Provider>
   );


### PR DESCRIPTION
## Summary

- Adds `src/features/live/SplitGuide.tsx` — 55/45 split layout with channel preview (left) + channel list (right). Each row registers with norigin via `useFocusable({focusKey: CHANNEL_<id>})` so Fire TV D-pad Up/Down traverses the list (lesson from Task 2.4: unregistered rows are unreachable on the remote).
- Replaces the `window.location.reload()` retry pattern from the verbatim plan with a parent-provided `onRetry` callback — reload causes a multi-second blank screen and norigin re-init on Silk. The empty-state `<ErrorShell icon="network">` fires the callback instead.
- Adds an optional `loading` prop that renders `<Skeleton>` placeholders so the parent can gate the empty-state alert during the initial fetch (prevents a flicker of "Can't load channels" before data lands).
- Patches `src/routes/LiveRoute.tsx` as a minimal proof-of-life: mounts `<SplitGuide channels={[]} …/>` with no-op callbacks so the ErrorShell visibly renders under `CONTENT_AREA_LIVE`. **The existing `useFocusable({focusKey: "CONTENT_AREA_LIVE"})` registration is preserved** — this unblocks Esc-key routing from BottomDock. Full fetch/state wiring lands in Task 4.4.

Design doc: `/home/crawler/.claude/projects/-home-crawler/memory/task-4.3-splitguide-design.md` (scored 3.83/5 conditional pass; findings G1/G3 resolved in this PR via D2/D3 user decisions, G7 proof-of-life via D4).

## Test plan

- [x] `npm test` — 16 files / 69 tests passing (8 new SplitGuide cases)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (3 pre-existing warnings in `coverage/` only)
- [x] SplitGuide test asserts `useFocusable` was called with `focusKey: CHANNEL_1` and `CHANNEL_2`
- [x] SplitGuide test asserts empty-state Retry click fires the injected callback AND that `window.location.reload` was NOT called
- [x] LiveRoute still registers `CONTENT_AREA_LIVE` via norigin (grep-verified)
- [ ] Manual Silk / Fire TV D-pad verification deferred to Task 4.4 when real channel data lands

## Follow-ups for Task 4.4

- Wire `fetchChannels()` + `useState<Channel[]>` + `useState<string | null>` for selected channel.
- Wire `fetchEpg(selectedChannelId)` + derive `epgCurrentTitle` / `epgNextTitle` from `EpgEntry[]`.
- Implement real `onRetry` that re-fetches channels (not a no-op).
- Add sort/category filter (explicitly scoped out of 4.3).
- Add D-pad E2E test gate — user's feedback rule: "E2E not done until player/D-pad tested."

🤖 Generated with [Claude Code](https://claude.com/claude-code)