### PR TITLE
feat: add Dockerfile + nginx.conf + security-headers.conf (match v2 pattern)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+.git
+.github
+dist
+*.md
+docs
+tests
+.claude
+.env*
+.vscode
+coverage
+playwright-report
+test-results
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+
+COPY . .
+RUN npm run build
+
+# Runtime stage
+FROM nginx:alpine AS runtime
+
+RUN rm /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY security-headers.conf /etc/nginx/conf.d/security-headers.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+RUN apk add --no-cache curl
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD curl -f http://localhost/ || exit 1
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,85 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Stream proxy — unbuffered, long timeout for video streaming (HLS lands in Phase 5a)
+    location /api/stream/ {
+        proxy_pass http://streamvault-api:3001/api/stream/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Range $http_range;
+        proxy_set_header If-Range $http_if_range;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
+    # API proxy to backend (same Docker network)
+    location /api/ {
+        proxy_pass http://streamvault-api:3001/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_read_timeout 300s;
+    }
+
+    # Health endpoint (proxied to backend)
+    location = /health {
+        proxy_pass http://streamvault-api:3001/health;
+        proxy_set_header Host $host;
+    }
+
+    # SPA routing — index.html must not be cached (JS/CSS have content hashes)
+    location / {
+        add_header Cache-Control "no-cache" always;
+        include /etc/nginx/conf.d/security-headers.conf;
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets aggressively (Vite content-hashed filenames)
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        include /etc/nginx/conf.d/security-headers.conf;
+    }
+
+    # Cache media files
+    location ~* \.(png|jpg|jpeg|gif|ico|svg|webp|woff2?)$ {
+        expires 7d;
+        add_header Cache-Control "public";
+        include /etc/nginx/conf.d/security-headers.conf;
+    }
+
+    # Gzip
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_min_length 256;
+    gzip_types
+        text/plain
+        text/css
+        text/javascript
+        application/javascript
+        application/json
+        application/xml
+        image/svg+xml;
+
+    # Security headers (server-level fallback for locations without own add_header)
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https:; media-src 'self' blob: http: https:; worker-src 'self' blob:; manifest-src 'self'; frame-ancestors 'self';" always;
+
+    server_tokens off;
+}

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -1,0 +1,6 @@
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Cross-Origin-Opener-Policy "same-origin" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https:; media-src 'self' blob: http: https:; worker-src 'self' blob:; manifest-src 'self'; frame-ancestors 'self';" always;


### PR DESCRIPTION
## Summary
Adds the last missing pieces before v3 can be built and deployed via docker-compose. Copies the v2 multi-stage build + nginx SPA pattern (`streamvault-frontend/{Dockerfile,nginx.conf,security-headers.conf}`) with minimal, targeted adaptations for v3.

## Files added
- `Dockerfile` — verbatim from v2: node:20-alpine build stage (`npm ci --ignore-scripts` + `npm run build`) + nginx:alpine runtime with curl healthcheck on `/`.
- `nginx.conf` — SPA `try_files` fallback, `/api/` proxy to `http://streamvault-api:3001/`, `/api/stream/` unbuffered proxy, `/health` passthrough, gzip, aggressive `/assets/` caching (Vite content-hashed), static media caching, server-level security headers.
- `security-headers.conf` — CSP + X-Frame-Options + X-Content-Type-Options + Referrer-Policy + COOP.
- `.dockerignore` — v2's is not git-tracked; added explicitly to keep build context lean (excludes node_modules, dist, tests, .claude, etc.).

## v3-specific adaptations (vs pure v2 copy)
- **CSP**: `fonts.googleapis.com` / `fonts.gstatic.com` instead of `api.fontshare.com` / `cdn.fontshare.com` — v3's `index.html` preconnects and loads Inter from Google Fonts.
- **No PWA yet**: removed `/sw.js` and `/manifest.json` location blocks — v3's `public/` has no service worker or manifest (only `favicon.svg` + `icons.svg`).
- Kept `/api/stream/` unbuffered proxy — `hls.js` is already in `package.json` deps and the live stream lands in Phase 5a per `src/features/live/SplitGuide.tsx`.

No gaps found — v3's Vite build outputs to `dist/` (matches v2); backend service name `streamvault-api` on port 3001 is unchanged.

## Test plan
- [x] `docker build -t streamvault-v3-frontend:test .` succeeds (image ~93MB).
- [x] `docker run` on `ai_network` (so `streamvault-api` resolves) serves `GET /` with HTTP 200 + correct `index.html`.
- [ ] Merge → wire into `ai-orchestration/docker-compose.yml` as a separate `streamvault_v3_frontend` service (out of scope for this PR).
- [ ] Confirm `/api/` proxy end-to-end once deployed alongside backend.

Note: standalone `docker run` without `--network ai_network` fails nginx startup because the `streamvault-api` upstream can't be resolved — matches v2 behavior; expected when not on the compose network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)