### PR TITLE
feat(ci): add deploy.yml for v3 frontend (same pattern as v2, targets port 3004)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    environment: production
+    steps:
+      - name: Deploy to VPS
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          timeout: 60s
+          command_timeout: 8m
+          script: |
+            set -e
+            echo "Pulling latest v3 code..."
+            cd ~/streamvault-v3-frontend
+            git fetch origin main
+            git reset --hard origin/main
+
+            echo "Rebuilding v3 frontend container..."
+            cd ~/ai-orchestration
+            docker compose up -d --build streamvault-v3-frontend
+
+            echo "Waiting for health check on port 3004..."
+            for i in $(seq 1 18); do
+              if curl -sf http://localhost:3004/ > /dev/null 2>&1; then
+                echo "v3 frontend is healthy!"
+                exit 0
+              fi
+              echo "Attempt $i/18 - waiting 5s..."
+              sleep 5
+            done
+
+            echo "Health check failed after 90s"
+            docker logs streamvault-v3-frontend --tail 50 || docker logs streamvault_v3_frontend --tail 50 || true
+            docker restart streamvault-v3-frontend || docker restart streamvault_v3_frontend || true
+            exit 1
+
+      - name: Cleanup
+        if: success()
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          timeout: 60s
+          script: docker image prune -f


### PR DESCRIPTION
## Summary

Adds `.github/workflows/deploy.yml` so v3 frontend auto-deploys to the VPS on every push to `main`, mirroring v2's deploy pattern.

- **Trigger:** `workflow_run` on `CI` workflow completion on `main` branch (broken code is not deployed — CI must pass first).
- **Action:** SSHes to VPS via `appleboy/ssh-action@v1`, pulls latest `main` into `~/streamvault-v3-frontend`, runs `docker compose up -d --build streamvault-v3-frontend` from `~/ai-orchestration`.
- **Health check:** curls `http://localhost:3004/` — 18 attempts x 5s (90s total). On failure, dumps container logs and restarts the service.
- **Cleanup:** `docker image prune -f` on success.

## Why this is safe to merge now

v2 is still live on `streamvault.srinivaskotha.uk`. v3 is **internal-only on port 3004** until a future NPM proxy flip. This workflow only rebuilds the v3 container — it does **not** touch nginx/NPM rules, so there is zero user-facing impact until the flip.

## Prerequisites before this workflow can run

### 1. ai-orchestration PR #90 must be merged
Adds the `streamvault-v3-frontend` service to `docker-compose.yml` on port 3004. Without it, `docker compose up -d --build streamvault-v3-frontend` will fail.

### 2. SSH secrets must be copied to v3's production environment
The `production` environment on this repo does not yet have `SSH_HOST`, `SSH_USER`, `SSH_KEY`. Copy them from `streamvault-backend` (or the v2 archive) via GitHub UI:

**Settings -> Environments -> production -> Add secret**
https://github.com/srinivas-kotha/streamvault-v3-frontend/settings/environments

Required secrets (same values as v2):
- `SSH_HOST`
- `SSH_USER`
- `SSH_KEY`

Until these secrets are set, the `deploy` job will fail at the SSH step with a clear error.

## Deviations from v2's pattern

| Aspect | v2 | v3 |
| --- | --- | --- |
| Workflow_run gate | `Validate` | `CI` (v3's CI workflow is named `CI` in `ci.yml`) |
| Compose service | `streamvault-frontend` | `streamvault-v3-frontend` |
| Health-check port | 3002 | 3004 |
| Docker container name (logs/restart) | `streamvault_frontend` | Tries both `streamvault-v3-frontend` and `streamvault_v3_frontend` on failure (container name not yet locked in PR #90) |

Everything else (appleboy/ssh-action@v1, 8m command timeout, 18x5s loop, cleanup job, `environment: production`, `if: conclusion == 'success'`) matches v2 exactly.

## Test plan

- [ ] Merge ai-orchestration PR #90 (v3 compose service on port 3004)
- [ ] Set `SSH_HOST`, `SSH_USER`, `SSH_KEY` on this repo's `production` environment
- [ ] Merge this PR
- [ ] Observe next push to `main` triggers CI -> Deploy
- [ ] Confirm `curl http://VPS:3004/` (from VPS shell) returns v3 frontend
- [ ] Confirm v2 on `streamvault.srinivaskotha.uk` still works (should be untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)