### PR TITLE
fix(ci): update deploy health check port 3004 → 3006

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,9 +31,9 @@ jobs:
             cd ~/ai-orchestration
             docker compose up -d --build streamvault-v3-frontend
 
-            echo "Waiting for health check on port 3004..."
+            echo "Waiting for health check on port 3006..."
             for i in $(seq 1 18); do
-              if curl -sf http://localhost:3004/ > /dev/null 2>&1; then
+              if curl -sf http://localhost:3006/ > /dev/null 2>&1; then
                 echo "v3 frontend is healthy!"
                 exit 0
               fi


### PR DESCRIPTION
## Summary

First v3 deploy attempt failed because port 3004 was occupied on the VPS. Companion to ai-orchestration PR moving the service to port 3006. This updates the deploy workflow's health check to match.

## Changes

- `.github/workflows/deploy.yml`:
  - Log message: `port 3004` → `port 3006`
  - Health check curl: `http://localhost:3004/` → `http://localhost:3006/`

## Companion PR

`srinivas-kotha/ai-orchestration`: docker-compose port mapping `3004:80` → `3006:80`.

## Test plan

- [ ] Merge this PR
- [ ] Push triggers CI → workflow_run fires Deploy
- [ ] Deploy SSH's to VPS, rebuilds `streamvault-v3-frontend`
- [ ] Health check hits `http://localhost:3006/` — passes
- [ ] Deploy workflow completes green