### PR TITLE
fix(auth): wire onEnterPress on login form — norigin preventDefaults Enter

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,6 +2,21 @@
 
 > Rule: never delete entries. Append only. Each entry: date · decision · rationale.
 
+## 2026-04-22 (follow-up) — norigin preventDefaults Enter; onEnterPress is mandatory, not optional
+
+Smoke test of PR #29 in the live browser caught a second bug: pressing Enter on the focused "Sign in" button did nothing. Root cause: **norigin's keyboard handler calls `event.preventDefault()` on Enter**, which blocks the browser's native `Enter-on-focused-button → click → form-submit` path. A `<button type="submit">` under `useFocusable` without an `onEnterPress` is a dead-end on OK press.
+
+Retrofit (LoginPage only — ErrorShell already wired `onEnterPress={onRetry}` on all three buttons):
+
+- `formRef` on the `<form>` + `submitForm()` helper that calls `formRef.current?.requestSubmit()` (re-enters `onSubmit` AND runs HTML5 required-field validation).
+- Username input `onEnterPress: () => setFocus("LOGIN_PASSWORD")` — Enter advances to next field (TV input convention).
+- Password input `onEnterPress: submitForm` — Enter on final field submits.
+- Submit Button `onEnterPress: submitForm` — Enter on the button submits.
+
+3 new LoginPage unit tests assert each focusKey's `onEnterPress` is a function, invoke it directly, and verify the expected side effect (setFocus or login call).
+
+**Rule for future TV work:** every `useFocusable`-registered target that the user can land on must supply an `onEnterPress` if OK is supposed to do anything. Not a browser fallback. This also means `<a href>` links under norigin need onEnterPress → navigate.
+
 ## 2026-04-22 — Button primitive made norigin-aware; LoginPage + ErrorShell retrofitted
 
 Discovered by user during first real-browser smoke test of v3 on streamvault.srinivaskotha.uk after the NPM proxy flip (2026-04-22 night): ArrowUp/ArrowDown did not move focus on LoginPage, only Tab worked. Tab is browser-native, not a TV-remote key — Fire TV remotes cannot fire Tab. This meant **the entire app was unreachable on the primary target device** (Fire TV Stick 4K Max).

--- a/src/features/auth/LoginPage.test.tsx
+++ b/src/features/auth/LoginPage.test.tsx
@@ -116,4 +116,66 @@ describe("LoginPage", () => {
       expect(setFocusSpy).toHaveBeenCalledWith("LOGIN_USERNAME");
     });
   });
+
+  // ─── norigin preventDefaults Enter, so onEnterPress must be wired on
+  //     every TV-reachable target (Username / Password / Sign-in). ────────
+
+  it("wires onEnterPress on LOGIN_USERNAME that advances focus to LOGIN_PASSWORD", () => {
+    render(<LoginPage onLoginSuccess={() => {}} />);
+    const calls = useFocusableSpy.mock.calls as Array<
+      [{ focusKey?: string; onEnterPress?: () => void }]
+    >;
+    const username = calls.find((c) => c[0]?.focusKey === "LOGIN_USERNAME");
+    expect(username?.[0].onEnterPress).toBeInstanceOf(Function);
+
+    setFocusSpy.mockClear();
+    username![0].onEnterPress!();
+    expect(setFocusSpy).toHaveBeenCalledWith("LOGIN_PASSWORD");
+  });
+
+  it("wires onEnterPress on LOGIN_PASSWORD that submits the form", async () => {
+    vi.spyOn(authApi, "login").mockImplementation(async (u) => {
+      apiClient.setSession(u);
+      return { message: "ok", userId: 1, username: u };
+    });
+    const onSuccess = vi.fn();
+    render(<LoginPage onLoginSuccess={onSuccess} />);
+    fireEvent.change(screen.getByLabelText("Username"), {
+      target: { value: "admin" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "pw" },
+    });
+    const calls = useFocusableSpy.mock.calls as Array<
+      [{ focusKey?: string; onEnterPress?: () => void }]
+    >;
+    const password = calls.find((c) => c[0]?.focusKey === "LOGIN_PASSWORD");
+    expect(password?.[0].onEnterPress).toBeInstanceOf(Function);
+
+    password![0].onEnterPress!();
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+  });
+
+  it("wires onEnterPress on LOGIN_SUBMIT that submits the form (norigin Enter path)", async () => {
+    vi.spyOn(authApi, "login").mockImplementation(async (u) => {
+      apiClient.setSession(u);
+      return { message: "ok", userId: 1, username: u };
+    });
+    const onSuccess = vi.fn();
+    render(<LoginPage onLoginSuccess={onSuccess} />);
+    fireEvent.change(screen.getByLabelText("Username"), {
+      target: { value: "admin" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "pw" },
+    });
+    const calls = useFocusableSpy.mock.calls as Array<
+      [{ focusKey?: string; onEnterPress?: () => void }]
+    >;
+    const submit = calls.find((c) => c[0]?.focusKey === "LOGIN_SUBMIT");
+    expect(submit?.[0].onEnterPress).toBeInstanceOf(Function);
+
+    submit![0].onEnterPress!();
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+  });
 });

--- a/src/features/auth/LoginPage.tsx
+++ b/src/features/auth/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   useFocusable,
   setFocus,
@@ -15,12 +15,29 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const formRef = useRef<HTMLFormElement>(null);
 
+  // `requestSubmit()` re-enters the form's onSubmit path AND runs HTML5
+  // required-field validation, so it behaves identically to a mouse click
+  // on the submit button.
+  const submitForm = () => {
+    if (!loading) formRef.current?.requestSubmit();
+  };
+
+  // Norigin captures Enter at the window level and `preventDefault`s it,
+  // which blocks the browser's native Enter-on-focused-button → click →
+  // form-submit flow. Every TV-reachable target that should respond to OK
+  // must supply its own `onEnterPress`. Below:
+  //   - Username Enter → advance to Password (TV input convention)
+  //   - Password Enter → submit form
+  //   - Submit button Enter → submit form
   const { ref: usernameRef } = useFocusable<HTMLInputElement>({
     focusKey: "LOGIN_USERNAME",
+    onEnterPress: () => setFocus("LOGIN_PASSWORD"),
   });
   const { ref: passwordRef } = useFocusable<HTMLInputElement>({
     focusKey: "LOGIN_PASSWORD",
+    onEnterPress: submitForm,
   });
 
   // Prime norigin's focus tree on mount. Raw DOM .focus() would land a
@@ -31,8 +48,8 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
     setFocus("LOGIN_USERNAME");
   }, []);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = async (e?: React.FormEvent) => {
+    e?.preventDefault();
     setLoading(true);
     setError(null);
     try {
@@ -58,6 +75,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
       }}
     >
       <form
+        ref={formRef}
         onSubmit={handleSubmit}
         aria-label="Login"
         style={{
@@ -147,6 +165,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
           disabled={loading}
           size="lg"
           focusKey="LOGIN_SUBMIT"
+          onEnterPress={submitForm}
         >
           {loading ? "Signing in…" : "Sign in"}
         </Button>

--- a/tests/e2e/d-pad-login.spec.ts
+++ b/tests/e2e/d-pad-login.spec.ts
@@ -68,6 +68,48 @@ test.describe("LoginPage D-pad navigation", () => {
     expect(submitFocused.text).toMatch(/sign in/i);
   });
 
+  test("Enter on Sign in button fires a POST /api/auth/login (norigin Enter path)", async ({
+    page,
+  }) => {
+    // Any response is fine — we only assert the submit wired through to a
+    // real network request. Without this, norigin preventDefaults Enter
+    // and nothing happens (the bug first caught by a real-browser smoke
+    // test after PR #29 merged).
+    await page.route("**/api/auth/login", (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Unauthorized" }),
+      }),
+    );
+
+    await page.waitForFunction(
+      () => document.activeElement?.id === "username",
+      { timeout: 2000 },
+    );
+    await page.fill("#username", "admin");
+    await page.fill("#password", "test-pw");
+
+    // Re-prime focus — fill() moved DOM focus to #password but norigin's
+    // lastFocused may be stale. Walk back from username via D-pad.
+    await page.evaluate(() => {
+      (document.getElementById("username") as HTMLInputElement).focus();
+    });
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowDown");
+    await page.waitForFunction(
+      () => document.activeElement?.tagName === "BUTTON",
+      { timeout: 2000 },
+    );
+
+    const requestPromise = page.waitForRequest((req) =>
+      req.url().includes("/api/auth/login"),
+    );
+    await page.keyboard.press("Enter");
+    const req = await requestPromise;
+    expect(req.method()).toBe("POST");
+  });
+
   test("ArrowUp from submit walks back to password then username", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

Second bug caught during live-browser smoke of PR #29: pressing **Enter on the focused Sign-in button did nothing**. norigin calls `event.preventDefault()` on Enter, which blocks the browser's native `Enter-on-focused-button → click → form-submit` path. A `<button type="submit">` under `useFocusable` without `onEnterPress` is a dead-end on OK press.

- Add `formRef` + `submitForm()` helper calling `formRef.current?.requestSubmit()` (re-enters `onSubmit` AND runs HTML5 required-field validation).
- Username `onEnterPress` → `setFocus("LOGIN_PASSWORD")` (TV input convention: OK advances to next field).
- Password `onEnterPress` → `submitForm`.
- Sign-in Button `onEnterPress` → `submitForm`.
- New Playwright E2E: fill both fields, walk focus via arrows, press Enter, assert `POST /api/auth/login` fires. **This is the scenario PR #29's E2E missed** — the test stopped at "focus the button" without exercising OK press.

## Test plan

- [x] `tsc -p tsconfig.app.json --noEmit` clean
- [x] `vitest run` — 18 files / 100 tests green (3 new: each focusKey's onEnterPress invokes the expected side effect)
- [x] `playwright test d-pad-login.spec.ts --project=chromium` — 4/4 green including new Enter-submit case
- [ ] CI green on this PR
- [ ] Live URL: login via keyboard Enter works end-to-end

## Rule shipped in DECISIONS.md

Every `useFocusable`-registered target the user can land on MUST supply an `onEnterPress` if OK is supposed to do anything. Not a browser fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)