### PR TITLE
fix(api): empty API base URL in prod — same-origin via nginx /api/*

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -136,6 +136,16 @@ export class ApiClient {
   }
 }
 
+// In production (Vite `npm run build`), fetch same-origin — nginx.conf
+// proxies `/api/*` to the backend container. Hard-coding `localhost:3001`
+// as the build-time default shipped a bundle that tried to talk to the
+// user's own laptop on prod, which CSP `connect-src 'self' https:` blocked
+// — the error got laundered into "Invalid username or password" by the
+// login catch, masking the real bug. `import.meta.env.DEV` is true ONLY
+// for `npm run dev`, so Vite-built artefacts always take the empty-base
+// branch.
+const DEFAULT_BASE_URL = import.meta.env.DEV ? "http://localhost:3001" : "";
+
 export const apiClient = new ApiClient(
-  import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3001",
+  import.meta.env.VITE_API_BASE_URL ?? DEFAULT_BASE_URL,
 );


### PR DESCRIPTION
## Summary

**Login has been broken on prod since the 2026-04-22 NPM flip.**

- The built bundle had `http://localhost:3001` baked in as the API base URL (client.ts defaulted to it; Dockerfile never passes `VITE_API_BASE_URL` at build time).
- Users' browsers tried `POST http://localhost:3001/api/auth/login` → CSP `connect-src 'self' https:` blocked it → the login catch laundered the network error into **"Invalid username or password"**, masking the real bug.
- Caught by opening DevTools on the live URL: `Fetch API cannot load http://localhost:3001/api/auth/login — Refused to connect because it violates the Content Security Policy`.

## Fix

Default to `""` when `import.meta.env.DEV === false` → fetch goes same-origin (`/api/...`), which `nginx.conf` already proxies to `streamvault-api:3001` on the internal Docker network.

`npm run dev` still defaults to `http://localhost:3001` (backend on 3001, vite on 5173, CORS already allows it).

## Test plan

- [x] `tsc -p tsconfig.app.json --noEmit` clean
- [x] `vitest run src/api` — 18/18 green (existing baseUrl mocks unaffected)
- [ ] CI green
- [ ] After deploy: log in with `admin` / `Testing@1234` on live URL works

🤖 Generated with [Claude Code](https://claude.com/claude-code)