### PR TITLE
fix(shell): auto-prime dock focus + full-bleed layout + prod E2E infra

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:prod": "playwright test --config=playwright.prod.config.ts",
     "typecheck": "tsc --noEmit",
     "check-budget": "node scripts/check-bundle-budget.js"
   },

--- a/playwright.prod.config.ts
+++ b/playwright.prod.config.ts
@@ -1,0 +1,57 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Production smoke + visual regression config.
+ *
+ * Separate from `playwright.config.ts` (which targets `npm run dev` on
+ * localhost:5173) — this runs against the deployed public URL so we catch
+ * bugs that only manifest in the prod bundle (e.g. baked env vars, nginx
+ * proxy misconfig, CDN caching, CSP).
+ *
+ * Required env vars:
+ *   STREAMVAULT_PROD_URL    — origin, defaults to https://streamvault.srinivaskotha.uk
+ *   STREAMVAULT_E2E_USER    — test username (e.g. sv_e2e_test)
+ *   STREAMVAULT_E2E_PASS    — test password
+ *
+ * Run locally: `npm run test:e2e:prod`
+ * Update snapshots: `npm run test:e2e:prod -- --update-snapshots`
+ */
+export default defineConfig({
+  testDir: "./tests/prod",
+  fullyParallel: false,
+  forbidOnly: !!process.env["CI"],
+  retries: process.env["CI"] ? 2 : 1,
+  workers: 1,
+  reporter: [["html", { outputFolder: "playwright-report-prod" }], ["list"]],
+  use: {
+    baseURL:
+      process.env["STREAMVAULT_PROD_URL"] ??
+      "https://streamvault.srinivaskotha.uk",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    ignoreHTTPSErrors: false,
+  },
+  projects: [
+    {
+      name: "fire-tv-1080p",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1920, height: 1080 },
+        deviceScaleFactor: 1,
+      },
+    },
+    {
+      name: "desktop-chrome",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "webkit-ipad",
+      use: { ...devices["iPad Pro 11"] },
+    },
+  ],
+  expect: {
+    // Tolerance for visual diffs — CDN re-compression + font hinting differ.
+    toHaveScreenshot: { maxDiffPixelRatio: 0.02, threshold: 0.2 },
+  },
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@
  * Preserved dev-time routes: /test-primitives and /silk-probe (permanent
  * Playwright probe targets — Task 1.7 + Task 2.1).
  */
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   BrowserRouter,
   Routes,
@@ -17,6 +17,7 @@ import {
   useNavigate,
   useLocation,
 } from "react-router-dom";
+import { setFocus } from "@noriginmedia/norigin-spatial-navigation";
 import { BottomDock, type DockItem } from "./nav/BottomDock";
 import { LiveRoute } from "./routes/LiveRoute";
 import { MoviesRoute } from "./routes/MoviesRoute";
@@ -50,6 +51,18 @@ function AppShell() {
   const hideDock =
     pathname.startsWith("/test-primitives") ||
     pathname.startsWith("/silk-probe");
+
+  // Prime norigin's focus tree on first render after auth. Without this,
+  // norigin's lastFocused pointer is null (or still holds the unmounted
+  // LOGIN_USERNAME), so the user's first ArrowLeft/Right press on the dock
+  // is a no-op — the bug reported on the live site. Fires once per AppShell
+  // mount; landing on the active dock tab lets the user immediately walk
+  // across the dock or press Up to enter the content area.
+  useEffect(() => {
+    if (hideDock) return;
+    setFocus(`DOCK_${activeTab.toUpperCase()}`);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div style={{ background: "var(--bg-base)", minHeight: "100vh" }}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,14 @@ const DOCK_IDS: readonly DockItem[] = [
   "settings",
 ] as const;
 
+const DOCK_LABELS: Record<DockItem, string> = {
+  live: "Live",
+  movies: "Movies",
+  series: "Series",
+  search: "Search",
+  settings: "Settings",
+};
+
 function isDockItem(value: string | undefined): value is DockItem {
   return value !== undefined && (DOCK_IDS as readonly string[]).includes(value);
 }
@@ -55,12 +63,33 @@ function AppShell() {
   // Prime norigin's focus tree on first render after auth. Without this,
   // norigin's lastFocused pointer is null (or still holds the unmounted
   // LOGIN_USERNAME), so the user's first ArrowLeft/Right press on the dock
-  // is a no-op — the bug reported on the live site. Fires once per AppShell
-  // mount; landing on the active dock tab lets the user immediately walk
-  // across the dock or press Up to enter the content area.
+  // is a no-op — the bug reported on the live site.
+  //
+  // The 100ms defer + short retry loop is load-bearing: DockTab children
+  // register via `useFocusable` inside their own useEffect. React 19 +
+  // StrictMode double-invoke + BrowserRouter mount order can race, so the
+  // first setFocus can fire before the DOCK_* keys are registered. We
+  // retry up to 10× every 50ms (max ~600ms) until the DOM activeElement
+  // matches the expected dock tab label.
   useEffect(() => {
     if (hideDock) return;
-    setFocus(`DOCK_${activeTab.toUpperCase()}`);
+    const target = `DOCK_${activeTab.toUpperCase()}`;
+    const expectedLabel = DOCK_LABELS[activeTab];
+    let attempts = 0;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const tryPrime = () => {
+      setFocus(target);
+      const landed =
+        document.activeElement?.getAttribute("aria-label") === expectedLabel;
+      if (!landed && attempts < 10) {
+        attempts += 1;
+        timer = setTimeout(tryPrime, 50);
+      }
+    };
+    timer = setTimeout(tryPrime, 100);
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/index.css
+++ b/src/index.css
@@ -57,114 +57,24 @@
   --duration-dock: var(--motion-dock);
 }
 
-:root {
-  --text: #6b6375;
-  --text-h: #08060d;
-  --bg: #fff;
-  --border: #e5e4e7;
-  --code-bg: #f4f3ec;
-  --accent: #aa3bff;
-  --accent-bg: rgba(170, 59, 255, 0.1);
-  --accent-border: rgba(170, 59, 255, 0.5);
-  --social-bg: rgba(244, 243, 236, 0.5);
-  --shadow:
-    rgba(0, 0, 0, 0.1) 0 10px 15px -3px, rgba(0, 0, 0, 0.05) 0 4px 6px -2px;
-
-  --sans: system-ui, "Segoe UI", Roboto, sans-serif;
-  --heading: system-ui, "Segoe UI", Roboto, sans-serif;
-  --mono: ui-monospace, Consolas, monospace;
-
-  font: 18px/145% var(--sans);
-  letter-spacing: 0.18px;
-  color-scheme: light dark;
-  color: var(--text);
-  background: var(--bg);
+/* Base reset: full-bleed app shell. #root was previously 1126px-capped from
+   the Vite template, which left black bars on wide TV viewports. */
+html,
+body {
+  margin: 0;
+  background: var(--bg-base);
+  color: var(--text-primary);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-
-  @media (max-width: 1024px) {
-    font-size: 16px;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --text: #9ca3af;
-    --text-h: #f3f4f6;
-    --bg: #16171d;
-    --border: #2e303a;
-    --code-bg: #1f2028;
-    --accent: #c084fc;
-    --accent-bg: rgba(192, 132, 252, 0.15);
-    --accent-border: rgba(192, 132, 252, 0.5);
-    --social-bg: rgba(47, 48, 58, 0.5);
-    --shadow:
-      rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
-  }
-
-  #social .button-icon {
-    filter: invert(1) brightness(2);
-  }
 }
 
 #root {
-  width: 1126px;
-  max-width: 100%;
-  margin: 0 auto;
-  text-align: center;
-  border-inline: 1px solid var(--border);
   min-height: 100svh;
-  display: flex;
-  flex-direction: column;
-  box-sizing: border-box;
+  width: 100%;
 }
 
-body {
-  margin: 0;
-}
-
-h1,
-h2 {
-  font-family: var(--heading);
-  font-weight: 500;
-  color: var(--text-h);
-}
-
-h1 {
-  font-size: 56px;
-  letter-spacing: -1.68px;
-  margin: 32px 0;
-  @media (max-width: 1024px) {
-    font-size: 36px;
-    margin: 20px 0;
-  }
-}
-h2 {
-  font-size: 24px;
-  line-height: 118%;
-  letter-spacing: -0.24px;
-  margin: 0 0 8px;
-  @media (max-width: 1024px) {
-    font-size: 20px;
-  }
-}
 p {
   margin: 0;
-}
-
-code,
-.counter {
-  font-family: var(--mono);
-  display: inline-flex;
-  border-radius: 4px;
-  color: var(--text-h);
-}
-
-code {
-  font-size: 15px;
-  line-height: 135%;
-  padding: 4px 8px;
-  background: var(--code-bg);
 }

--- a/tests/e2e/dock-nav-auto-prime.spec.ts
+++ b/tests/e2e/dock-nav-auto-prime.spec.ts
@@ -19,7 +19,9 @@ test.describe("BottomDock auto-prime (AppShell useEffect)", () => {
     await seedFakeAuth(page);
     await page.goto("/live");
     // Let norigin init + useFocusable registrations + AppShell useEffect run.
-    await page.waitForTimeout(500);
+    // The prime has a 100ms defer + up to 10 retries at 50ms = ~600ms worst
+    // case; 1500ms gives plenty of head room.
+    await page.waitForTimeout(1500);
   });
 
   test("focus lands on DOCK_LIVE on first paint without manual priming", async ({
@@ -68,7 +70,7 @@ test.describe("BottomDock auto-prime (AppShell useEffect)", () => {
     page,
   }) => {
     await page.goto("/movies");
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(1500);
     const label = await page.evaluate(() =>
       document.activeElement?.getAttribute("aria-label"),
     );

--- a/tests/e2e/dock-nav-auto-prime.spec.ts
+++ b/tests/e2e/dock-nav-auto-prime.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "@playwright/test";
+import { seedFakeAuth } from "./helpers";
+
+/**
+ * BottomDock auto-prime E2E.
+ *
+ * Proves the AppShell mount-effect primes norigin's focus tree onto the
+ * active dock tab. WITHOUT this fix, a real user landing on the live URL
+ * after login sees the dock but arrow keys do nothing — norigin has no
+ * `lastFocused` anchor. Existing `dock-nav.spec.ts` side-steps the bug by
+ * calling `__svSetFocus("DOCK_LIVE")` itself; this spec explicitly does NOT.
+ *
+ * The difference versus `dock-nav.spec.ts`: no `__svSetFocus()` call before
+ * pressing arrows. If AppShell's useEffect is removed, ArrowRight becomes a
+ * no-op and this test fails.
+ */
+test.describe("BottomDock auto-prime (AppShell useEffect)", () => {
+  test.beforeEach(async ({ page }) => {
+    await seedFakeAuth(page);
+    await page.goto("/live");
+    // Let norigin init + useFocusable registrations + AppShell useEffect run.
+    await page.waitForTimeout(500);
+  });
+
+  test("focus lands on DOCK_LIVE on first paint without manual priming", async ({
+    page,
+  }) => {
+    const label = await page.evaluate(() =>
+      document.activeElement?.getAttribute("aria-label"),
+    );
+    expect(label).toBe("Live");
+  });
+
+  test("ArrowRight moves from Live to Movies without __svSetFocus priming", async ({
+    page,
+  }) => {
+    await page.keyboard.press("ArrowRight");
+    await page.waitForFunction(
+      () => document.activeElement?.getAttribute("aria-label") === "Movies",
+      { timeout: 2000 },
+    );
+    expect(
+      await page.evaluate(() =>
+        document.activeElement?.getAttribute("aria-label"),
+      ),
+    ).toBe("Movies");
+  });
+
+  test("ArrowRight walks the whole dock: Live -> Movies -> Series -> Search -> Settings", async ({
+    page,
+  }) => {
+    const expected = ["Live", "Movies", "Series", "Search", "Settings"];
+    for (let i = 0; i < expected.length; i += 1) {
+      const want = expected[i];
+      await page.waitForFunction(
+        (label) =>
+          document.activeElement?.getAttribute("aria-label") === label,
+        want,
+        { timeout: 2000 },
+      );
+      if (i < expected.length - 1) {
+        await page.keyboard.press("ArrowRight");
+      }
+    }
+  });
+
+  test("deep-linking to /movies primes focus on DOCK_MOVIES", async ({
+    page,
+  }) => {
+    await page.goto("/movies");
+    await page.waitForTimeout(500);
+    const label = await page.evaluate(() =>
+      document.activeElement?.getAttribute("aria-label"),
+    );
+    expect(label).toBe("Movies");
+  });
+});

--- a/tests/prod/helpers.ts
+++ b/tests/prod/helpers.ts
@@ -1,0 +1,43 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Log in through the real login form on the production site.
+ *
+ * We deliberately avoid sessionStorage / cookie injection tricks here — the
+ * whole point of the prod suite is to exercise the *actual* login flow that
+ * a user (or a Fire TV) goes through, including httpOnly cookie set-up,
+ * CSRF handshake, and the post-auth focus handoff into AppShell.
+ */
+export async function loginViaUI(page: Page): Promise<void> {
+  const username = process.env["STREAMVAULT_E2E_USER"];
+  const password = process.env["STREAMVAULT_E2E_PASS"];
+  if (!username || !password) {
+    throw new Error(
+      "Missing STREAMVAULT_E2E_USER / STREAMVAULT_E2E_PASS env vars. " +
+        "Set them before running the prod Playwright suite.",
+    );
+  }
+
+  await page.goto("/");
+  // Wait for norigin to prime LOGIN_USERNAME focus.
+  await page.waitForSelector("input#username", { timeout: 10_000 });
+  await page.fill("input#username", username);
+  await page.fill("input#password", password);
+  await page.click('button[type="submit"]');
+
+  // Post-login: dock should appear within 5s. If this times out, login
+  // failed silently — check credentials or the /api/auth/login response.
+  await page.waitForSelector('nav[aria-label="Main navigation"]', {
+    timeout: 10_000,
+  });
+}
+
+/**
+ * Read the currently-focused element's aria-label (what norigin's focus
+ * tree landed on, since we set shouldFocusDOMNode:true during init).
+ */
+export async function activeLabel(page: Page): Promise<string | null> {
+  return page.evaluate(
+    () => document.activeElement?.getAttribute("aria-label") ?? null,
+  );
+}

--- a/tests/prod/login-and-dock.spec.ts
+++ b/tests/prod/login-and-dock.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "@playwright/test";
+import { loginViaUI, activeLabel } from "./helpers";
+
+/**
+ * End-to-end smoke on the live site: login → dock auto-primes → D-pad walks
+ * the whole dock → Enter navigates routes.
+ *
+ * Also takes a visual-regression screenshot per project so a regression on
+ * layout (e.g. reintroducing the 1126px #root cap that produced black left/
+ * right bars) fails the check.
+ */
+test.describe("prod: login + dock D-pad", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginViaUI(page);
+  });
+
+  test("dock auto-primes focus on Live after login (no manual focus call)", async ({
+    page,
+  }) => {
+    // Give AppShell's mount useEffect + norigin registrations a beat.
+    await page.waitForTimeout(750);
+    expect(await activeLabel(page)).toBe("Live");
+  });
+
+  test("ArrowRight walks the entire dock: Live -> Movies -> Series -> Search -> Settings", async ({
+    page,
+  }) => {
+    await page.waitForTimeout(750);
+    const items = ["Live", "Movies", "Series", "Search", "Settings"];
+    for (let i = 0; i < items.length; i += 1) {
+      await page.waitForFunction(
+        (want) =>
+          document.activeElement?.getAttribute("aria-label") === want,
+        items[i],
+        { timeout: 3000 },
+      );
+      if (i < items.length - 1) await page.keyboard.press("ArrowRight");
+    }
+  });
+
+  test("Enter on Movies tab navigates to /movies", async ({ page }) => {
+    await page.waitForTimeout(750);
+    await page.keyboard.press("ArrowRight"); // Live → Movies
+    await page.keyboard.press("Enter");
+    await expect(page).toHaveURL(/\/movies/);
+    await expect(page.locator('[data-page="movies"]')).toBeVisible();
+  });
+
+  test("visual: dashboard renders full-bleed (no black side bars)", async ({
+    page,
+  }) => {
+    await page.waitForTimeout(1000);
+    // Sanity: #root width must equal the viewport width — catches the
+    // regression where the Vite-template CSS capped #root at 1126px.
+    const { rootWidth, viewportWidth } = await page.evaluate(() => ({
+      rootWidth: document.getElementById("root")?.clientWidth ?? 0,
+      viewportWidth: window.innerWidth,
+    }));
+    expect(rootWidth).toBe(viewportWidth);
+
+    await expect(page).toHaveScreenshot("dashboard-live.png", {
+      fullPage: false,
+      mask: [
+        // Mask dynamic content so the baseline is stable: channel rows,
+        // EPG now-line, timestamps, channel numbers.
+        page.locator('[data-epg-now="true"]'),
+        page.locator("[data-channel-row]"),
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

PR 1 of the autonomous 2026-04-22 session. Fixes two P0 TV bugs surfaced on the live URL + lays down prod E2E infrastructure for every subsequent phase.

### Bugs fixed

1. **D-pad dock was dead after login.** BottomDock wiring was correct, but norigin's \`lastFocused\` pointer was null, so arrow keys had nothing to navigate FROM. Fix: \`AppShell\` calls \`setFocus(\`DOCK_\${activeTab.toUpperCase()}\`)\` once on mount. Works for login-flow mount AND deep-linking.
2. **Black left/right bars on TV / wide desktop.** \`src/index.css\` carried Vite template leftovers (\`#root { width: 1126px }\` + conflicting \`:root\` color/font vars). Stripped to the @theme block + a minimal body reset. Full-bleed now.

### Prod E2E infra (so every phase ships with a live-URL smoke)

- \`playwright.prod.config.ts\` — Fire-TV 1080p, desktop-chrome, webkit-ipad; retain-on-failure traces + videos.
- \`tests/prod/login-and-dock.spec.ts\` — real login + dock auto-prime + ArrowRight across all 5 tabs + Enter navigates + visual screenshot asserting \`#root.clientWidth === innerWidth\`.
- \`tests/prod/helpers.ts\` — \`loginViaUI()\` hitting the real form.
- \`npm run test:e2e:prod\` script.
- Gated on \`STREAMVAULT_E2E_USER\` / \`STREAMVAULT_E2E_PASS\` env vars (surfaces a clear error if unset).

Also adds \`tests/e2e/dock-nav-auto-prime.spec.ts\` which explicitly does NOT call \`__svSetFocus()\`, so deleting the AppShell useEffect breaks it — unlike the existing \`dock-nav.spec.ts\` which primes manually.

### Verification

- \`tsc --noEmit\` clean
- \`eslint\` clean
- \`vitest\`: 100/100 pass
- Live-URL verification pending deploy of this PR.

## Test plan
- [ ] CI green (lint + unit + dev E2E).
- [ ] After merge + deploy: hit https://streamvault.srinivaskotha.uk on a wide viewport — no black side bars; arrow keys move across the dock without touching the keyboard \`Tab\`.
- [ ] \`npm run test:e2e:prod\` passes (credentials required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)