### PR TITLE
hotfix(schemas): Movies empty on live — accept provider rating as string|number|null

### DIFF
--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -1,5 +1,22 @@
 import { z } from "zod";
 
+/**
+ * RatingSchema — the Xtream provider returns `rating` as any of:
+ *   - a string ("3.8", "0")
+ *   - a number (3.8, 0)
+ *   - an integer (0)
+ *   - null / missing
+ * Empirical distribution from /api/vod/streams/240 (156 items):
+ *   6 None, 5 float, 2 int, 143 str. If we declare `rating: z.string()`
+ *   Zod rejects the whole array on the first number and the list silently
+ *   renders as empty — the bug the user reported 2026-04-22 for Movies.
+ * We normalise to `string | undefined` so UI code can display or skip uniformly.
+ */
+const RatingSchema = z
+  .union([z.string(), z.number(), z.null()])
+  .optional()
+  .transform((v) => (v === null || v === undefined ? undefined : String(v)));
+
 // Backend auth is cookie-based (httpOnly access_token / refresh_token cookies).
 // /api/auth/login returns only a confirmation body; the session itself lives in
 // cookies set by the Set-Cookie header. The frontend must NOT expect JWT strings
@@ -87,7 +104,7 @@ export const SeriesItemSchema = z.object({
   icon: z.string().nullable().optional(),
   added: z.string().nullable().optional(),
   isAdult: z.boolean().optional(),
-  rating: z.string().optional(),
+  rating: RatingSchema,
   genre: z.string().optional(),
   year: z.string().optional(),
 });
@@ -112,7 +129,7 @@ export const CatalogItemSchema = z.object({
   icon: z.string().nullable().optional(),
   added: z.string().nullable().optional(),
   isAdult: z.boolean().optional(),
-  rating: z.string().optional(),
+  rating: RatingSchema,
   genre: z.string().optional(),
   year: z.string().optional(),
 });
@@ -144,10 +161,10 @@ export const VodStreamSchema = z.object({
   name: z.string(),
   type: z.literal("vod"),
   categoryId: z.string(),
-  icon: z.string().nullable(),
+  icon: z.string().nullable().optional(),
   added: z.string().nullable().optional(),
-  isAdult: z.boolean(),
-  rating: z.string().optional(),
+  isAdult: z.boolean().optional(),
+  rating: RatingSchema,
   genre: z.string().optional(),
   year: z.string().optional(),
 });


### PR DESCRIPTION
## Summary

User reported Movies screen renders empty on live URL after the Phase 5b merge. Root cause is a Zod schema mismatch:

\`VodStreamSchema.rating: z.string().optional()\` rejects numbers, but the Xtream provider returns \`rating\` as mixed types. Distribution on \`/api/vod/streams/240\` (156 items):

- 6 \`null\`
- 5 \`float\` (e.g. \`3.8\`)
- 2 \`int\` (e.g. \`0\`)
- 143 \`string\`

A single \`rating: 3.8\` in the response causes \`z.array(VodStreamSchema).parse()\` to reject the entire array → \`fetchVodStreams\` throws → the route silently falls back to empty state. Identical pattern was latent in \`SeriesItemSchema\` and \`CatalogItemSchema\`.

## Fix

- Introduce a shared \`RatingSchema\` that accepts \`string | number | null\` and normalises to \`string | undefined\`.
- Apply to \`VodStream\`, \`SeriesItem\`, \`CatalogItem\`.
- Loosen \`VodStream.icon\` + \`isAdult\` to \`.optional()\` (defensive — wouldn't have blocked Movies today, but identical failure mode for tomorrow).

No backend change.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` 204/204 green
- [ ] Deploy → load \`/movies\` on live URL → 156 posters visible for the first category
- [ ] \`/series\` → cards still render (regression guard)
- [ ] \`/search\` → query returns results (regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)