### PR TITLE
hotfix(channels): ChannelSchema matches backend CatalogItem shape

### DIFF
--- a/src/api/schemas.test.ts
+++ b/src/api/schemas.test.ts
@@ -30,9 +30,27 @@ describe("API Zod schemas", () => {
     };
     expect(() => ChannelSchema.parse(raw)).not.toThrow();
   });
-  it("rejects channel without streamUrl", () => {
-    expect(() =>
-      ChannelSchema.parse({ id: "1", name: "BBC", categoryId: "5", num: 1 }),
-    ).toThrow();
+  it("parses a backend CatalogItem-shaped channel (no num / no streamUrl)", () => {
+    // Backend /api/live/channels returns CatalogItem shape — legacy fields
+    // (num / streamUrl / logo / epgChannelId) are optional in the v3 schema.
+    const raw = {
+      id: "705131",
+      name: "IPL Hindi Match 1",
+      type: "live",
+      categoryId: "807",
+      icon: null,
+      added: "1775054300",
+      isAdult: false,
+    };
+    expect(() => ChannelSchema.parse(raw)).not.toThrow();
+  });
+  it("parses channel with rating as number (provider returns mixed types)", () => {
+    const raw = {
+      id: "1",
+      name: "ESPN",
+      categoryId: "5",
+      rating: 3.8,
+    };
+    expect(() => ChannelSchema.parse(raw)).not.toThrow();
   });
 });

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -40,12 +40,25 @@ export const RefreshResponseSchema = z.object({
   message: z.string(),
 });
 
+// Mirrors the backend CatalogItem shape returned by GET /api/live/channels
+// (added 2026-04-22 — was missing until the post-merge smoke caught a 501).
+// Fields that the v3 frontend tests originally expected (num/streamUrl/logo/
+// epgChannelId) are kept optional so existing LiveRoute code compiles; num
+// especially is derived client-side from array index when absent.
 export const ChannelSchema = z.object({
   id: z.string(),
-  num: z.number(),
   name: z.string(),
+  type: z.string().optional(),
   categoryId: z.string(),
-  streamUrl: z.string().url(),
+  icon: z.string().nullable().optional(),
+  added: z.string().nullable().optional(),
+  isAdult: z.boolean().optional(),
+  rating: RatingSchema,
+  genre: z.string().optional(),
+  year: z.string().optional(),
+  // Legacy fields — optional; fallback is handled at render time (num ?? index+1).
+  num: z.number().optional(),
+  streamUrl: z.string().url().optional(),
   logo: z.string().optional(),
   epgChannelId: z.string().optional(),
 });

--- a/src/features/live/SplitGuide.tsx
+++ b/src/features/live/SplitGuide.tsx
@@ -125,10 +125,11 @@ export function SplitGuide({
 
       {/* ── Right pane: channel list ── */}
       <ul aria-label="Channel list" style={listPaneStyle}>
-        {channels.map((channel) => (
+        {channels.map((channel, index) => (
           <ChannelRow
             key={channel.id}
             channel={channel}
+            index={index}
             isSelected={channel.id === selectedChannelId}
             onSelect={onSelectChannel}
           />
@@ -145,10 +146,12 @@ export function SplitGuide({
 
 function ChannelRow({
   channel,
+  index,
   isSelected,
   onSelect,
 }: {
   channel: Channel;
+  index: number;
   isSelected: boolean;
   onSelect: (id: string) => void;
 }) {
@@ -157,6 +160,9 @@ function ChannelRow({
     onEnterPress: () => onSelect(channel.id),
   });
   const active = isSelected || focused;
+  // Backend catalog items don't carry a channel number; fall back to 1-based
+  // array index so the left-gutter digit + aria-label stay human-readable.
+  const displayNum = channel.num ?? index + 1;
 
   return (
     <li style={{ listStyle: "none" }}>
@@ -165,7 +171,7 @@ function ChannelRow({
         type="button"
         className="focus-ring"
         onClick={() => onSelect(channel.id)}
-        aria-label={`Channel ${channel.num}: ${channel.name}`}
+        aria-label={`Channel ${displayNum}: ${channel.name}`}
         aria-current={isSelected ? "true" : undefined}
         style={{
           display: "flex",
@@ -193,7 +199,7 @@ function ChannelRow({
             opacity: 0.8,
           }}
         >
-          {channel.num}
+          {displayNum}
         </span>
         <span style={{ flex: 1 }}>{channel.name}</span>
         {isSelected && (

--- a/src/features/live/useSortedChannels.ts
+++ b/src/features/live/useSortedChannels.ts
@@ -45,7 +45,7 @@ export function useSortedChannels(
 
     switch (sortBy) {
       case "number":
-        out.sort((a, b) => a.num - b.num);
+        out.sort((a, b) => (a.num ?? 0) - (b.num ?? 0));
         break;
       case "name":
         out.sort((a, b) => a.name.localeCompare(b.name));
@@ -58,7 +58,7 @@ export function useSortedChannels(
           const diff = resolveCategoryName(a).localeCompare(
             resolveCategoryName(b),
           );
-          return diff !== 0 ? diff : a.num - b.num;
+          return diff !== 0 ? diff : (a.num ?? 0) - (b.num ?? 0);
         });
         break;
     }


### PR DESCRIPTION
Follow-up to backend hotfix. Live page now expects id/name/type/categoryId/icon/added/isAdult/rating — num and streamUrl are optional. SplitGuide falls back to array index for the gutter digit.