### PR TITLE
fix(dpad): ArrowUp from dock enters content area across all routes

### DIFF
--- a/src/nav/BottomDock.tsx
+++ b/src/nav/BottomDock.tsx
@@ -2,6 +2,7 @@
 import {
   useFocusable,
   FocusContext,
+  setFocus,
 } from "@noriginmedia/norigin-spatial-navigation";
 
 export type DockItem = "live" | "movies" | "series" | "search" | "settings";
@@ -92,9 +93,24 @@ function DockTab({
   // Task 2.4: explicit focusKey per tab. Without this, norigin can't uniquely
   // identify siblings under DOCK, so ArrowRight can't route spatial focus —
   // verified via E2E debug (pre-fix, ArrowRight stayed on the initial tab).
+  //
+  // 2026-04-22 followup: norigin's geometric ArrowUp from the dock only finds
+  // a candidate above when content-area focusables are already registered.
+  // Race window: initial paint + data fetch + useEffect registration can take
+  // a second or two, and during that window ArrowUp is a no-op — the user
+  // feels stuck. Handle ArrowUp explicitly: setFocus to the active route's
+  // CONTENT_AREA_* container, which has trackChildren:true so norigin forwards
+  // focus into the grid/list instead of staying pinned on the dock.
   const { ref, focused } = useFocusable({
     focusKey: `DOCK_${item.id.toUpperCase()}`,
     onEnterPress: onSelect,
+    onArrowPress: (direction) => {
+      if (direction === "up") {
+        setFocus(`CONTENT_AREA_${item.id.toUpperCase()}`);
+        return false; // consume the event — we've handled it
+      }
+      return true; // let norigin handle left/right/down
+    },
   });
   const active = isActive || focused;
 

--- a/src/routes/FavoritesRoute.tsx
+++ b/src/routes/FavoritesRoute.tsx
@@ -191,6 +191,8 @@ function FavoriteSection({
 export function FavoritesRoute() {
   const { ref, focusKey } = useFocusable({
     focusKey: "CONTENT_AREA_FAVORITES",
+    focusable: false,
+    trackChildren: true,
   });
   const navigate = useNavigate();
   const { favorites, loading, error, toggle, reload } = useFavorites();

--- a/src/routes/HistoryRoute.tsx
+++ b/src/routes/HistoryRoute.tsx
@@ -210,6 +210,8 @@ function RemoveButton({
 export function HistoryRoute() {
   const { ref, focusKey } = useFocusable({
     focusKey: "CONTENT_AREA_HISTORY",
+    focusable: false,
+    trackChildren: true,
   });
   const navigate = useNavigate();
   const { history, loading, error, remove, reload } = useWatchHistory();

--- a/src/routes/LiveRoute.tsx
+++ b/src/routes/LiveRoute.tsx
@@ -93,7 +93,15 @@ export function LiveRoute() {
   // MUST PRESERVE: norigin root registration for the content area.
   // Dropping this breaks BottomDock's setFocus("CONTENT_AREA_LIVE") Esc flow
   // wired in Task 2.4.
-  const { ref, focusKey } = useFocusable({ focusKey: "CONTENT_AREA_LIVE" });
+  // trackChildren + non-focusable container: when BottomDock fires
+  // setFocus("CONTENT_AREA_LIVE") on ArrowUp, norigin forwards focus to the
+  // first registered child (toolbar sort button or a channel row) instead of
+  // staying pinned on the container itself.
+  const { ref, focusKey } = useFocusable({
+    focusKey: "CONTENT_AREA_LIVE",
+    focusable: false,
+    trackChildren: true,
+  });
   const { openPlayer } = usePlayerOpener();
 
   const [channels, setChannels] = useState<Channel[]>([]);

--- a/src/routes/MoviesRoute.tsx
+++ b/src/routes/MoviesRoute.tsx
@@ -38,7 +38,14 @@ import type { VodCategory, VodStream } from "../api/schemas";
 
 export function MoviesRoute() {
   // MUST PRESERVE: norigin root registration for the content area.
-  const { ref, focusKey } = useFocusable({ focusKey: "CONTENT_AREA_MOVIES" });
+  // trackChildren + non-focusable container: when BottomDock fires
+  // setFocus("CONTENT_AREA_MOVIES") on ArrowUp, norigin forwards focus to the
+  // first child (category chip or poster) rather than staying on the shell.
+  const { ref, focusKey } = useFocusable({
+    focusKey: "CONTENT_AREA_MOVIES",
+    focusable: false,
+    trackChildren: true,
+  });
 
   const [categories, setCategories] = useState<VodCategory[]>([]);
   const [streams, setStreams] = useState<VodStream[]>([]);

--- a/src/routes/SearchRoute.tsx
+++ b/src/routes/SearchRoute.tsx
@@ -114,7 +114,11 @@ function useSearchQuery(debouncedQuery: string) {
 export function SearchRoute() {
   // MUST PRESERVE: norigin root registration for the content area.
   // Dropping this breaks BottomDock's setFocus("CONTENT_AREA_SEARCH") Esc flow.
-  const { ref, focusKey } = useFocusable({ focusKey: "CONTENT_AREA_SEARCH" });
+  const { ref, focusKey } = useFocusable({
+    focusKey: "CONTENT_AREA_SEARCH",
+    focusable: false,
+    trackChildren: true,
+  });
 
   const [query, setQuery] = useState("");
   const debouncedQuery = useDebounce(query, 300);

--- a/src/routes/SeriesRoute.tsx
+++ b/src/routes/SeriesRoute.tsx
@@ -31,7 +31,11 @@ import type { SeriesCategory, SeriesItem } from "../api/schemas";
 export function SeriesRoute() {
   // MUST PRESERVE: norigin root registration for the content area.
   // Dropping this breaks BottomDock's setFocus("CONTENT_AREA_SERIES") Esc flow.
-  const { ref, focusKey } = useFocusable({ focusKey: "CONTENT_AREA_SERIES" });
+  const { ref, focusKey } = useFocusable({
+    focusKey: "CONTENT_AREA_SERIES",
+    focusable: false,
+    trackChildren: true,
+  });
   const navigate = useNavigate();
 
   const [categories, setCategories] = useState<SeriesCategory[]>([]);

--- a/src/routes/SettingsRoute.tsx
+++ b/src/routes/SettingsRoute.tsx
@@ -241,6 +241,8 @@ function DangerSection() {
 export function SettingsRoute() {
   const { ref, focusKey } = useFocusable({
     focusKey: "CONTENT_AREA_SETTINGS",
+    focusable: false,
+    trackChildren: true,
   });
 
   // onLoggedOut is a no-op here — the redirect in AccountSection handles navigation.


### PR DESCRIPTION
**Bug:** On the live site, dock left/right works but ArrowUp stays on the tab — movies/series grids and channel list are unreachable without a mouse.

**Fix:**
1. `DockTab` `onArrowPress('up')` → `setFocus('CONTENT_AREA_<active>')`.
2. All route `CONTENT_AREA_*` `useFocusable` registrations become `{ focusable: false, trackChildren: true }` containers so norigin forwards focus to a child.

205/205 unit tests green, typecheck + lint clean.