### PR TITLE
fix(routes): click movie/series/search → open player (skip blank detail route)

### DIFF
--- a/src/features/movies/MovieGrid.tsx
+++ b/src/features/movies/MovieGrid.tsx
@@ -3,8 +3,8 @@
  * 6 columns at 1920px, fewer on narrow screens (CSS grid auto-fill).
  * Renders MovieCard per stream, plus an empty state when the list is empty.
  */
-import { useNavigate } from "react-router-dom";
 import { MovieCard } from "./MovieCard";
+import { usePlayerOpener } from "../../player";
 import type { VodStream } from "../../api/schemas";
 
 interface MovieGridProps {
@@ -12,7 +12,11 @@ interface MovieGridProps {
 }
 
 export function MovieGrid({ streams }: MovieGridProps) {
-  const navigate = useNavigate();
+  // Enter on a poster opens the player overlay directly. The detail page
+  // (/movies/:id) was never implemented — navigating there produced a blank
+  // screen for the user. Opening the player matches the LiveRoute pattern
+  // and is the minimum viable path to "press play and it plays".
+  const { openPlayer } = usePlayerOpener();
 
   if (streams.length === 0) {
     return (
@@ -60,7 +64,9 @@ export function MovieGrid({ streams }: MovieGridProps) {
         <MovieCard
           key={stream.id}
           stream={stream}
-          onSelect={(id) => navigate(`/movies/${id}`)}
+          onSelect={(id) =>
+            void openPlayer({ kind: "vod", id, title: stream.name })
+          }
         />
       ))}
     </div>

--- a/src/features/search/SearchResultsSection.tsx
+++ b/src/features/search/SearchResultsSection.tsx
@@ -9,14 +9,15 @@
  */
 import type { RefObject } from "react";
 import { useFocusable } from "@noriginmedia/norigin-spatial-navigation";
-import { useNavigate } from "react-router-dom";
+import { usePlayerOpener } from "../../player";
 import type { CatalogItem } from "../../api/schemas";
+import type { PlayerKind } from "../../player/PlayerProvider";
 
-// Route map: vod → /movies/:id (backend type "vod" = movies section)
-const ROUTE_MAP: Record<string, string> = {
-  live: "/live",
-  vod: "/movies",
-  series: "/series",
+// Map backend content type → player kind. "vod" is the VOD movies shelf.
+const KIND_MAP: Record<string, PlayerKind> = {
+  live: "live",
+  vod: "vod",
+  series: "series-episode",
 };
 
 interface SearchCardProps {
@@ -24,24 +25,27 @@ interface SearchCardProps {
 }
 
 function SearchCard({ item }: SearchCardProps) {
-  const navigate = useNavigate();
+  const { openPlayer } = usePlayerOpener();
   const focusKey = `SEARCH_RESULT_${item.type.toUpperCase()}_${item.id}`;
 
-  const goToDetail = () => {
-    const base = ROUTE_MAP[item.type] ?? "/search";
-    navigate(`${base}/${item.id}`);
+  // Enter on a search result opens the player overlay directly — there is
+  // no detail page yet and the previous behaviour (navigate to a non-
+  // existent route) produced a blank screen.
+  const playItem = () => {
+    const kind = KIND_MAP[item.type] ?? "vod";
+    void openPlayer({ kind, id: item.id, title: item.name });
   };
 
   const { ref, focused } = useFocusable<HTMLButtonElement>({
     focusKey,
-    onEnterPress: goToDetail,
+    onEnterPress: playItem,
   });
 
   return (
     <button
       ref={ref as RefObject<HTMLButtonElement>}
       type="button"
-      onClick={goToDetail}
+      onClick={playItem}
       aria-label={item.name}
       style={{
         flex: "0 0 auto",

--- a/src/routes/MoviesRoute.test.tsx
+++ b/src/routes/MoviesRoute.test.tsx
@@ -48,6 +48,11 @@ vi.mock("../api/vod", () => ({
   fetchVodStreams: fetchVodStreamsMock,
 }));
 
+const openPlayerMock = vi.hoisted(() => vi.fn());
+vi.mock("../player", () => ({
+  usePlayerOpener: () => ({ openPlayer: openPlayerMock }),
+}));
+
 import { MoviesRoute } from "./MoviesRoute";
 
 // ─── Fixtures ───────────────────────────────────────────────────────────────
@@ -170,15 +175,20 @@ describe("MoviesRoute", () => {
     });
   });
 
-  it("clicking a movie card calls navigate('/movies/:id')", async () => {
+  it("clicking a movie card opens the player with the vod kind + item title", async () => {
     fetchVodCategoriesMock.mockResolvedValue(mockCategories);
     fetchVodStreamsMock.mockResolvedValue(mockStreams);
+    openPlayerMock.mockClear();
 
     render(<MoviesRoute />);
     const card = await screen.findByRole("button", { name: /die hard/i });
     await userEvent.click(card);
 
-    expect(mockNavigate).toHaveBeenCalledWith("/movies/v1");
+    expect(openPlayerMock).toHaveBeenCalledWith({
+      kind: "vod",
+      id: "v1",
+      title: "Die Hard",
+    });
   });
 
   it("registers CONTENT_AREA_MOVIES focus key", async () => {

--- a/src/routes/SearchRoute.test.tsx
+++ b/src/routes/SearchRoute.test.tsx
@@ -57,6 +57,12 @@ vi.mock("react-router-dom", () => ({
   useNavigate: () => navigateMock,
 }));
 
+// Player opener used by SearchResultsSection for Enter-to-play.
+const openPlayerMock = vi.hoisted(() => vi.fn());
+vi.mock("../player", () => ({
+  usePlayerOpener: () => ({ openPlayer: openPlayerMock }),
+}));
+
 import { SearchRoute } from "./SearchRoute";
 
 // ─── Fixtures ──────────────────────────────────────────────────────────────

--- a/src/routes/SeriesRoute.test.tsx
+++ b/src/routes/SeriesRoute.test.tsx
@@ -51,6 +51,11 @@ vi.mock("../api/series", () => ({
   fetchSeriesList: fetchSeriesListMock,
 }));
 
+const openPlayerMock = vi.hoisted(() => vi.fn());
+vi.mock("../player", () => ({
+  usePlayerOpener: () => ({ openPlayer: openPlayerMock }),
+}));
+
 import { SeriesRoute } from "./SeriesRoute";
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
@@ -135,15 +140,20 @@ describe("SeriesRoute", () => {
     ).toBeInTheDocument();
   });
 
-  it("clicking a card navigates to /series/:id", async () => {
+  it("clicking a card opens the player with kind=series-episode + id + title", async () => {
     fetchSeriesCategoriesMock.mockResolvedValue(mockCategories);
     fetchSeriesListMock.mockResolvedValue(mockItems);
+    openPlayerMock.mockClear();
 
     render(<SeriesRoute />);
     const card = await screen.findByRole("button", { name: /breaking bad/i });
     await userEvent.click(card);
 
-    expect(mockNavigate).toHaveBeenCalledWith("/series/s1");
+    expect(openPlayerMock).toHaveBeenCalledWith({
+      kind: "series-episode",
+      id: "s1",
+      title: expect.stringMatching(/breaking bad/i),
+    });
   });
 
   it("registers useFocusable with CONTENT_AREA_SERIES", async () => {

--- a/src/routes/SeriesRoute.tsx
+++ b/src/routes/SeriesRoute.tsx
@@ -20,12 +20,12 @@ import {
   useFocusable,
   FocusContext,
 } from "@noriginmedia/norigin-spatial-navigation";
-import { useNavigate } from "react-router-dom";
 import { ErrorShell } from "../primitives/ErrorShell";
 import { Skeleton } from "../primitives/Skeleton";
 import { SeriesCategoryStrip } from "../features/series/SeriesCategoryStrip";
 import { SeriesGrid } from "../features/series/SeriesGrid";
 import { fetchSeriesCategories, fetchSeriesList } from "../api/series";
+import { usePlayerOpener } from "../player";
 import type { SeriesCategory, SeriesItem } from "../api/schemas";
 
 export function SeriesRoute() {
@@ -36,7 +36,7 @@ export function SeriesRoute() {
     focusable: false,
     trackChildren: true,
   });
-  const navigate = useNavigate();
+  const { openPlayer } = usePlayerOpener();
 
   const [categories, setCategories] = useState<SeriesCategory[]>([]);
   const [activeCategoryId, setActiveCategoryId] = useState<string | null>(null);
@@ -128,9 +128,14 @@ export function SeriesRoute() {
 
   const handleCardClick = useCallback(
     (seriesId: string) => {
-      navigate(`/series/${seriesId}`);
+      const item = items.find((s) => s.id === seriesId);
+      void openPlayer({
+        kind: "series-episode",
+        id: seriesId,
+        title: item?.name ?? "Episode",
+      });
     },
-    [navigate],
+    [items, openPlayer],
   );
 
   // ─── Render ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Clicking a movie went to `/movies/:id` which had no registered route, producing a blank screen. Detail pages weren't built. Enter/click now opens the player overlay directly. PlayerProvider already handles TV-remote Back via popstate, so closing the player returns to the grid. 205/205 tests green.