### PR TITLE
feat(nav): global LanguageRail on Live/Movies/Series + unified sv_lang_pref (#50)

### DIFF
--- a/src/components/LanguageRail.tsx
+++ b/src/components/LanguageRail.tsx
@@ -1,0 +1,129 @@
+/**
+ * LanguageRail — global language filter chip strip.
+ *
+ * Shared across Live, Movies, and Series routes.
+ * Each chip registers with norigin via useFocusable.
+ *
+ * Props:
+ *   value      — currently active language id (controlled)
+ *   onChange   — called when user selects a chip
+ *   showSports — render the Sports chip (Live only; default false)
+ *   className  — optional extra CSS class on the wrapper div
+ */
+import type { RefObject } from "react";
+import { useFocusable } from "@noriginmedia/norigin-spatial-navigation";
+import type { LangId } from "../lib/langPref";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface LanguageOption {
+  id: LangId;
+  label: string;
+}
+
+// Base chips present on every surface.
+const BASE_OPTIONS: LanguageOption[] = [
+  { id: "telugu", label: "Telugu" },
+  { id: "hindi", label: "Hindi" },
+  { id: "english", label: "English" },
+  { id: "all", label: "All" },
+];
+
+// Sports chip is Live-specific (no sports-category concept on VOD/Series).
+const SPORTS_OPTION: LanguageOption = { id: "sports", label: "Sports" };
+
+// ─── Chip component ──────────────────────────────────────────────────────────
+
+interface ChipProps {
+  option: LanguageOption;
+  isActive: boolean;
+  onSelect: () => void;
+}
+
+function LanguageChip({ option, isActive, onSelect }: ChipProps) {
+  const { ref, focused } = useFocusable({
+    focusKey: `LANG_${option.id.toUpperCase()}`,
+    onEnterPress: onSelect,
+  });
+  const active = isActive || focused;
+
+  return (
+    <button
+      ref={ref as RefObject<HTMLButtonElement>}
+      type="button"
+      role="radio"
+      aria-checked={isActive}
+      aria-label={option.label}
+      onClick={onSelect}
+      className="focus-ring"
+      style={{
+        padding: "var(--space-2) var(--space-5)",
+        borderRadius: "var(--radius-pill)",
+        border: isActive
+          ? "2px solid var(--accent-copper)"
+          : "2px solid transparent",
+        background: active ? "var(--accent-copper)" : "var(--bg-surface)",
+        color: active ? "var(--bg-base)" : "var(--text-primary)",
+        fontSize: "var(--text-body-size)",
+        fontWeight: active ? 600 : 500,
+        cursor: "pointer",
+        whiteSpace: "nowrap",
+        transition:
+          "background var(--motion-focus), color var(--motion-focus), border-color var(--motion-focus)",
+      }}
+    >
+      {option.label}
+    </button>
+  );
+}
+
+// ─── LanguageRail ─────────────────────────────────────────────────────────────
+
+interface LanguageRailProps {
+  value: LangId;
+  onChange: (lang: LangId) => void;
+  /** Show the Sports chip (Live TV only). Default: false */
+  showSports?: boolean;
+  className?: string;
+}
+
+export function LanguageRail({
+  value,
+  onChange,
+  showSports = false,
+  className,
+}: LanguageRailProps) {
+  // Build the ordered option list; insert Sports after English when shown.
+  const options: LanguageOption[] = showSports
+    ? [
+        { id: "telugu", label: "Telugu" },
+        { id: "hindi", label: "Hindi" },
+        { id: "english", label: "English" },
+        SPORTS_OPTION,
+        { id: "all", label: "All" },
+      ]
+    : BASE_OPTIONS;
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Filter by language"
+      className={className}
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: "var(--space-3)",
+        padding: "var(--space-4) var(--space-6) var(--space-2)",
+      }}
+    >
+      {options.map((opt) => (
+        <LanguageChip
+          key={opt.id}
+          option={opt}
+          isActive={value === opt.id}
+          onSelect={() => onChange(opt.id)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/lib/langPref.ts
+++ b/src/lib/langPref.ts
@@ -1,0 +1,68 @@
+/**
+ * langPref — unified language preference helper.
+ *
+ * Single localStorage key: sv_lang_pref
+ * Default: "telugu"
+ *
+ * Migration: on first read, if the legacy key sv_live_lang exists and
+ * sv_lang_pref does NOT, copy the value over and delete the legacy key.
+ * This is a one-shot migration — subsequent reads skip the check.
+ */
+
+export type LangId = "telugu" | "hindi" | "english" | "sports" | "all";
+
+const PREF_KEY = "sv_lang_pref";
+const LEGACY_KEY = "sv_live_lang";
+const DEFAULT_LANG: LangId = "telugu";
+
+const VALID_LANGS: ReadonlySet<string> = new Set<LangId>([
+  "telugu",
+  "hindi",
+  "english",
+  "sports",
+  "all",
+]);
+
+function isValidLang(value: string): value is LangId {
+  return VALID_LANGS.has(value);
+}
+
+/**
+ * Read the unified language preference from localStorage.
+ * Performs one-shot migration from sv_live_lang on first call
+ * when sv_lang_pref is absent.
+ */
+export function getLangPref(): LangId {
+  try {
+    // One-shot migration: if new key is absent but legacy exists, copy it.
+    if (
+      localStorage.getItem(PREF_KEY) === null &&
+      localStorage.getItem(LEGACY_KEY) !== null
+    ) {
+      const legacy = localStorage.getItem(LEGACY_KEY);
+      if (legacy !== null) {
+        localStorage.setItem(PREF_KEY, legacy);
+      }
+      localStorage.removeItem(LEGACY_KEY);
+    }
+
+    const stored = localStorage.getItem(PREF_KEY);
+    if (stored !== null && isValidLang(stored)) {
+      return stored;
+    }
+  } catch {
+    // localStorage may throw in private/restricted contexts — fall back silently.
+  }
+  return DEFAULT_LANG;
+}
+
+/**
+ * Persist the language preference to localStorage.
+ */
+export function setLangPref(lang: LangId): void {
+  try {
+    localStorage.setItem(PREF_KEY, lang);
+  } catch {
+    // Silently ignore write failures (quota exceeded, private browsing, etc.)
+  }
+}

--- a/src/routes/LiveRoute.test.tsx
+++ b/src/routes/LiveRoute.test.tsx
@@ -53,6 +53,13 @@ vi.mock("../player/usePlayerOpener", () => ({
   usePlayerOpener: () => ({ openPlayer: vi.fn() }),
 }));
 
+// Mock langPref: return "all" so the language filter passes all mock channels
+// (mock category names like "News"/"Entertainment" don't match language patterns).
+vi.mock("../lib/langPref", () => ({
+  getLangPref: () => "all",
+  setLangPref: vi.fn(),
+}));
+
 import { LiveRoute } from "./LiveRoute";
 
 const mockChannels: Channel[] = [

--- a/src/routes/LiveRoute.tsx
+++ b/src/routes/LiveRoute.tsx
@@ -5,9 +5,9 @@
  *  - Fetch channels + categories on mount.
  *  - Own `selectedChannelId`, `sortBy`, `epgTimeFilter` state.
  *  - Derive the sorted channel list via `useSortedChannels`.
- *  - Render the sort + EPG-time toolbar ABOVE the channel list (Q3 — fewer
- *    D-pad hops). Each toolbar control uses `useFocusable` with a stable
- *    `focusKey` (D6a — Task 2.4 incident lesson).
+ *  - Render LanguageRail (global, shared) + sort + EPG-time toolbar ABOVE the
+ *    channel list (Q3 — fewer D-pad hops). Each toolbar control uses
+ *    `useFocusable` with a stable `focusKey` (D6a — Task 2.4 incident lesson).
  *  - Show <Skeleton> while loading, <ErrorShell> on fetch failure.
  *  - Retry callback re-fetches channels WITHOUT resetting `selectedChannelId`
  *    (Q1 — less jarring UX) and WITHOUT window.location.reload (TV-hostile).
@@ -35,62 +35,9 @@ import { Skeleton } from "../primitives/Skeleton";
 import { fetchChannels, fetchCategories } from "../api/live";
 import type { Channel } from "../api/schemas";
 import { usePlayerOpener } from "../player/usePlayerOpener";
-
-// ─── Language filter ─────────────────────────────────────────────────────────
-// User request (2026-04-22): Live should default to Telugu; also surface Hindi,
-// English, Sports. Other categories (UAE/Morocco/Poland/etc.) are noise for
-// this user and sit behind the "All" option.
-type LanguageFilter = "telugu" | "hindi" | "english" | "sports" | "all";
-
-const LANGUAGE_OPTIONS: { id: LanguageFilter; label: string }[] = [
-  { id: "telugu", label: "Telugu" },
-  { id: "hindi", label: "Hindi" },
-  { id: "english", label: "English" },
-  { id: "sports", label: "Sports" },
-  { id: "all", label: "All" },
-];
-
-function LanguageButton({
-  option,
-  isActive,
-  onSelect,
-}: {
-  option: { id: LanguageFilter; label: string };
-  isActive: boolean;
-  onSelect: () => void;
-}) {
-  const { ref, focused } = useFocusable({
-    focusKey: `LANG_${option.id.toUpperCase()}`,
-    onEnterPress: onSelect,
-  });
-  const active = isActive || focused;
-
-  return (
-    <button
-      ref={ref as RefObject<HTMLButtonElement>}
-      type="button"
-      className="focus-ring"
-      aria-pressed={isActive}
-      onClick={onSelect}
-      style={{
-        padding: "var(--space-2) var(--space-5)",
-        borderRadius: "var(--radius-pill)",
-        border: isActive
-          ? "2px solid var(--accent-copper)"
-          : "2px solid transparent",
-        background: active ? "var(--accent-copper)" : "var(--bg-surface)",
-        color: active ? "var(--bg-base)" : "var(--text-primary)",
-        fontSize: "var(--text-body-size)",
-        fontWeight: active ? 600 : 500,
-        cursor: "pointer",
-        transition:
-          "background var(--motion-focus), color var(--motion-focus), border-color var(--motion-focus)",
-      }}
-    >
-      {option.label}
-    </button>
-  );
-}
+import { LanguageRail } from "../components/LanguageRail";
+import { getLangPref, setLangPref } from "../lib/langPref";
+import type { LangId } from "../lib/langPref";
 
 // ─── Sort button (per-button norigin registration — D6a) ────────────────────
 
@@ -171,17 +118,23 @@ export function LiveRoute() {
   const [epgTimeFilter, setEpgTimeFilter] = useState<EpgTimeFilterValue>(
     "all",
   );
-  // Default "all" so the page renders every channel on first paint; user can
-  // narrow to Telugu / Hindi / English / Sports via the language rail.
-  // (Unit tests rely on the "all" default — their mock categories don't match
-  // language patterns.)
-  const [languageFilter, setLanguageFilter] =
-    useState<LanguageFilter>("all");
+  // Language filter — initialised from the unified sv_lang_pref key (falls
+  // back to "telugu" on first launch). Unit tests rely on the "all" default
+  // since their mock categories don't match language patterns; the default
+  // from getLangPref() is "telugu" for real sessions.
+  const [languageFilter, setLanguageFilter] = useState<LangId>(() =>
+    getLangPref(),
+  );
+
+  const handleLanguageChange = useCallback((lang: LangId) => {
+    setLangPref(lang);
+    setLanguageFilter(lang);
+  }, []);
 
   // Language → category-name match patterns. Matched case-insensitively against
   // the channel's resolved category name (falls back to channel name for
   // categories we can't resolve).
-  const LANGUAGE_PATTERNS: Record<Exclude<LanguageFilter, "all">, string[]> = {
+  const LANGUAGE_PATTERNS: Record<Exclude<LangId, "all">, string[]> = {
     telugu: ["telugu"],
     hindi: ["hindi", "india entertainment", "indian", "bollywood"],
     english: ["english", "netflix", "amazon", "hbo", "usa ", "uk "],
@@ -332,26 +285,14 @@ export function LiveRoute() {
           />
         ) : (
           <>
-            {/* Language rail — first row of toolbar. Defaults to Telugu. */}
-            <div
-              role="toolbar"
-              aria-label="Language filter"
-              style={{
-                display: "flex",
-                flexWrap: "wrap",
-                gap: "var(--space-3)",
-                padding: "var(--space-4) var(--space-6) var(--space-2)",
-              }}
-            >
-              {LANGUAGE_OPTIONS.map((opt) => (
-                <LanguageButton
-                  key={opt.id}
-                  option={opt}
-                  isActive={languageFilter === opt.id}
-                  onSelect={() => setLanguageFilter(opt.id)}
-                />
-              ))}
-            </div>
+            {/* Language rail — first row of toolbar. Shared component,
+                persists selection to sv_lang_pref. Sports chip shown on
+                Live only (no sports concept on Movies/Series). */}
+            <LanguageRail
+              value={languageFilter}
+              onChange={handleLanguageChange}
+              showSports
+            />
 
             {/* Toolbar — lives ABOVE the channel list (Q3) so D-pad reaches
                 it in one ArrowUp from the list. UX designer: flag for

--- a/src/routes/MoviesRoute.test.tsx
+++ b/src/routes/MoviesRoute.test.tsx
@@ -53,6 +53,13 @@ vi.mock("../player", () => ({
   usePlayerOpener: () => ({ openPlayer: openPlayerMock }),
 }));
 
+// Mock langPref: return "all" so language filter passes all mock streams
+// (mock category names like "Action"/"Comedy" don't match language patterns).
+vi.mock("../lib/langPref", () => ({
+  getLangPref: () => "all",
+  setLangPref: vi.fn(),
+}));
+
 import { MoviesRoute } from "./MoviesRoute";
 
 // ─── Fixtures ───────────────────────────────────────────────────────────────

--- a/src/routes/MoviesRoute.tsx
+++ b/src/routes/MoviesRoute.tsx
@@ -4,14 +4,23 @@
  * Structure:
  *   FocusContext(CONTENT_AREA_MOVIES)
  *     <main>
+ *       LanguageRail  — global language chip row (above category strip)
  *       CategoryStrip — horizontal D-pad navigable category chips
  *       MovieGrid     — responsive poster grid (6 cols @ 1920px)
+ *
+ * Layout decision (issue #50): LanguageRail sits ABOVE CategoryStrip (two
+ * stacked rows — option (a)). CategoryStrip remains unchanged; revisit
+ * replacing it with a secondary filter via issue #51.
+ *
+ * Language filtering uses the same LANGUAGE_PATTERNS regex logic as LiveRoute
+ * applied client-side against each stream's resolved category name. Moving
+ * this to the backend (with a lang_tags column) is tracked in issue #52.
  *
  * States:
  *   loading  → Skeleton rows (category strip height + grid height)
  *   error    → ErrorShell with onRetry (NO page reload — SPA state preserved)
  *   empty    → "No movies in this category" inside MovieGrid
- *   content  → CategoryStrip + MovieGrid
+ *   content  → LanguageRail + CategoryStrip + MovieGrid
  *
  * Data fetching:
  *   - On mount: fetchVodCategories() → auto-select first VOD category →
@@ -35,6 +44,19 @@ import { ErrorShell } from "../primitives/ErrorShell";
 import { Skeleton } from "../primitives/Skeleton";
 import { fetchVodCategories, fetchVodStreams } from "../api/vod";
 import type { VodCategory, VodStream } from "../api/schemas";
+import { LanguageRail } from "../components/LanguageRail";
+import { getLangPref, setLangPref } from "../lib/langPref";
+import type { LangId } from "../lib/langPref";
+
+// Language → category-name match patterns.
+// Matched case-insensitively against the stream's resolved category name.
+// Sports is omitted: no sports concept on VOD (issue #52 will move to backend).
+const LANGUAGE_PATTERNS: Record<Exclude<LangId, "all" | "sports">, string[]> =
+  {
+    telugu: ["telugu"],
+    hindi: ["hindi", "india entertainment", "indian", "bollywood"],
+    english: ["english", "netflix", "amazon", "hbo", "usa ", "uk "],
+  };
 
 export function MoviesRoute() {
   // MUST PRESERVE: norigin root registration for the content area.
@@ -52,6 +74,36 @@ export function MoviesRoute() {
   const [activeCategoryId, setActiveCategoryId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  // Language filter — reads from the unified sv_lang_pref key so it picks up
+  // whatever the user last set on Live or Series.
+  // If the stored pref is "sports" (Live-only), fall back to "all" since
+  // sports has no meaning on the VOD surface.
+  const [languageFilter, setLanguageFilter] = useState<LangId>(() => {
+    const stored = getLangPref();
+    return stored === "sports" ? "all" : stored;
+  });
+
+  const handleLanguageChange = useCallback((lang: LangId) => {
+    setLangPref(lang);
+    setLanguageFilter(lang);
+  }, []);
+
+  // Build the category-name lookup once per category list change.
+  const catNameById = new Map<string, string>();
+  for (const c of categories) catNameById.set(c.id, c.name);
+
+  // Apply language filter client-side against resolved category name.
+  const filteredStreams: VodStream[] =
+    languageFilter === "all" || languageFilter === "sports"
+      ? streams
+      : streams.filter((stream) => {
+          const hay = (
+            catNameById.get(stream.categoryId) ?? stream.categoryId
+          ).toLowerCase();
+          return LANGUAGE_PATTERNS[languageFilter].some((pat) =>
+            hay.includes(pat),
+          );
+        });
 
   // ─── Initial fetch ────────────────────────────────────────────────────────
   useEffect(() => {
@@ -182,12 +234,18 @@ export function MoviesRoute() {
           />
         ) : (
           <>
+            {/* Language rail — above category strip (layout option (a), issue #50).
+                Sports chip hidden: no sports-category concept on VOD. */}
+            <LanguageRail
+              value={languageFilter}
+              onChange={handleLanguageChange}
+            />
             <CategoryStrip
               categories={categories}
               activeCategoryId={activeCategoryId}
               onSelectCategory={(id) => void handleCategorySelect(id)}
             />
-            <MovieGrid streams={streams} />
+            <MovieGrid streams={filteredStreams} />
           </>
         )}
       </main>

--- a/src/routes/SeriesRoute.test.tsx
+++ b/src/routes/SeriesRoute.test.tsx
@@ -56,6 +56,13 @@ vi.mock("../player", () => ({
   usePlayerOpener: () => ({ openPlayer: openPlayerMock }),
 }));
 
+// Mock langPref: return "all" so language filter passes all mock items
+// (mock category names like "Drama"/"Comedy" don't match language patterns).
+vi.mock("../lib/langPref", () => ({
+  getLangPref: () => "all",
+  setLangPref: vi.fn(),
+}));
+
 import { SeriesRoute } from "./SeriesRoute";
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────

--- a/src/routes/SeriesRoute.tsx
+++ b/src/routes/SeriesRoute.tsx
@@ -2,7 +2,8 @@
  * SeriesRoute — Series browse screen (Phase 6).
  *
  * Layout:
- *  - SeriesCategoryStrip at top (horizontal, D-pad ArrowLeft/Right).
+ *  - LanguageRail at very top (global chip row, persists to sv_lang_pref).
+ *  - SeriesCategoryStrip below (horizontal, D-pad ArrowLeft/Right).
  *    Each chip has focusKey: SERIES_CAT_<id>.
  *  - SeriesGrid below (poster cards, D-pad 2D nav).
  *    Each card has focusKey: SERIES_CARD_<id>.
@@ -11,8 +12,14 @@
  *  - Empty state when no items in a category.
  *  - Bottom padding clears the dock.
  *
+ * Language filtering uses the same LANGUAGE_PATTERNS logic as LiveRoute and
+ * MoviesRoute applied client-side against the resolved category name. Moving
+ * this to backend is tracked in issue #52.
+ *
  * MUST PRESERVE: CONTENT_AREA_SERIES FocusContext registration
  * (BottomDock Esc-key routing — Task 2.4 lesson).
+ *
+ * NOTE: Do NOT touch /series/:id (SeriesDetailRoute) — that is issue #49.
  */
 import type { RefObject } from "react";
 import { useCallback, useEffect, useState } from "react";
@@ -27,6 +34,18 @@ import { SeriesGrid } from "../features/series/SeriesGrid";
 import { fetchSeriesCategories, fetchSeriesList } from "../api/series";
 import { usePlayerOpener } from "../player";
 import type { SeriesCategory, SeriesItem } from "../api/schemas";
+import { LanguageRail } from "../components/LanguageRail";
+import { getLangPref, setLangPref } from "../lib/langPref";
+import type { LangId } from "../lib/langPref";
+
+// Language → category-name match patterns (same logic as LiveRoute/MoviesRoute).
+// Sports is omitted: no sports feed concept on Series.
+const LANGUAGE_PATTERNS: Record<Exclude<LangId, "all" | "sports">, string[]> =
+  {
+    telugu: ["telugu"],
+    hindi: ["hindi", "india entertainment", "indian", "bollywood"],
+    english: ["english", "netflix", "amazon", "hbo", "usa ", "uk "],
+  };
 
 export function SeriesRoute() {
   // MUST PRESERVE: norigin root registration for the content area.
@@ -44,6 +63,34 @@ export function SeriesRoute() {
   const [loading, setLoading] = useState(true);
   const [itemsLoading, setItemsLoading] = useState(false);
   const [error, setError] = useState(false);
+  // Language filter — reads from unified sv_lang_pref. Falls back to "all"
+  // when stored pref is "sports" (Live-only concept).
+  const [languageFilter, setLanguageFilter] = useState<LangId>(() => {
+    const stored = getLangPref();
+    return stored === "sports" ? "all" : stored;
+  });
+
+  const handleLanguageChange = useCallback((lang: LangId) => {
+    setLangPref(lang);
+    setLanguageFilter(lang);
+  }, []);
+
+  // Build category-name lookup for language filtering.
+  const catNameById = new Map<string, string>();
+  for (const c of categories) catNameById.set(c.id, c.name);
+
+  // Apply language filter client-side.
+  const filteredItems: SeriesItem[] =
+    languageFilter === "all" || languageFilter === "sports"
+      ? items
+      : items.filter((item) => {
+          const hay = (
+            catNameById.get(item.categoryId) ?? item.categoryId
+          ).toLowerCase();
+          return LANGUAGE_PATTERNS[languageFilter].some((pat) =>
+            hay.includes(pat),
+          );
+        });
 
   // ─── Initial fetch — categories ──────────────────────────────────────────
   useEffect(() => {
@@ -177,6 +224,13 @@ export function SeriesRoute() {
           />
         ) : (
           <>
+            {/* Language rail — above category strip (layout option (a), issue #50).
+                Sports chip hidden: no sports feed concept on Series. */}
+            <LanguageRail
+              value={languageFilter}
+              onChange={handleLanguageChange}
+            />
+
             {/* Category strip */}
             <SeriesCategoryStrip
               categories={categories}
@@ -197,7 +251,7 @@ export function SeriesRoute() {
                 <Skeleton width="100%" height={360} />
               </div>
             ) : (
-              <SeriesGrid items={items} onCardClick={handleCardClick} />
+              <SeriesGrid items={filteredItems} onCardClick={handleCardClick} />
             )}
           </>
         )}


### PR DESCRIPTION
## Summary

- Extracts the inline language chip row from `LiveRoute.tsx` into a shared `<LanguageRail value onChange showSports? className?>` component at `src/components/LanguageRail.tsx`
- Introduces `src/lib/langPref.ts` (`getLangPref` / `setLangPref`) backed by a single `localStorage` key `sv_lang_pref`; includes one-shot migration that reads `sv_live_lang`, copies its value to `sv_lang_pref`, and deletes the legacy key on first read
- Mounts `LanguageRail` at the top of Live, Movies, AND Series routes — picking Telugu on any surface now persists globally

## Layout decision

**Option (a): LanguageRail above CategoryStrip** — two stacked rows on Movies and Series. Minimal disruption, zero regressions. Option (b) (replace CategoryStrip with a secondary filter drawer) is deferred to issue #51.

## Language filtering (Movies + Series)

Uses the same `LANGUAGE_PATTERNS` regex against each item's resolved category name that `LiveRoute` already uses — identical logic, kept client-side and inline for now. Moving this to a backend `lang_tags` column is tracked in issue #52.

Sports chip is shown on Live only (no sports-feed concept on VOD/Series). When `sv_lang_pref = "sports"` on a Movies/Series mount the filter gracefully falls back to `"all"`.

## D-pad

Rail uses existing norigin `useFocusable` with stable `LANG_*` focusKeys, matching the pattern already in LiveRoute. `Down` from rail → first element of next toolbar row (norigin natural fall-through). `Up` from grid → dock (norigin). Focus is NOT stolen on mount (`focusable: false` container at route level, `trackChildren: true`).

## Acceptance checklist

- [x] LanguageRail renders at top of Live, Movies, AND Series routes
- [x] Single `sv_lang_pref` key; legacy `sv_live_lang` migrated + deleted on first read
- [x] No regression in Live filtering behavior
- [x] Movies + Series use same LANGUAGE_PATTERNS inference as Live
- [x] Sports chip on Live only; Movies/Series fall back to "all" when stored pref is "sports"
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 205/205 passed

## Test plan

- [ ] Navigate to `/live` — confirm LanguageRail visible with Sports chip; pick Telugu, reload page — Telugu chip still active
- [ ] Navigate to `/movies` — LanguageRail visible (no Sports chip) ABOVE category strip; Telugu filter active from previous step
- [ ] Navigate to `/series` — same as Movies
- [ ] Pick Hindi on Series → navigate to Live → Hindi chip should be active
- [ ] D-pad: Up from grid → rail chips focusable; Left/Right cycles chips; Down returns to grid/toolbar

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)