### PR TITLE
perf(ci): cache Playwright browsers + backend npm; webkit drop aborted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,23 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "20"
+          cache: "npm"
+          cache-dependency-path: |
+            frontend/package-lock.json
+            backend/package-lock.json
+
+      # --- Playwright browser cache ------------------------------------------
+      # Keyed on the @playwright/test version pinned in package.json so the
+      # cache is invalidated whenever the Playwright release changes.
+      # system-level libs (libgtk, libwebp, etc.) are NOT cached — those come
+      # from playwright install-deps and live in /usr/lib, not ~/.cache.
+      # Restore early so the cache is primed; actual install runs after npm ci.
+      - name: Restore Playwright browser cache
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
 
       # --- Postgres schema ---------------------------------------------------
       # Mirror of ai-orchestration/postgres/20-streamvault-schema.sql (the real
@@ -236,9 +253,15 @@ jobs:
         working-directory: frontend
         run: npm ci
 
-      - name: Install Playwright browsers
+      - name: Install Playwright browsers (cache miss — full install with deps)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: frontend
         run: npx playwright install --with-deps chromium webkit
+
+      - name: Install Playwright system deps only (cache hit — binaries already cached)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        working-directory: frontend
+        run: npx playwright install-deps chromium webkit
 
       - name: Run Playwright E2E
         working-directory: frontend


### PR DESCRIPTION
## Summary

Three CI speed improvements targeting the `e2e` job ("Playwright E2E vs real backend"), which currently takes 20–30 min with no caching. Two of three applied; one aborted with evidence.

### Changes applied

**1. Cache `~/.cache/ms-playwright` (saves ~3–5 min)**

Added `actions/cache@v4` keyed on `hashFiles('frontend/package-lock.json')`. On cache hit the job runs `playwright install-deps chromium webkit` (system libs only, not cached). On cache miss it runs the full `playwright install --with-deps chromium webkit`. Binary downloads (~300 MB for chromium + webkit) are skipped on warm runs.

**2. Cache backend npm downloads in e2e job (saves ~2–3 min)**

The `test` job already sets `cache: "npm"` on `actions/setup-node@v5`. The e2e job's `setup-node` step was missing it. Added `cache: 'npm'` plus `cache-dependency-path` covering both `frontend/package-lock.json` and `backend/package-lock.json` so both `npm ci` calls benefit from the `~/.npm` download cache.

**3. Drop webkit from `playwright install` — ABORTED (see webkit grep evidence below)**

Cannot safely drop. The grep showed active webkit projects in the config.

### Webkit grep evidence (why change #3 was aborted)

```
tests/e2e/auth.spec.ts:21:  // Retries on this suite only: webkit-desktop has been the single source of
playwright.config.ts:22:      name: "webkit",
playwright.config.ts:29:      name: "webkit-desktop",
```

`playwright.config.ts` defines two webkit projects: `webkit` (iPad Pro 11 / Amazon Silk baseline) and `webkit-desktop` (Desktop Safari). Dropping webkit from `playwright install` would cause both projects to fail at browser launch. webkit is intentional here — two distinct viewport/UA profiles that catch layout regressions.

### Estimated wall-clock savings (warm cache)

| Change | Saving |
|--------|--------|
| Playwright browser cache | ~3–5 min |
| Backend npm cache | ~2–3 min |
| webkit drop (aborted) | — |
| **Total** | **~5–8 min** |

---

### Rebase risk vs PR #40

**Both this PR and PR #40 (`test/prod-e2e-regression-suite`) edit `.github/workflows/ci.yml`.** If #40 merges first, this branch will need a rebase.

PR #40's change is isolated to the "Apply Phase 3 service tables" step — it adds a `sed` one-liner before the `psql` call to patch a `NOW()` predicate index issue. This PR's changes are in different sections (the `setup-node` step at line ~80 and the frontend install section at lines ~256–264), so the rebase should be mechanical with no semantic conflict. After rebasing, the `sed` step in #40 will sit untouched inside the "Apply Phase 3 service tables" block.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)