### PR TITLE
perf(movies): VirtuosoGrid for Movies (61k rows, Silk OOM fix) (#59)

### DIFF
--- a/docs/ux/03-movies.md
+++ b/docs/ux/03-movies.md
@@ -14,6 +14,14 @@ conventions. No code in this doc.
 
 ---
 
+## Virtualization mandate
+
+`react-virtuoso` (`VirtuosoGrid`) is **required** for the Movies poster grid. The DOM card count must stay under ~150 regardless of catalog size. Rationale: the VOD catalog has 61,442 rows; without virtualization, the Silk browser on Fire TV OOMs at ~600–1000 rendered cards.
+
+Implementation reference: `MoviesRoute → MovieGrid uses VirtuosoGrid (Issue #59)`.
+
+---
+
 ## 1. `/movies` page structure
 
 Three stacked zones, same spatial grammar as `LiveRoute`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^6.30.3",
+        "react-virtuoso": "^4.18.5",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -5261,6 +5262,16 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-virtuoso": {
+      "version": "4.18.5",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.5.tgz",
+      "integrity": "sha512-QDyNjyNEuurZG67SOmzYyxEkQYSyGmAMixOI6M15L/Q4CF39EgG+88y6DgZRo0q7rmy0HPx3Fj90I8/tPdnRCQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18 || >= 19",
+        "react-dom": ">=16 || >=17 || >= 18 || >=19"
       }
     },
     "node_modules/redent": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^6.30.3",
+    "react-virtuoso": "^4.18.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/features/movies/MovieGrid.tsx
+++ b/src/features/movies/MovieGrid.tsx
@@ -1,8 +1,25 @@
 /**
- * MovieGrid — responsive poster grid.
- * 6 columns at 1920px, fewer on narrow screens (CSS grid auto-fill).
+ * MovieGrid — responsive poster grid with react-virtuoso virtualization.
+ *
+ * Virtualization mandate (Issue #59):
+ *   The VOD catalog has ~61,000 rows. Without virtualization, the Silk browser
+ *   on Fire TV OOMs at ~600–1000 cards. VirtuosoGrid keeps the DOM card count
+ *   under ~150 regardless of catalog size.
+ *
+ *   MoviesRoute → MovieGrid uses VirtuosoGrid (Issue #59)
+ *
+ * Grid: 6 columns at 1920px, auto-fill down to ~120px min (same geometry as
+ * before virtualization). Each card retains its useFocusable registration so
+ * norigin D-pad navigation is unchanged.
+ *
+ * Overscan: 500px (≈ 2–3 rows at typical card height) keeps the focused card
+ * mounted during ordinary D-pad scrolling, preventing norigin from losing
+ * focus when a card is virtualized out.
+ *
  * Renders MovieCard per stream, plus an empty state when the list is empty.
  */
+import { useMemo } from "react";
+import { VirtuosoGrid } from "react-virtuoso";
 import { MovieCard } from "./MovieCard";
 import { usePlayerOpener } from "../../player";
 import type { VodStream } from "../../api/schemas";
@@ -11,12 +28,47 @@ interface MovieGridProps {
   streams: VodStream[];
 }
 
+// Container for the CSS grid — applied as the VirtuosoGrid List component.
+// Must be a stable reference (defined outside the render function) so Virtuoso
+// does not remount the grid container on every render.
+const GridList = ({ style, ...rest }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    {...rest}
+    aria-label="Movie poster grid"
+    style={{
+      ...style,
+      display: "grid",
+      // 6 columns at 1920px, auto-fill down to ~120px min (same as pre-virtuoso)
+      gridTemplateColumns:
+        "repeat(auto-fill, minmax(clamp(120px, 14vw, 280px), 1fr))",
+      gap: "var(--space-4)",
+      padding: "var(--space-6)",
+    }}
+  />
+);
+
+// Wrapper for each grid cell — Virtuoso needs an Item wrapper that does NOT
+// alter layout (no flex/grid on its own; the parent List is the grid).
+const GridItem = ({ style, ...rest }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div {...rest} style={{ ...style, display: "contents" }} />
+);
+
 export function MovieGrid({ streams }: MovieGridProps) {
   // Enter on a poster opens the player overlay directly. The detail page
   // (/movies/:id) was never implemented — navigating there produced a blank
   // screen for the user. Opening the player matches the LiveRoute pattern
   // and is the minimum viable path to "press play and it plays".
   const { openPlayer } = usePlayerOpener();
+
+  // Stable components object — must not be re-created inline or Virtuoso
+  // will remount the entire grid on every render.
+  const components = useMemo(
+    () => ({
+      List: GridList,
+      Item: GridItem,
+    }),
+    [],
+  );
 
   if (streams.length === 0) {
     return (
@@ -49,26 +101,29 @@ export function MovieGrid({ streams }: MovieGridProps) {
   }
 
   return (
-    <div
-      aria-label="Movie poster grid"
-      style={{
-        display: "grid",
-        // 6 columns at 1920px, auto-fill down to ~150px min
-        gridTemplateColumns:
-          "repeat(auto-fill, minmax(clamp(120px, 14vw, 280px), 1fr))",
-        gap: "var(--space-4)",
-        padding: "var(--space-6)",
+    <VirtuosoGrid
+      // useWindowScroll lets the page scroll naturally (same as the pre-Virtuoso
+      // plain div) rather than creating a second inner scrollable container.
+      useWindowScroll
+      totalCount={streams.length}
+      components={components}
+      // overscan: keep ~500px of off-screen cards rendered so norigin focus
+      // stays mounted during normal D-pad navigation (avoids focus loss when
+      // the focused card scrolls just off the viewport edge).
+      overscan={500}
+      itemContent={(index) => {
+        const stream = streams[index];
+        if (!stream) return null;
+        return (
+          <MovieCard
+            key={stream.id}
+            stream={stream}
+            onSelect={(id) =>
+              void openPlayer({ kind: "vod", id, title: stream.name })
+            }
+          />
+        );
       }}
-    >
-      {streams.map((stream) => (
-        <MovieCard
-          key={stream.id}
-          stream={stream}
-          onSelect={(id) =>
-            void openPlayer({ kind: "vod", id, title: stream.name })
-          }
-        />
-      ))}
-    </div>
+    />
   );
 }

--- a/src/routes/MoviesRoute.test.tsx
+++ b/src/routes/MoviesRoute.test.tsx
@@ -60,6 +60,35 @@ vi.mock("../lib/langPref", () => ({
   setLangPref: vi.fn(),
 }));
 
+// Mock react-virtuoso: jsdom has no real layout engine, so VirtuosoGrid renders
+// nothing (all items are virtualised out at zero scroll position). Replace with
+// a simple eager renderer that renders all items — virtualization is a runtime
+// perf concern, not a DOM-structure concern tested here.
+vi.mock("react-virtuoso", () => ({
+  VirtuosoGrid: ({
+    totalCount,
+    itemContent,
+    components,
+  }: {
+    totalCount: number;
+    itemContent: (index: number) => React.ReactNode;
+    components?: {
+      List?: React.ComponentType<React.HTMLAttributes<HTMLDivElement>>;
+      Item?: React.ComponentType<React.HTMLAttributes<HTMLDivElement>>;
+    };
+  }) => {
+    const List = components?.List ?? "div";
+    const Item = components?.Item ?? "div";
+    return (
+      <List>
+        {Array.from({ length: totalCount }, (_, i) => (
+          <Item key={i}>{itemContent(i)}</Item>
+        ))}
+      </List>
+    );
+  },
+}));
+
 import { MoviesRoute } from "./MoviesRoute";
 
 // ─── Fixtures ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Closes #59
- Wraps `MovieGrid` in `VirtuosoGrid` (react-virtuoso 4.18.5) so the DOM card count stays under ~150 regardless of how many streams are loaded
- The 61,442-row VOD catalog was OOM-crashing Silk on Fire TV at ~600–1000 rendered cards; virtualization eliminates that ceiling

## Changes

| File | Change |
|------|--------|
| `src/features/movies/MovieGrid.tsx` | Replace plain `<div>` grid with `VirtuosoGrid`; `useWindowScroll`; `overscan=500px`; stable `GridList`/`GridItem` component refs |
| `src/routes/MoviesRoute.test.tsx` | Mock `react-virtuoso` with eager renderer (jsdom has no layout engine) |
| `package.json` / `package-lock.json` | Add `react-virtuoso ^4.18.5` (peer compat: React >=16–19 ✓) |
| `docs/ux/03-movies.md` | Add "Virtualization mandate" section near §1 |

## Acceptance criteria

- [x] DOM card count under ~150 at any catalog size (VirtuosoGrid renders only visible + `overscan` rows)
- [x] Focus retained during D-pad navigation (`overscan=500px` keeps ~2–3 off-screen rows mounted)
- [x] No regression in existing tests — all 205 tests pass
- [x] `LanguageRail` and `CategoryStrip` above the grid are untouched

## Verification

```
npm run typecheck  ✓
npm run lint       ✓
npm run build      ✓
npm test           ✓  205 passed
```

## Non-goals

- Live and Series grids — their row counts don't warrant virtualization yet
- Pagination / server-side filtering — tracked separately in #9

## D-pad / focus notes

`VirtuosoGrid` virtualizes off-screen items (unmounts them from the DOM). When the focused card scrolls out of view norigin would normally lose focus. The `overscan={500}` prop keeps ~2–3 additional rows rendered beyond the visible viewport, which is sufficient for typical D-pad navigation pace. If a user D-pads very fast through hundreds of rows this could still race; that edge case is tracked in #59 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)