### PR TITLE
refactor(routes): consume backend inferredLang; remove inline LANGUAGE_PATTERNS (#52)

### DIFF
--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -24,6 +24,17 @@ const RatingSchema = z.preprocess(
   z.string().optional(),
 );
 
+/**
+ * InferredLangSchema — language tag inferred server-side from the item's
+ * category name (backend issue #52 / frontend PR #52 refactor).
+ * Optional and nullable: null when no pattern matched, undefined when the
+ * backend has not yet been updated (forward-compat with older deployments).
+ */
+const InferredLangSchema = z
+  .enum(["telugu", "hindi", "english", "sports"])
+  .nullable()
+  .optional();
+
 // Backend auth is cookie-based (httpOnly access_token / refresh_token cookies).
 // /api/auth/login returns only a confirmation body; the session itself lives in
 // cookies set by the Set-Cookie header. The frontend must NOT expect JWT strings
@@ -61,6 +72,8 @@ export const ChannelSchema = z.object({
   streamUrl: z.string().url().optional(),
   logo: z.string().optional(),
   epgChannelId: z.string().optional(),
+  /** Language inferred server-side from category name (backend PR #45 / frontend issue #52). */
+  inferredLang: InferredLangSchema,
 });
 export type Channel = z.infer<typeof ChannelSchema>;
 
@@ -185,6 +198,8 @@ export const SeriesItemSchema = z.object({
   rating: RatingSchema,
   genre: z.string().optional(),
   year: z.string().optional(),
+  /** Language inferred server-side from category name (backend PR #45 / frontend issue #52). */
+  inferredLang: InferredLangSchema,
 });
 export type SeriesItem = z.infer<typeof SeriesItemSchema>;
 
@@ -210,6 +225,8 @@ export const CatalogItemSchema = z.object({
   rating: RatingSchema,
   genre: z.string().optional(),
   year: z.string().optional(),
+  /** Language inferred server-side from category name (backend PR #45 / frontend issue #52). */
+  inferredLang: InferredLangSchema,
 });
 export type CatalogItem = z.infer<typeof CatalogItemSchema>;
 
@@ -245,6 +262,8 @@ export const VodStreamSchema = z.object({
   rating: RatingSchema,
   genre: z.string().optional(),
   year: z.string().optional(),
+  /** Language inferred server-side from category name (backend PR #45 / frontend issue #52). */
+  inferredLang: InferredLangSchema,
 });
 export type VodStream = z.infer<typeof VodStreamSchema>;
 

--- a/src/routes/LiveRoute.tsx
+++ b/src/routes/LiveRoute.tsx
@@ -131,46 +131,15 @@ export function LiveRoute() {
     setLanguageFilter(lang);
   }, []);
 
-  // Language → category-name match patterns. Matched case-insensitively against
-  // the channel's resolved category name (falls back to channel name for
-  // categories we can't resolve).
-  const LANGUAGE_PATTERNS: Record<Exclude<LangId, "all">, string[]> = {
-    telugu: ["telugu"],
-    hindi: ["hindi", "india entertainment", "indian", "bollywood"],
-    english: ["english", "netflix", "amazon", "hbo", "usa ", "uk "],
-    sports: [
-      "sport",
-      "sports",
-      "football",
-      "cricket",
-      "tennis",
-      "nba",
-      "nfl",
-      "mlb",
-      "epl",
-      "ipl",
-      "rugby",
-      "f1",
-      "racing",
-    ],
-  };
-
-  // Resolve category name once per channel set for fast lookup.
-  const catNameById = new Map<string, string>();
-  for (const c of categories) catNameById.set(c.id, c.name);
-
+  // Language filter — uses the server-provided `inferredLang` field (issue #52).
+  // When `inferredLang` is absent (e.g. older backend) or null (no pattern
+  // matched), the channel passes through when the filter is "all"; it is hidden
+  // for any specific language selection (safe degradation: untagged items do not
+  // appear under a language they haven't been tagged to).
   const filteredChannels =
     languageFilter === "all"
       ? channels
-      : channels.filter((ch) => {
-          const hay = (
-            catNameById.get(ch.categoryId) ??
-            ch.categoryId
-          ).toLowerCase();
-          return LANGUAGE_PATTERNS[languageFilter].some((pat) =>
-            hay.includes(pat),
-          );
-        });
+      : channels.filter((ch) => ch.inferredLang === languageFilter);
 
   const sorted = useSortedChannels(filteredChannels, sortBy, categories);
 

--- a/src/routes/MoviesRoute.tsx
+++ b/src/routes/MoviesRoute.tsx
@@ -12,9 +12,9 @@
  * stacked rows — option (a)). CategoryStrip remains unchanged; revisit
  * replacing it with a secondary filter via issue #51.
  *
- * Language filtering uses the same LANGUAGE_PATTERNS regex logic as LiveRoute
- * applied client-side against each stream's resolved category name. Moving
- * this to the backend (with a lang_tags column) is tracked in issue #52.
+ * Language filtering uses the server-provided `inferredLang` field on each
+ * stream (backend PR #45). The inline LANGUAGE_PATTERNS regex blocks were
+ * removed as part of issue #52.
  *
  * States:
  *   loading  → Skeleton rows (category strip height + grid height)
@@ -48,16 +48,6 @@ import { LanguageRail } from "../components/LanguageRail";
 import { getLangPref, setLangPref } from "../lib/langPref";
 import type { LangId } from "../lib/langPref";
 
-// Language → category-name match patterns.
-// Matched case-insensitively against the stream's resolved category name.
-// Sports is omitted: no sports concept on VOD (issue #52 will move to backend).
-const LANGUAGE_PATTERNS: Record<Exclude<LangId, "all" | "sports">, string[]> =
-  {
-    telugu: ["telugu"],
-    hindi: ["hindi", "india entertainment", "indian", "bollywood"],
-    english: ["english", "netflix", "amazon", "hbo", "usa ", "uk "],
-  };
-
 export function MoviesRoute() {
   // MUST PRESERVE: norigin root registration for the content area.
   // trackChildren + non-focusable container: when BottomDock fires
@@ -88,22 +78,14 @@ export function MoviesRoute() {
     setLanguageFilter(lang);
   }, []);
 
-  // Build the category-name lookup once per category list change.
-  const catNameById = new Map<string, string>();
-  for (const c of categories) catNameById.set(c.id, c.name);
-
-  // Apply language filter client-side against resolved category name.
+  // Language filter — uses the server-provided `inferredLang` field (issue #52).
+  // Sports falls through to "all" on VOD: no sports-category concept on Movies.
+  // When `inferredLang` is absent or null (no pattern matched / older backend),
+  // items are hidden under any specific language filter (safe degradation).
   const filteredStreams: VodStream[] =
     languageFilter === "all" || languageFilter === "sports"
       ? streams
-      : streams.filter((stream) => {
-          const hay = (
-            catNameById.get(stream.categoryId) ?? stream.categoryId
-          ).toLowerCase();
-          return LANGUAGE_PATTERNS[languageFilter].some((pat) =>
-            hay.includes(pat),
-          );
-        });
+      : streams.filter((stream) => stream.inferredLang === languageFilter);
 
   // ─── Initial fetch ────────────────────────────────────────────────────────
   useEffect(() => {

--- a/src/routes/SeriesRoute.tsx
+++ b/src/routes/SeriesRoute.tsx
@@ -12,9 +12,9 @@
  *  - Empty state when no items in a category.
  *  - Bottom padding clears the dock.
  *
- * Language filtering uses the same LANGUAGE_PATTERNS logic as LiveRoute and
- * MoviesRoute applied client-side against the resolved category name. Moving
- * this to backend is tracked in issue #52.
+ * Language filtering uses the server-provided `inferredLang` field on each
+ * series item (backend PR #45). The inline LANGUAGE_PATTERNS regex blocks
+ * were removed as part of issue #52.
  *
  * MUST PRESERVE: CONTENT_AREA_SERIES FocusContext registration
  * (BottomDock Esc-key routing — Task 2.4 lesson).
@@ -37,15 +37,6 @@ import type { SeriesCategory, SeriesItem } from "../api/schemas";
 import { LanguageRail } from "../components/LanguageRail";
 import { getLangPref, setLangPref } from "../lib/langPref";
 import type { LangId } from "../lib/langPref";
-
-// Language → category-name match patterns (same logic as LiveRoute/MoviesRoute).
-// Sports is omitted: no sports feed concept on Series.
-const LANGUAGE_PATTERNS: Record<Exclude<LangId, "all" | "sports">, string[]> =
-  {
-    telugu: ["telugu"],
-    hindi: ["hindi", "india entertainment", "indian", "bollywood"],
-    english: ["english", "netflix", "amazon", "hbo", "usa ", "uk "],
-  };
 
 export function SeriesRoute() {
   // MUST PRESERVE: norigin root registration for the content area.
@@ -75,22 +66,14 @@ export function SeriesRoute() {
     setLanguageFilter(lang);
   }, []);
 
-  // Build category-name lookup for language filtering.
-  const catNameById = new Map<string, string>();
-  for (const c of categories) catNameById.set(c.id, c.name);
-
-  // Apply language filter client-side.
+  // Language filter — uses the server-provided `inferredLang` field (issue #52).
+  // Sports falls through to "all" on Series: no sports feed concept on Series.
+  // When `inferredLang` is absent or null (no pattern matched / older backend),
+  // items are hidden under any specific language filter (safe degradation).
   const filteredItems: SeriesItem[] =
     languageFilter === "all" || languageFilter === "sports"
       ? items
-      : items.filter((item) => {
-          const hay = (
-            catNameById.get(item.categoryId) ?? item.categoryId
-          ).toLowerCase();
-          return LANGUAGE_PATTERNS[languageFilter].some((pat) =>
-            hay.includes(pat),
-          );
-        });
+      : items.filter((item) => item.inferredLang === languageFilter);
 
   // ─── Initial fetch — categories ──────────────────────────────────────────
   useEffect(() => {


### PR DESCRIPTION
## Summary

Closes #52.

- Removes the duplicated `LANGUAGE_PATTERNS` regex blocks from `LiveRoute.tsx`, `MoviesRoute.tsx`, and `SeriesRoute.tsx` that shipped in PR #60.
- Replaces client-side category-name regex matching with a simple `item.inferredLang === languageFilter` equality check against the new server-populated field.
- Adds `InferredLangSchema` to `src/api/schemas.ts` and wires it into `ChannelSchema`, `VodStreamSchema`, `SeriesItemSchema`, and `CatalogItemSchema` (all `optional().nullable()` — forward-compatible with older backend deployments).

## IMPORTANT: Backend PR must merge first

**This PR depends on:** srinivas-kotha/streamvault-backend#45

The backend PR adds `inferredLang` to all catalog item responses. Until it is deployed, the field will be absent from API responses and the frontend will degrade safely: items without `inferredLang` are hidden under a specific language filter (they appear under "All"). This is intentional — the schema field is optional/nullable for exactly this reason.

## Files changed

| File | Change |
|------|--------|
| `src/api/schemas.ts` | `InferredLangSchema` + `inferredLang` on 4 schemas |
| `src/routes/LiveRoute.tsx` | Removed `LANGUAGE_PATTERNS` + `catNameById`; one-liner filter |
| `src/routes/MoviesRoute.tsx` | Same |
| `src/routes/SeriesRoute.tsx` | Same |

## What is NOT in scope

- `lang_tags TEXT[]` DB column — deferred to P1.5 per issue spec
- Changes to `LanguageRail.tsx`, `useSortedChannels`, or any other component

## Test plan

- [x] `npm run typecheck` — no errors
- [x] `npm run lint` — no errors
- [x] `npm run build` — builds successfully
- [x] `npm test` — 205/205 passing (no regressions)
- [ ] After backend PR merges and deploys: smoke-test Live TV, Movies, Series with each language chip
- [ ] Verify Telugu channels appear under Telugu filter, sports under Sports on Live

🤖 Generated with [Claude Code](https://claude.com/claude-code)