### PR TITLE
fix(tests): skip visual-polish on non-chromium (unblock Deploy)

### DIFF
--- a/tests/e2e/visual-polish.spec.ts
+++ b/tests/e2e/visual-polish.spec.ts
@@ -18,7 +18,12 @@ import { seedFakeAuth } from "./helpers";
 // We're capturing the authenticated shell (skeleton/error states still have
 // the polished atmosphere: gradient, dock, ambient fill).
 
-test.beforeEach(async ({ page }) => {
+// Visual baselines only exist for chromium-linux (see *.png snapshots checked in).
+// On webkit + webkit-desktop the test would fail with "snapshot doesn't exist,
+// writing actual" — and the Deploy gate is then permanently red. Until webkit
+// baselines are generated and committed, scope this suite to chromium only.
+test.beforeEach(async ({ page, browserName }) => {
+  test.skip(browserName !== "chromium", "visual baselines only exist for chromium");
   await seedFakeAuth(page);
 });
 


### PR DESCRIPTION
## Summary

\`visual-polish.spec.ts\` (added in PR #39) has 5 baseline PNGs for chromium-linux but NONE for webkit-linux / webkit-desktop-linux. Since playwright.config.ts defines 3 projects (chromium, webkit, webkit-desktop), the suite has been failing on the 2 webkit projects since PR #39 landed → CI fails → Deploy is gated on CI=success → **no frontend deploy has fired since PR #39**.

This is the reason the LIVE production site at streamvault.srinivaskotha.uk has not picked up any of today's merged work (P0 LanguageRail + Series detail + CI caching + grill fixes).

## Fix

One change to \`tests/e2e/visual-polish.spec.ts\`:

\`\`\`ts
test.beforeEach(async ({ page, browserName }) => {
  test.skip(browserName !== "chromium", "visual baselines only exist for chromium");
  await seedFakeAuth(page);
});
\`\`\`

## Follow-up (out of scope; tracked in #63)

Generate webkit + webkit-desktop baselines:
\`\`\`
npx playwright test tests/e2e/visual-polish.spec.ts --update-snapshots \\
  --project=webkit --project=webkit-desktop
\`\`\`
Commit the resulting \`*-webkit-linux.png\` and \`*-webkit-desktop-linux.png\` files. Then this skip can be removed.

## Verification

- chromium baselines unchanged → chromium project continues to assert pixel diff
- webkit + webkit-desktop projects now skip the suite cleanly with a stated reason
- All other suites unaffected