### PR TITLE
infra(ci+deploy): dedupe triggers + manual deploy escape hatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: CI
-on: [push, pull_request]
+# Triggers:
+#   - pull_request: validate every PR against its base
+#   - push to main: validate the merged result (gates the Deploy workflow)
+# (Earlier `[push, pull_request]` doubled triggers on every PR push — wasteful.)
+on:
+  pull_request:
+  push:
+    branches: [main]
 permissions:
   contents: read
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,24 @@
 name: Deploy
 
+# Triggers:
+#   - workflow_run: auto-deploy after CI passes on main
+#   - workflow_dispatch: ESCAPE HATCH — manual trigger from the Actions UI when
+#     CI is silently broken on a non-app-code issue (flaky tests, missing
+#     baselines, etc). Production was frozen 2026-04-22 14:08 → 23:xx because
+#     no manual override existed; this prevents that recurring.
 on:
   workflow_run:
     workflows: [CI]
     types: [completed]
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # workflow_run path: only deploy if CI succeeded.
+    # workflow_dispatch path: always run (operator explicitly chose to deploy).
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     environment: production
     steps:
       - name: Deploy to VPS


### PR DESCRIPTION
## Two small CI/CD hardening changes

### 1. \`ci.yml\`: stop double-triggering CI on PRs

\`on: [push, pull_request]\` runs CI **twice** for every PR commit (once for the push event, once for the pull_request event). Switch to:
\`\`\`yaml
on:
  pull_request:
  push:
    branches: [main]
\`\`\`
Same coverage (PRs tested on every push, main tested on every merge). Half the CI minutes.

### 2. \`deploy.yml\`: add \`workflow_dispatch\` escape hatch

Production was frozen 2026-04-22 14:08 → 23:xx because Deploy gates strictly on \`workflow_run.conclusion == 'success'\` and CI kept failing on flaky webkit tests. **There was no way to manually deploy.** The fix: add \`workflow_dispatch\` so a maintainer can go to Actions → Deploy → "Run workflow" and ship from main when CI is broken on non-app-code issues. The if-conditional accepts either path:

\`\`\`yaml
if: \${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
\`\`\`

Use sparingly — operator owns post-deploy validation when bypassing CI. But better than 9-hour frozen prod.

## Pairs with

- PR #67 (visual-polish skip) — band-aid #1
- PR #68 (auth skip) — band-aid #2
- Issue #69 — proper root-cause fixes