### PR TITLE
fix(tests/e2e): use E2E_USER/E2E_PASS in player-smoke (unblock CI)

### DIFF
--- a/tests/e2e/player-smoke.spec.ts
+++ b/tests/e2e/player-smoke.spec.ts
@@ -12,6 +12,13 @@
  */
 import { test, expect } from "@playwright/test";
 
+// Match auth.spec.ts: fail loud if creds are missing instead of silently
+// falling back to a value that doesn't exist in the seeded CI DB. The prior
+// `?? "admin"` fallback hid a mismatched env-var name (E2E_USERNAME vs
+// E2E_USER) for an unknown duration — login just timed out on /live.
+const E2E_USER = process.env["E2E_USER"];
+const E2E_PASS = process.env["E2E_PASS"];
+
 test.describe.serial("Player smoke (prod)", () => {
   test(
     "login → /live → select channel → video element mounts",
@@ -30,8 +37,8 @@ test.describe.serial("Player smoke (prod)", () => {
         .locator('button[type="submit"]')
         .or(page.getByRole("button", { name: /sign in|log in|login/i }));
 
-      await usernameInput.fill(process.env["E2E_USERNAME"] ?? "admin");
-      await passwordInput.fill(process.env["E2E_PASSWORD"] ?? "admin");
+      await usernameInput.fill(E2E_USER!);
+      await passwordInput.fill(E2E_PASS!);
       await submitButton.click();
 
       // ── 2. Navigate to /live ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `player-smoke.spec.ts` read `E2E_USERNAME`/`E2E_PASSWORD` but CI secrets and every other spec use `E2E_USER`/`E2E_PASS`. The `?? "admin"` fallback silently masked the mismatch.
- Login filled non-existent credentials → never redirected to /live → `waitForURL` timed out × 3 retries × 3 browsers. This was the root cause of CI failures on `0a860ce` after the webkit band-aids (#67, #68) exposed it.
- Dropped the fallback so a missing env var fails loudly, matching `auth.spec.ts` pattern.

## Context

Prod was frozen at `5eebe4d` since 14:12. Manual Deploy fired via the #70 escape hatch is rolling out `0a860ce` now. This PR restores the normal CI → auto-deploy path for future changes.

## Test plan

- [ ] CI green on this PR
- [ ] Player smoke passes on chromium (primary)
- [ ] Merge → auto Deploy fires (no manual dispatch needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)