### PR TITLE
fix(nav): ArrowUp from dock targets active route, not hovered tab

### DIFF
--- a/src/nav/BottomDock.tsx
+++ b/src/nav/BottomDock.tsx
@@ -72,6 +72,7 @@ export function BottomDock({
               key={item.id}
               item={item}
               isActive={activeItem === item.id}
+              activeItem={activeItem}
               onSelect={() => onNavigate(item.id)}
             />
           ))}
@@ -84,10 +85,12 @@ export function BottomDock({
 function DockTab({
   item,
   isActive,
+  activeItem,
   onSelect,
 }: {
   item: (typeof DOCK_ITEMS)[0];
   isActive: boolean;
+  activeItem: DockItem;
   onSelect: () => void;
 }) {
   // Task 2.4: explicit focusKey per tab. Without this, norigin can't uniquely
@@ -101,12 +104,18 @@ function DockTab({
   // feels stuck. Handle ArrowUp explicitly: setFocus to the active route's
   // CONTENT_AREA_* container, which has trackChildren:true so norigin forwards
   // focus into the grid/list instead of staying pinned on the dock.
+  //
+  // 2026-04-23 fix: target CONTENT_AREA_{activeItem}, not {item.id}. When the
+  // user ArrowRight's to hover a different tab WITHOUT pressing Enter, the
+  // hovered tab's route isn't mounted — calling setFocus on an unmounted key
+  // silently fails AND corrupts norigin's focus state (subsequent arrows
+  // stop working). Always target the mounted route's content area.
   const { ref, focused } = useFocusable({
     focusKey: `DOCK_${item.id.toUpperCase()}`,
     onEnterPress: onSelect,
     onArrowPress: (direction) => {
       if (direction === "up") {
-        setFocus(`CONTENT_AREA_${item.id.toUpperCase()}`);
+        setFocus(`CONTENT_AREA_${activeItem.toUpperCase()}`);
         return false; // consume the event — we've handled it
       }
       return true; // let norigin handle left/right/down


### PR DESCRIPTION
## Summary

Pre-existing D-pad bug the user hit while validating Phase 1.

**Scenario:** On /live, press ArrowRight to hover the Movies dock tab (no Enter). Press ArrowUp expecting to enter content. Old code called \`setFocus(\"CONTENT_AREA_MOVIES\")\` — but /movies isn't mounted. Norigin silently fails the setFocus and corrupts its focus state, so every subsequent arrow key does nothing until the user clicks to re-prime.

**Fix:** [src/nav/BottomDock.tsx](src/nav/BottomDock.tsx) — target \`CONTENT_AREA_\${activeItem}\` (current route, always mounted) instead of \`CONTENT_AREA_\${item.id}\` (hovered tab).

**Behavior change:** ArrowUp from any dock tab now enters the current route's content area, regardless of which tab you're hovering. Matches the spec's \"Up from dock → content\" rule (docs/ux/00-ia-navigation.md §2.1).

## Reproduction

Confirmed via Playwright repro against dev server:
- Before fix: Right → Up → activeElement stuck on Movies dock, Left/Right/Down also stuck
- After fix: Right → Up → focus lands on first focusable in current route (LanguageRail on Live/Movies/Series)

## Tests

- Typecheck ✅
- 246 unit tests pass (no new tests — behavior was verified via manual repro; adding a jsdom test would require stubbing norigin enough to see setFocus behavior, which has limited signal)
- Build ✅

## Test plan

- [ ] From /live, ArrowRight to Movies dock → ArrowUp → land on Live's Telugu chip
- [ ] From /movies, ArrowRight to Series dock → ArrowUp → land on Movies' Telugu chip
- [ ] From any route, dock-hover a non-current tab then Up → focus enters current route content (no stuck state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)