### PR TITLE
fix(movies): VirtuosoGrid Item needs a real box to render rows

### DIFF
--- a/src/features/movies/MovieGrid.tsx
+++ b/src/features/movies/MovieGrid.tsx
@@ -52,8 +52,13 @@ const GridList = ({
   />
 );
 
+// Item must be a real layout box so VirtuosoGrid can measure row height.
+// `display: contents` was previously used to let cards flow straight into
+// the parent grid, but it makes the item transparent to layout — Virtuoso's
+// size-observer reads 0 height for every row and freezes after rendering
+// index 0 alone (observed in prod with a 3,706-item Telugu union).
 const GridItem = ({ style, ...rest }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div {...rest} style={{ ...style, display: "contents" }} />
+  <div {...rest} style={style} />
 );
 
 export function MovieGrid({


### PR DESCRIPTION
## Summary

Hotfix on top of #75. In prod the Telugu union returns 3,706 movies but only the first poster rendered — the rest of the viewport was blank.

Root cause: `GridItem` used `display: contents` so the wrapper was transparent to layout. Virtuoso's size observer reads 0 for every row's height and stops windowing after index 0.

Fix: drop the `display: contents`; the Item now has a normal block box so Virtuoso can measure row height and render the correct window of cards.

## Test plan

- [ ] `/movies` with Telugu → see many posters (not just one)
- [ ] Scroll the grid down — new rows keep mounting, focused card stays focused through scroll
- [ ] Other languages (Hindi/English/All) render the full grid
- [ ] ⋯ overflow still positions on the focused card

🤖 Generated with [Claude Code](https://claude.com/claude-code)