### PR TITLE
feat(movies): ResumeHero replaces Continue-watching chip in LanguageRail

### DIFF
--- a/docs/ux/00-ia-navigation.md
+++ b/docs/ux/00-ia-navigation.md
@@ -245,21 +245,29 @@ Every press counts. **Target: hero tasks ≤ 3 inputs from a focused dock.**
 | Cold login → resume mid-watch Telugu series | **4** | ArrowRight×2 · Enter (series card) · Enter (Continue CTA auto-focused) |
 | Browse Hindi movies → play one | **5** | ArrowRight · Enter (Movies) · ArrowUp · ArrowRight (Hindi) · Enter on poster · Enter (one per step — accepted overshoot for non-pref language) |
 | Search "vikram" → play top result | **9** | Dock nav (4) · type 6 letters · Enter (debounce fires, focus top result, Enter) |
-| Resume last watched from anywhere | **3** | Continue-watching chip (leftmost in LanguageRail) · Enter |
+| Resume last watched movie | **2** | ResumeHero on `/movies` auto-focused on cold mount · Enter |
 
 Budgets depend on:
 - Route mount focuses grid row 1, col 1 (§2.2 rule 1)
 - LanguageRail respects `sv_lang_pref` on mount (§4)
 - Series detail auto-focuses Continue/Play CTA (covered in 02-series)
-- A "Continue watching" chip, leftmost in the LanguageRail, appears when `/api/history` is non-empty (see §6.1)
+- On `/movies`, a ResumeHero card above the LanguageRail renders when `/api/history` has a partial-watch VOD; cold mount seeds focus there (see §6.1)
 
 ---
 
 ## 6. Cross-cutting primitives (shared across sibling specs)
 
-### 6.1 Continue-watching chip
+### 6.1 Resume entry point
 
-Leftmost slot in the LanguageRail on `/live`, `/movies`, `/series`. Different visual treatment from language chips (⟲ icon, neutral background). Conditional: only renders when `/api/history` returns ≥1 item. Enter → plays the most recent resume point (respects its kind — Live channel / VOD / series-episode).
+**Updated 2026-04-23 (Phase 2 UX review).** The original design placed a "Continue watching" chip leftmost in the LanguageRail on every surface. User testing in prod revealed a mental-model clash — the chip sat with filter controls but fired a playback action. It has been replaced on `/movies` with a **full-width ResumeHero** above the LanguageRail (`src/features/movies/ResumeHero.tsx`).
+
+ResumeHero:
+- Renders only when `/api/history` has a VOD item with `0 < progress/duration < 0.9`.
+- Label: `▶ Resume <Title> — <N>m left` (title + remaining time, no language label — history endpoint does not carry `inferredLang`).
+- Focus key `RESUME_HERO`. On cold mount with a resume candidate, the route seeds focus here → Enter plays = **2 inputs**. Language change seeds focus to the first poster, not the hero, so browsing does not get hijacked.
+- Cross-language by design: a paused Hindi movie shows on the hero regardless of the current language filter. The title disambiguates what will play.
+
+**Ripple to `/live` and `/series` is pending.** For `/live` the plan is to drop the chip entirely (no resume semantics on live TV) when Phase 3 touches that surface. For `/series` a ResumeHero variant with episode context ("Resume S2E4 of Panchayat — 12m left") is a Phase 4 follow-up. Until those phases land, their specs should not introduce new Continue chips.
 
 ### 6.2 Tier-locked badge
 

--- a/docs/ux/03-movies.md
+++ b/docs/ux/03-movies.md
@@ -43,7 +43,11 @@ Catalog size: **~61k VOD rows.** Virtualization is mandatory.
 │  MOVIES                                                          │  ← route title, 32px
 │                                                                  │
 │  ┌──────────────────────────────────────────────────────────┐   │
-│  │ [⏮ Continue]  [Telugu*]  [Hindi]  [English]  [All]       │   │  ← LanguageRail (§00-ia §4)
+│  │ ▶  Resume Bhediya                           43m left      │   │  ← ResumeHero (§00-ia §6.1, conditional)
+│  └──────────────────────────────────────────────────────────┘   │
+│                                                                  │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │ [Telugu*]  [Hindi]  [English]  [All]                     │   │  ← LanguageRail (§00-ia §4)
 │  └──────────────────────────────────────────────────────────┘   │
 │                                                                  │
 │  ┌──────────────────────────────────────────────────────────┐   │
@@ -67,9 +71,10 @@ Catalog size: **~61k VOD rows.** Virtualization is mandatory.
 ### Zones top-to-bottom
 
 1. **Route title** "MOVIES" (32px, `--type-title-lg`). Scrolls away with content.
-2. **LanguageRail** (sticky? **no** — scrolls with content; re-entering from dock ArrowUp walks back to it). Chips + optional "⏮ Continue" chip (leftmost, conditional on history non-empty).
-3. **Toolbar** (sticky **yes** — thin band). Sort segmented control + result count.
-4. **Poster grid** (6 cols @ 1080p, 5 @ 1600w, 4 @ 1280w, fully virtualized). Card ratio 2:3.
+2. **ResumeHero** (conditional — only when `/api/history` has a partial-watch VOD). Full-width "▶ Resume <Title> — <N>m left" card. See `00-ia §6.1`.
+3. **LanguageRail** (not sticky — scrolls with content). Four chips: Telugu · Hindi · English · All. **No Continue chip on Movies** (moved to the hero above).
+4. **Toolbar** (sticky **yes** — thin band). Sort segmented control + result count.
+5. **Poster grid** (6 cols @ 1920w, 5 @ 1600w, 4 @ 1280w, 3 @ 960w, 2 below; row-chunk virtualized). Card ratio 2:3.
 
 ---
 
@@ -116,7 +121,7 @@ If 0 categories match the language pattern OR all matching categories return emp
 Full spec in `00-ia §4` and `04-search-and-language-rail §A`. On Movies:
 
 - 4 chips: Telugu · Hindi · English · All. **No Sports chip.**
-- Continue-watching chip leftmost when history is non-empty, per `00-ia §6.1`.
+- **No Continue chip on Movies** — replaced by the ResumeHero above the rail (`00-ia §6.1`, updated 2026-04-23).
 - Default on cold mount: `sv_lang_pref` (Telugu out of the box).
 - Change → writes `sv_lang_pref`, re-runs §3 fetch plan, focus returns to grid row 1 col 1.
 

--- a/src/features/movies/ResumeHero.tsx
+++ b/src/features/movies/ResumeHero.tsx
@@ -1,0 +1,117 @@
+/**
+ * ResumeHero — full-width "Resume <Title>" CTA above the LanguageRail.
+ *
+ * Spec: UX-Lead recommendation 2026-04-23 — supersedes the Continue-watching
+ * chip's placement inside the LanguageRail on /movies (00-ia §6.1). Rationale:
+ *   - A resume action belongs in action real estate, not filter real estate.
+ *   - Hero is its own row → chip appearance doesn't mutate rail width mid-row.
+ *   - Cold-open budget drops from 3 inputs (chip → Enter) to 2 (hero → Enter),
+ *     matching the "mount → Enter plays" philosophy for the landing route.
+ *
+ * Ripple to /series and /live is pending Phase 3/4 design — for now the hero
+ * pattern is Movies-only and the chip stays out of the Movies rail.
+ *
+ * Focus: `RESUME_HERO`. On cold mount with a resume candidate, the route
+ * seeds focus here instead of the first poster.
+ */
+import type { RefObject } from "react";
+import { useFocusable } from "@noriginmedia/norigin-spatial-navigation";
+
+export interface ResumeHeroProps {
+  title: string;
+  /** Seconds remaining in the movie (duration − progress). */
+  remainingSeconds: number;
+  onSelect: () => void;
+}
+
+function formatRemaining(seconds: number): string {
+  if (seconds <= 0) return "almost done";
+  if (seconds < 60) return "<1m left";
+  const mins = Math.ceil(seconds / 60);
+  if (mins < 60) return `${mins}m left`;
+  const hours = Math.floor(mins / 60);
+  const rem = mins % 60;
+  return rem === 0 ? `${hours}h left` : `${hours}h ${rem}m left`;
+}
+
+export function ResumeHero({
+  title,
+  remainingSeconds,
+  onSelect,
+}: ResumeHeroProps) {
+  const { ref, focused } = useFocusable<HTMLButtonElement>({
+    focusKey: "RESUME_HERO",
+    onEnterPress: onSelect,
+  });
+
+  return (
+    <div
+      style={{
+        padding: "var(--space-4) var(--space-6) var(--space-2)",
+      }}
+    >
+      <button
+        ref={ref as RefObject<HTMLButtonElement>}
+        type="button"
+        aria-label={`Resume ${title} — ${formatRemaining(remainingSeconds)}`}
+        onClick={onSelect}
+        className="focus-ring"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-4)",
+          width: "100%",
+          padding: "var(--space-4) var(--space-6)",
+          borderRadius: "var(--radius-md, 12px)",
+          border: focused
+            ? "2px solid var(--accent-copper)"
+            : "2px solid rgba(200, 121, 65, 0.35)",
+          background: focused
+            ? "var(--accent-copper)"
+            : "linear-gradient(90deg, rgba(200, 121, 65, 0.22), rgba(200, 121, 65, 0.08))",
+          color: focused ? "var(--bg-base)" : "var(--text-primary)",
+          cursor: "pointer",
+          textAlign: "left",
+          boxShadow: focused
+            ? "0 0 0 2px var(--accent-copper), 0 12px 40px -12px rgba(200, 121, 65, 0.6)"
+            : "0 4px 16px rgba(0, 0, 0, 0.35)",
+          transition:
+            "background var(--motion-focus), color var(--motion-focus), border-color var(--motion-focus), box-shadow var(--motion-focus)",
+        }}
+      >
+        <span
+          aria-hidden="true"
+          style={{
+            fontSize: 28,
+            lineHeight: 1,
+            flexShrink: 0,
+          }}
+        >
+          ▶
+        </span>
+        <span
+          style={{
+            flex: 1,
+            fontSize: "var(--type-body-lg, 18px)",
+            fontWeight: 600,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          Resume {title}
+        </span>
+        <span
+          style={{
+            flexShrink: 0,
+            fontSize: "var(--text-body-size)",
+            opacity: focused ? 0.85 : 0.7,
+            fontVariantNumeric: "tabular-nums",
+          }}
+        >
+          {formatRemaining(remainingSeconds)}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/src/routes/MoviesRoute.tsx
+++ b/src/routes/MoviesRoute.tsx
@@ -5,9 +5,10 @@
  *
  * Layout:
  *   Title "MOVIES"
- *   LanguageRail (4 chips — no Sports)  ← optional Continue-watching chip leftmost
+ *   ResumeHero (conditional — only when /api/history has a partial VOD)
+ *   LanguageRail (4 chips — no Sports; no Continue chip on Movies)
  *   Toolbar: sort segmented control + count (sticky)
- *   MovieGrid (VirtuosoGrid) / EmptyStateWithLanguageSwitch
+ *   MovieGrid / EmptyStateWithLanguageSwitch
  *   MovieDetailSheet overlay (opens via ⋯ → More info)
  *
  * Category fetch strategy: we no longer show a CategoryStrip. Instead we
@@ -15,6 +16,11 @@
  * "client-side language union"). Each language swap re-runs the union and
  * focus seeds to row 0 col 0. Sort flips re-order in place and never pull
  * focus.
+ *
+ * Focus seeding rules:
+ *   - Cold mount + resume candidate → focus lands on ResumeHero
+ *   - Cold mount + no resume → focus lands on first poster
+ *   - Language change → focus lands on first poster (resume doesn't grab)
  *
  * MUST PRESERVE: CONTENT_AREA_MOVIES focus key + FocusContext — load-bearing
  * for BottomDock's setFocus("CONTENT_AREA_MOVIES") on ArrowUp (Task 2.4).
@@ -28,6 +34,7 @@ import {
 } from "@noriginmedia/norigin-spatial-navigation";
 import { MovieGrid } from "../features/movies/MovieGrid";
 import { MovieDetailSheet } from "../features/movies/MovieDetailSheet";
+import { ResumeHero } from "../features/movies/ResumeHero";
 import {
   fetchLanguageUnion,
   invalidateLanguageUnionCache,
@@ -197,9 +204,11 @@ export function MoviesRoute() {
     [],
   );
 
-  // ─── Continue-watching chip data ──────────────────────────────────────────
-  // Show the chip when at least one VOD history item has partial progress.
-  // Selecting the chip resumes the most recent partial-watch movie.
+  // ─── Resume candidate — drives the ResumeHero above the LanguageRail ─────
+  // Most recent VOD history entry whose progress sits between 0 and the
+  // watched threshold. Cross-language by design: a user who paused Bhediya
+  // (Hindi) should still see "Resume Bhediya" when they land on /movies,
+  // regardless of the current language filter.
   const resumeCandidate = useMemo<HistoryItem | null>(() => {
     for (const h of history) {
       if (h.content_type !== "vod") continue;
@@ -219,18 +228,30 @@ export function MoviesRoute() {
     });
   }, [resumeCandidate, openPlayer]);
 
-  // ─── Focus seeding — first card on lang change / initial mount ───────────
-  // Only fires when the language actually changes, so sort flips don't steal
-  // focus. A timeout lets VirtuosoGrid render the first card before setFocus.
+  // ─── Focus seeding ────────────────────────────────────────────────────────
+  // Cold mount seeds to the hero when a resume candidate exists (2-input
+  // resume path), else to the first poster (2-input play path). Language
+  // change always seeds to the first poster — the user is actively browsing,
+  // so resume should not pull focus back.
   const lastSeededLangRef = useRef<LangId | null>(null);
+  const didInitialSeedRef = useRef<boolean>(false);
   useEffect(() => {
     if (sortedStreams.length === 0) return;
-    if (lastSeededLangRef.current === lang) return;
+    const langChanged = lastSeededLangRef.current !== lang;
+    const isInitialSeed = !didInitialSeedRef.current;
+    if (!langChanged && !isInitialSeed) return;
+
     lastSeededLangRef.current = lang;
-    const firstId = sortedStreams[0]!.id;
-    const t = setTimeout(() => setFocus(`VOD_CARD_${firstId}`), 0);
+    didInitialSeedRef.current = true;
+
+    // Initial mount + resume available → seed hero. Otherwise seed first card.
+    const target =
+      isInitialSeed && resumeCandidate
+        ? "RESUME_HERO"
+        : `VOD_CARD_${sortedStreams[0]!.id}`;
+    const t = setTimeout(() => setFocus(target), 0);
     return () => clearTimeout(t);
-  }, [lang, sortedStreams]);
+  }, [lang, sortedStreams, resumeCandidate]);
 
   // ─── Handlers ─────────────────────────────────────────────────────────────
   const handleSelect = useCallback(
@@ -297,13 +318,18 @@ export function MoviesRoute() {
           />
         ) : (
           <>
-            <LanguageRail
-              value={lang}
-              onChange={setLang}
-              {...(resumeCandidate
-                ? { continueWatching: { onSelect: handleResume } }
-                : {})}
-            />
+            {resumeCandidate ? (
+              <ResumeHero
+                title={resumeCandidate.content_name ?? "your movie"}
+                remainingSeconds={
+                  resumeCandidate.duration_seconds -
+                  resumeCandidate.progress_seconds
+                }
+                onSelect={handleResume}
+              />
+            ) : null}
+
+            <LanguageRail value={lang} onChange={setLang} />
 
             <div
               role="toolbar"


### PR DESCRIPTION
## Summary

Follow-up on #75/#77 Phase 2 Movies rebuild. User tested Continue-watching in prod and flagged the chip placement as wrong — it sat with language filter chips but fired a playback action (mental-model clash).

UX Lead reviewed and recommended: **full-width ResumeHero above the LanguageRail on /movies**.

- Conditional: renders only when `/api/history` has a partial-watch VOD (`0 < progress/duration < 0.9`).
- Label: `▶ Resume <Title> — <N>m left`. Title answers "what will play?" — solves the original confusion.
- Focus key `RESUME_HERO`. Cold mount seeds focus here → Enter plays = **2 inputs** (was 3 via chip).
- Language change seeds focus to the first poster, not the hero — browsing isn't hijacked by resume.
- Cross-language by design: a paused Hindi movie shows on the hero regardless of current language filter (the title disambiguates).

## Ripple plan (not in this PR)

- `/live` — drop Continue entirely in Phase 3. No resume semantics on live TV.
- `/series` — hero variant with episode context (`Resume S2E4 of Panchayat — 12m left`) is a Phase 4 follow-up.
- LanguageRail's `continueWatching` prop stays in the component for now (unused on Movies); Phase 3/4 will decide whether to delete it.

## Spec updates

- `docs/ux/00-ia-navigation.md` §6.1 rewritten — chip deprecated on Movies, hero documented, Phase 3/4 plan noted. Click-budget table: "Resume last watched movie" drops 3 → 2.
- `docs/ux/03-movies.md` §2 and §4 updated — hero zone added, Continue chip removed from the Movies rail.

## Checks

- 260/260 tests pass
- Typecheck clean
- Lint clean

## Test plan

- [ ] Fresh mount `/movies` with partial-watch history → hero shows with title + minutes left, focus is on hero
- [ ] Press Enter on hero → movie plays from resume point
- [ ] Press Down from hero → focus walks to LanguageRail → Toolbar → grid
- [ ] Fresh mount with no history → no hero, focus lands on first poster (budget = 2 inputs to play)
- [ ] Switch language → focus jumps to first poster, not hero (even if hero is visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)