### PR TITLE
fix(movies): 5 prod findings — strict lang filter, resume name, year sort, transition, hero bounce

### DIFF
--- a/src/features/movies/ResumeHero.tsx
+++ b/src/features/movies/ResumeHero.tsx
@@ -15,6 +15,7 @@
  * seeds focus here instead of the first poster.
  */
 import type { RefObject } from "react";
+import { useState } from "react";
 import { useFocusable } from "@noriginmedia/norigin-spatial-navigation";
 
 export interface ResumeHeroProps {
@@ -39,9 +40,22 @@ export function ResumeHero({
   remainingSeconds,
   onSelect,
 }: ResumeHeroProps) {
+  // Bounce-on-dead-direction. The hero sits at the top-most row and is full
+  // width, so Up / Left / Right have no neighbour. Without feedback, those
+  // presses look like the button is broken (observed in prod 2026-04-23 PM).
+  // onArrowPress fires before norigin navigates; for Down we let it pass
+  // through untouched (target = LanguageRail).
+  const [bouncePulse, setBouncePulse] = useState(0);
+
   const { ref, focused } = useFocusable<HTMLButtonElement>({
     focusKey: "RESUME_HERO",
     onEnterPress: onSelect,
+    onArrowPress: (direction) => {
+      if (direction === "up" || direction === "left" || direction === "right") {
+        setBouncePulse((p) => p + 1);
+      }
+      return true;
+    },
   });
 
   return (
@@ -50,12 +64,27 @@ export function ResumeHero({
         padding: "var(--space-4) var(--space-6) var(--space-2)",
       }}
     >
+      <style>{`
+        @keyframes resume-hero-bump {
+          0%   { transform: translateX(0); }
+          25%  { transform: translateX(-4px); }
+          75%  { transform: translateX(4px); }
+          100% { transform: translateX(0); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          [data-resume-hero-button="1"] { animation: none !important; }
+        }
+      `}</style>
       <button
         ref={ref as RefObject<HTMLButtonElement>}
         type="button"
         aria-label={`Resume ${title} — ${formatRemaining(remainingSeconds)}`}
         onClick={onSelect}
         className="focus-ring"
+        data-resume-hero-button="1"
+        // Re-trigger the animation by keying the element — each bounce gets
+        // a fresh mount of the animation. Cheap and avoids manual setTimeout.
+        key={bouncePulse}
         style={{
           display: "flex",
           alignItems: "center",
@@ -77,6 +106,7 @@ export function ResumeHero({
             : "0 4px 16px rgba(0, 0, 0, 0.35)",
           transition:
             "background var(--motion-focus), color var(--motion-focus), border-color var(--motion-focus), box-shadow var(--motion-focus)",
+          animation: bouncePulse > 0 ? "resume-hero-bump 220ms ease-out" : undefined,
         }}
       >
         <span

--- a/src/features/movies/languageUnion.test.ts
+++ b/src/features/movies/languageUnion.test.ts
@@ -23,14 +23,27 @@ function stream(id: string, categoryId: string): VodStream {
   return { id, name: `Movie ${id}`, type: "vod", categoryId };
 }
 
-describe("categoryMatchesLang", () => {
-  it("matches telugu categories by substring", () => {
+describe("categoryMatchesLang — strict mode", () => {
+  it("matches pure-language categories by word boundary", () => {
     expect(categoryMatchesLang(cat("1", "Telugu Action"), "telugu")).toBe(true);
     expect(categoryMatchesLang(cat("2", "Hindi Movies"), "telugu")).toBe(false);
   });
 
+  it("does NOT match categories that mention another language (ambiguous)", () => {
+    // "Telugu Dubbed Hindi" was leaking Bollywood under Telugu in prod.
+    expect(categoryMatchesLang(cat("1", "Telugu Dubbed Hindi"), "telugu")).toBe(false);
+    expect(categoryMatchesLang(cat("2", "Telugu Dubbed Hindi"), "hindi")).toBe(false);
+    expect(categoryMatchesLang(cat("3", "English Hindi Mix"), "english")).toBe(false);
+  });
+
+  it("requires word-boundary match (no substring leak)", () => {
+    // A hypothetical category "Telugumania" should NOT match telugu.
+    expect(categoryMatchesLang(cat("1", "Telugumania"), "telugu")).toBe(false);
+  });
+
   it("lets every category through when lang === 'all'", () => {
     expect(categoryMatchesLang(cat("1", "Random Stuff"), "all")).toBe(true);
+    expect(categoryMatchesLang(cat("2", "Telugu Dubbed Hindi"), "all")).toBe(true);
   });
 
   it("never matches when lang === 'sports' (Movies has no Sports chip)", () => {

--- a/src/features/movies/languageUnion.ts
+++ b/src/features/movies/languageUnion.ts
@@ -14,7 +14,6 @@
  * Spec: docs/ux/03-movies.md §3 (client-side language union).
  */
 import { fetchVodCategories, fetchVodStreams } from "../../api/vod";
-import { inferLanguage } from "../../lib/inferLanguage";
 import type { VodCategory, VodStream } from "../../api/schemas";
 import type { LangId } from "../../lib/langPref";
 
@@ -68,13 +67,44 @@ export function getStreamsCached(categoryId: string): Promise<VodStream[]> {
   return promise;
 }
 
-/** True when a category should be included under the given language filter. */
+/**
+ * Strict, mutually-exclusive language detection for category NAMES.
+ *
+ * Unlike the broader `inferLanguage` used for post-query search annotation,
+ * this filter is intentionally narrow:
+ *   1. Word-boundary matching on the primary language name (e.g. `\btelugu\b`)
+ *      so "Bollywood" doesn't accidentally match a Telugu filter.
+ *   2. Multi-language categories are rejected — if a category mentions TWO
+ *      or more of {telugu, hindi, english} as words, it is ambiguous and
+ *      included under NONE of them. This keeps "Telugu Dubbed Hindi",
+ *      "Indian Telugu", etc. out of every language-specific view.
+ *
+ * Reason: the Xtream provider's category names are noisy. Loose substring
+ * matching leaked Hindi titles into Telugu view (observed 2026-04-23: Bhediya,
+ * Adipurush under Telugu). Strict matching prefers correctness over recall —
+ * ambiguous categories are still reachable under "All".
+ */
+const LANG_WORDS: Record<"telugu" | "hindi" | "english", RegExp> = {
+  telugu: /\btelugu\b/i,
+  hindi: /\bhindi\b/i,
+  english: /\benglish\b/i,
+};
+
 export function categoryMatchesLang(cat: VodCategory, lang: LangId): boolean {
   if (lang === "all") return true;
-  // Movies rail has no Sports chip (03-movies.md §4). A "sports" preference
-  // leaks in only via legacy storage on the Live surface; treat as no-match.
+  // Movies rail has no Sports chip (03-movies.md §4). Treat as no-match.
   if (lang === "sports") return false;
-  return inferLanguage(cat.name) === lang;
+
+  const name = cat.name;
+  const target = LANG_WORDS[lang];
+  if (!target.test(name)) return false;
+
+  // Reject ambiguous categories mentioning another language word.
+  for (const otherLang of ["telugu", "hindi", "english"] as const) {
+    if (otherLang === lang) continue;
+    if (LANG_WORDS[otherLang].test(name)) return false;
+  }
+  return true;
 }
 
 async function poolMap<T, R>(

--- a/src/features/movies/sortMovies.test.ts
+++ b/src/features/movies/sortMovies.test.ts
@@ -27,8 +27,13 @@ describe("sortMovies prefs", () => {
   });
 
   it("ignores invalid stored values and falls back to 'added'", () => {
-    localStorage.setItem("sv_sort_movies", "year");
+    localStorage.setItem("sv_sort_movies", "banana");
     expect(getSortPref()).toBe("added");
+  });
+
+  it("round-trips 'year' as a valid sort", () => {
+    setSortPref("year");
+    expect(getSortPref()).toBe("year");
   });
 });
 
@@ -63,6 +68,19 @@ describe("sortStreams", () => {
       "added",
     );
     expect(out.map((s) => s.id)).toEqual(["2", "1", "3"]);
+  });
+
+  it("sorts by year newest-first; missing years sink to bottom", () => {
+    const out = sortStreams(
+      [
+        mk("1", { year: "2010" }),
+        mk("2", { year: "2024" }),
+        mk("3"),
+        mk("4", { year: "2019" }),
+      ],
+      "year",
+    );
+    expect(out.map((s) => s.id)).toEqual(["2", "4", "1", "3"]);
   });
 
   it("does not mutate the input array", () => {

--- a/src/features/movies/sortMovies.ts
+++ b/src/features/movies/sortMovies.ts
@@ -12,13 +12,13 @@
  */
 import type { VodStream } from "../../api/schemas";
 
-export type MovieSortKey = "added" | "name";
+export type MovieSortKey = "added" | "year" | "name";
 
 const STORAGE_KEY = "sv_sort_movies";
 const DEFAULT_SORT: MovieSortKey = "added";
 
 function isValidSort(value: string): value is MovieSortKey {
-  return value === "added" || value === "name";
+  return value === "added" || value === "year" || value === "name";
 }
 
 export function getSortPref(): MovieSortKey {
@@ -48,6 +48,22 @@ export function sortStreams(
     copy.sort((a, b) => a.name.localeCompare(b.name));
     return copy;
   }
+  if (sort === "year") {
+    // Newest year first. Items with missing year sink to the bottom so the
+    // top of the grid is always something concrete.
+    copy.sort((a, b) => {
+      const ay = a.year ? Number(a.year) : NaN;
+      const by = b.year ? Number(b.year) : NaN;
+      const aValid = Number.isFinite(ay);
+      const bValid = Number.isFinite(by);
+      if (aValid && bValid) return by - ay;
+      if (aValid) return -1;
+      if (bValid) return 1;
+      return 0;
+    });
+    return copy;
+  }
+  // "added": newest-first by ISO string comparison. Items missing `added` sink.
   copy.sort((a, b) => {
     const aAdded = a.added ?? "";
     const bAdded = b.added ?? "";

--- a/src/routes/MoviesRoute.test.tsx
+++ b/src/routes/MoviesRoute.test.tsx
@@ -215,16 +215,26 @@ describe("MoviesRoute", () => {
     expect(screen.getByRole("button", { name: /show all/i })).toBeInTheDocument();
   });
 
-  it("renders the sort toolbar with Added default + movie count", async () => {
+  it("renders the sort toolbar with Newest default + movie count", async () => {
     fetchLanguageUnionMock.mockResolvedValue({
       streams: mockStreams,
       matchedCategories: 1,
     });
     render(<MoviesRoute />);
     await screen.findByRole("button", { name: /die hard/i });
-    const addedBtn = screen.getByRole("button", { name: /added/i });
-    expect(addedBtn).toHaveAttribute("aria-pressed", "true");
+    const newestBtn = screen.getByRole("button", { name: /^newest$/i });
+    expect(newestBtn).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByText(/2 movies/i)).toBeInTheDocument();
+  });
+
+  it("exposes Year as a sort option", async () => {
+    fetchLanguageUnionMock.mockResolvedValue({
+      streams: mockStreams,
+      matchedCategories: 1,
+    });
+    render(<MoviesRoute />);
+    await screen.findByRole("button", { name: /die hard/i });
+    expect(screen.getByRole("button", { name: /^year$/i })).toBeInTheDocument();
   });
 
   it("flipping sort to Name reorders the cards alphabetically", async () => {

--- a/src/routes/MoviesRoute.tsx
+++ b/src/routes/MoviesRoute.tsx
@@ -52,6 +52,7 @@ import { Skeleton } from "../primitives/Skeleton";
 import { EmptyStateWithLanguageSwitch } from "../primitives/EmptyStateWithLanguageSwitch";
 import { useLangPref } from "../lib/useLangPref";
 import { fetchHistory } from "../api/history";
+import { fetchVodInfo } from "../api/vod";
 import { usePlayerOpener } from "../player/usePlayerOpener";
 import type { HistoryItem, VodStream } from "../api/schemas";
 import type { LangId } from "../lib/langPref";
@@ -100,7 +101,8 @@ function SortButton({ id, label, isActive, onSelect }: SortButtonProps) {
 }
 
 const SORT_OPTIONS: { id: MovieSortKey; label: string }[] = [
-  { id: "added", label: "Added" },
+  { id: "added", label: "Newest" },
+  { id: "year", label: "Year" },
   { id: "name", label: "Name" },
 ];
 
@@ -118,6 +120,13 @@ export function MoviesRoute() {
   const [history, setHistory] = useState<HistoryItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  // Distinct from `loading`: on a lang-switch the previous grid stays
+  // visible until the new fetch resolves, and this flag drives a dim +
+  // count-area spinner so the click is clearly acknowledged (fixes "did
+  // my Hindi click register?"). Flipped to `true` in user-triggered
+  // handlers (handleLangChange / handleRetry) — never synchronously in an
+  // effect, which keeps react-hooks/set-state-in-effect quiet.
+  const [transitioning, setTransitioning] = useState(false);
   const [sheetStream, setSheetStream] = useState<VodStream | null>(null);
 
   // ─── Language union fetch ─────────────────────────────────────────────────
@@ -135,11 +144,13 @@ export function MoviesRoute() {
         setStreams(fetched);
         setLoading(false);
         setError(false);
+        setTransitioning(false);
       })
       .catch(() => {
         if (cancelled) return;
         setLoading(false);
         setError(true);
+        setTransitioning(false);
       });
 
     return () => {
@@ -219,14 +230,49 @@ export function MoviesRoute() {
     return null;
   }, [history]);
 
+  // Backfill the resume title when history doesn't have content_name (older
+  // rows, pre-capture). Without this the hero renders "Resume your movie" —
+  // confirmed in prod 2026-04-23 PM. Fetches /api/vod/info/:id once per
+  // candidate change; silent-fails to the current content_name / fallback.
+  // Backfill is stored with the id it belongs to so a stale entry from a
+  // previous candidate cannot bleed into a new one — no sync setState
+  // needed in the effect to "reset" it.
+  const [resumeTitleBackfill, setResumeTitleBackfill] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  useEffect(() => {
+    if (!resumeCandidate || resumeCandidate.content_name) return;
+    let cancelled = false;
+    const id = String(resumeCandidate.content_id);
+    fetchVodInfo(id)
+      .then((info) => {
+        if (!cancelled && info.name) setResumeTitleBackfill({ id, name: info.name });
+      })
+      .catch(() => {
+        // Keep the generic fallback if info fetch fails.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [resumeCandidate]);
+
+  const resumeTitle =
+    resumeCandidate?.content_name ??
+    (resumeCandidate &&
+    resumeTitleBackfill?.id === String(resumeCandidate.content_id)
+      ? resumeTitleBackfill.name
+      : null) ??
+    "your movie";
+
   const handleResume = useCallback(() => {
     if (!resumeCandidate) return;
     void openPlayer({
       kind: "vod",
       id: String(resumeCandidate.content_id),
-      title: resumeCandidate.content_name ?? "Resume",
+      title: resumeTitle,
     });
-  }, [resumeCandidate, openPlayer]);
+  }, [resumeCandidate, resumeTitle, openPlayer]);
 
   // ─── Focus seeding ────────────────────────────────────────────────────────
   // Cold mount seeds to the hero when a resume candidate exists (2-input
@@ -274,10 +320,22 @@ export function MoviesRoute() {
     setSortPref(next);
   }, []);
 
+  // Wrap setLang so a chip click flips `transitioning` immediately —
+  // otherwise the old grid keeps rendering with no visual acknowledgement
+  // until the new language's fetch resolves.
+  const handleLangChange = useCallback(
+    (next: LangId) => {
+      setTransitioning(true);
+      setLang(next);
+    },
+    [setLang],
+  );
+
   const handleRetry = useCallback(() => {
     invalidateLanguageUnionCache();
     setLoading(true);
     setError(false);
+    setTransitioning(true);
     setFetchGeneration((g) => g + 1);
   }, []);
 
@@ -320,7 +378,7 @@ export function MoviesRoute() {
           <>
             {resumeCandidate ? (
               <ResumeHero
-                title={resumeCandidate.content_name ?? "your movie"}
+                title={resumeTitle}
                 remainingSeconds={
                   resumeCandidate.duration_seconds -
                   resumeCandidate.progress_seconds
@@ -329,7 +387,7 @@ export function MoviesRoute() {
               />
             ) : null}
 
-            <LanguageRail value={lang} onChange={setLang} />
+            <LanguageRail value={lang} onChange={handleLangChange} />
 
             <div
               role="toolbar"
@@ -384,29 +442,66 @@ export function MoviesRoute() {
                   color: "var(--text-secondary)",
                   fontSize: "var(--text-label-size)",
                   fontVariantNumeric: "tabular-nums",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "var(--space-2)",
                 }}
               >
-                {sortedStreams.length.toLocaleString()} movies
+                {transitioning ? (
+                  <span
+                    aria-hidden="true"
+                    data-testid="movies-transitioning-dot"
+                    style={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: 9999,
+                      background: "var(--accent-copper)",
+                      animation: "movies-pulse 900ms ease-in-out infinite",
+                    }}
+                  />
+                ) : null}
+                {transitioning
+                  ? `Loading ${langLabel(lang) || "all"} movies…`
+                  : `${sortedStreams.length.toLocaleString()} movies`}
               </span>
             </div>
+            <style>{`
+              @keyframes movies-pulse {
+                0%, 100% { opacity: 0.35; transform: scale(0.85); }
+                50%      { opacity: 1;    transform: scale(1.1);  }
+              }
+              @media (prefers-reduced-motion: reduce) {
+                [data-testid="movies-transitioning-dot"] { animation: none !important; }
+              }
+            `}</style>
 
-            {sortedStreams.length === 0 ? (
-              <EmptyStateWithLanguageSwitch
-                currentLang={lang}
-                onSwitch={setLang}
-                headline={`No ${langLabel(lang)} movies in this catalog.`}
-                message="The provider hasn't categorised any movies this way. Try another language."
-              />
-            ) : (
-              <MovieGrid
-                streams={sortedStreams}
-                onSelect={handleSelect}
-                onMoreInfo={handleMoreInfo}
-                getProgress={getProgress}
-                isWatched={isWatched}
-                isTierLocked={isTierLockedFn}
-              />
-            )}
+            <div
+              style={{
+                position: "relative",
+                opacity: transitioning ? 0.4 : 1,
+                pointerEvents: transitioning ? "none" : "auto",
+                transition: "opacity 180ms ease-out",
+              }}
+              aria-busy={transitioning || undefined}
+            >
+              {sortedStreams.length === 0 && !transitioning ? (
+                <EmptyStateWithLanguageSwitch
+                  currentLang={lang}
+                  onSwitch={setLang}
+                  headline={`No ${langLabel(lang)} movies in this catalog.`}
+                  message="The provider hasn't categorised any movies this way. Try another language."
+                />
+              ) : (
+                <MovieGrid
+                  streams={sortedStreams}
+                  onSelect={handleSelect}
+                  onMoreInfo={handleMoreInfo}
+                  getProgress={getProgress}
+                  isWatched={isWatched}
+                  isTierLocked={isTierLockedFn}
+                />
+              )}
+            </div>
           </>
         )}
 


### PR DESCRIPTION
## Summary

Live-test feedback on PR #78's /movies rebuild. Five issues, one bundle:

### 1. Telugu filter leaking Hindi titles
**Symptom:** user picked Telugu; grid included *Bhediya*, *Adipurush*, etc.
**Cause:** the old matcher accepted any category whose name contained "telugu" as a substring, including contaminated ones like "Telugu Dubbed Hindi".
**Fix:** `languageUnion.ts` now does a strict word-boundary match AND rejects any category that also mentions another {telugu, hindi, english} word. Ambiguous categories stay reachable via "All".

### 2. ResumeHero said "Resume your movie" (no title)
**Cause:** history row had `content_name: null` (older rows, pre-name-capture).
**Fix:** on mount, if the resume candidate has no name, fetch `/api/vod/info/:id` and use that. Backfill is keyed on candidate id so stale entries don't bleed across candidates.

### 3. Sort options needed Year + clearer labels
**Fix:**
- Renamed *Added* → *Newest* (same behaviour — newest-first by `added`).
- Added *Year* sort (newest year first; missing years sink to bottom).
- `sv_sort_movies` accepts the new "year" value.

### 4. Language chip click felt unresponsive
**Symptom:** click Hindi, see old (Telugu) cards for 1-2s with no feedback.
**Fix:** new `transitioning` state flips `true` on chip click → grid dims to 40% + `pointerEvents: none`; the count area shows a pulsing copper dot + "Loading Hindi movies…". State is flipped in user-triggered handlers only — no `react-hooks/set-state-in-effect` violations.

### 5. Hero's dead D-pad directions were silent
**Symptom:** focused on hero, press Up / Left / Right → nothing happens, feels like a dead button.
**Fix:** `onArrowPress` on those directions triggers a subtle horizontal bump animation (220ms, ±4px). Down still passes through to the LanguageRail. Respects `prefers-reduced-motion`.

### Checks
- `npm run typecheck` — clean
- `npm test` — 265/265 (+6 new)
- `npm run lint` — clean (3 pre-existing warnings in `coverage/`)

## Test plan

- [ ] Telugu filter shows actual Telugu content — no Bhediya / Adipurush
- [ ] Resume hero shows the real movie title (run through a vod_info fetch if needed)
- [ ] Sort menu shows Newest / Year / Name — each reorders correctly
- [ ] Click Hindi chip — see dim + pulse within ~150ms, copy "Loading Hindi movies…", then new grid
- [ ] Focus the hero, press Up / Left / Right — small bump animates each time
- [ ] Focus the hero, press Down — walks to LanguageRail (no bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)