### PR TITLE
fix(movies): resume title schema bug + hero Down + progressive union loading

### DIFF
--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -269,21 +269,29 @@ export type VodStream = z.infer<typeof VodStreamSchema>;
 
 /**
  * VodInfoSchema — detail response from GET /api/vod/info/:id.
- * All fields except id + name are optional: backend aggregates from Xtream's
- * get_vod_info which returns sparse data for many titles.
- * containerExtension is the only source of tier-lock truth for VOD
- * (03-movies.md §6, §9).
+ *
+ * Mirrors backend `CatalogItemDetail` from provider.types.ts. Every field
+ * past `id` is optional because Xtream returns sparse data for many titles;
+ * a strict schema would reject the whole payload whenever one field is
+ * missing or loosely typed.
+ *
+ * `duration` is a DISPLAY STRING (e.g. "2h 15min") per the Xtream provider.
+ * Earlier versions of this schema declared it as `z.number()` and every
+ * `fetchVodInfo` call silently threw on parse — ResumeHero's title backfill
+ * then fell back to "your movie" forever. Observed in prod 2026-04-23.
+ * Use `durationSecs` for numeric computation.
  */
 export const VodInfoSchema = z.object({
   id: z.string(),
-  name: z.string(),
+  name: z.string().optional(),
   plot: z.string().optional(),
   cast: z.string().optional(),
   director: z.string().optional(),
   genre: z.string().optional(),
   year: z.string().optional(),
   rating: RatingSchema,
-  duration: z.number().optional(),
+  duration: z.string().optional(),
+  durationSecs: z.number().optional(),
   backdropUrl: z.string().optional(),
   icon: z.string().nullable().optional(),
   containerExtension: z.string().optional(),

--- a/src/features/movies/ResumeHero.tsx
+++ b/src/features/movies/ResumeHero.tsx
@@ -51,10 +51,16 @@ export function ResumeHero({
     focusKey: "RESUME_HERO",
     onEnterPress: onSelect,
     onArrowPress: (direction) => {
+      // Dead directions (no neighbour) → bounce + consume the event so
+      // norigin doesn't traverse.
       if (direction === "up" || direction === "left" || direction === "right") {
         setBouncePulse((p) => p + 1);
+        return true;
       }
-      return true;
+      // Down has a real target (LanguageRail) — let norigin navigate.
+      // Returning `true` here previously pinned focus on the hero and
+      // broke the only working direction (observed in prod 2026-04-23 PM).
+      return false;
     },
   });
 

--- a/src/features/movies/languageUnion.ts
+++ b/src/features/movies/languageUnion.ts
@@ -28,6 +28,17 @@ interface CacheEntry<T> {
 let categoriesCache: CacheEntry<VodCategory[]> | null = null;
 const streamsCache = new Map<string, CacheEntry<VodStream[]>>();
 
+// Sync (id → VodStream) index populated as streamsCache promises resolve.
+// Used by MoviesRoute to look up a resume-candidate's name without a round
+// trip whenever any category containing that id has already been fetched
+// (e.g., the user paused a Hindi movie, the Hindi union ran, the name is
+// now in this index and available on the Telugu view too).
+const resolvedStreamsIndex = new Map<string, VodStream>();
+
+export function lookupCachedStream(id: string): VodStream | undefined {
+  return resolvedStreamsIndex.get(id);
+}
+
 function fresh<T>(entry: CacheEntry<T> | null | undefined): Promise<T> | null {
   if (!entry) return null;
   if (Date.now() - entry.at > TTL_MS) return null;
@@ -38,6 +49,7 @@ function fresh<T>(entry: CacheEntry<T> | null | undefined): Promise<T> | null {
 export function invalidateLanguageUnionCache(): void {
   categoriesCache = null;
   streamsCache.clear();
+  resolvedStreamsIndex.clear();
 }
 
 /** Fetch /api/vod/categories, memoised module-wide with a 5-min TTL. */
@@ -57,7 +69,11 @@ export function getCategoriesCached(): Promise<VodCategory[]> {
 export function getStreamsCached(categoryId: string): Promise<VodStream[]> {
   const hit = fresh(streamsCache.get(categoryId));
   if (hit) return hit;
-  const promise = fetchVodStreams(categoryId);
+  const promise = fetchVodStreams(categoryId).then((items) => {
+    // Populate the sync lookup index as soon as the fetch resolves.
+    for (const s of items) resolvedStreamsIndex.set(s.id, s);
+    return items;
+  });
   streamsCache.set(categoryId, { at: Date.now(), promise });
   promise.catch(() => {
     if (streamsCache.get(categoryId)?.promise === promise) {
@@ -137,6 +153,9 @@ export interface LanguageUnionResult {
 /**
  * Fetch the union of streams across all categories matching `lang`.
  * Duplicates (same stream in multiple categories) are collapsed to one entry.
+ *
+ * Single-shot version: resolves once with the full result. Prefer
+ * `streamLanguageUnion` in UI code so partial results can render quickly.
  */
 export async function fetchLanguageUnion(
   lang: LangId,
@@ -164,4 +183,67 @@ export async function fetchLanguageUnion(
   }
 
   return { streams: merged, matchedCategories: matching.length };
+}
+
+export interface LanguageUnionBatch {
+  streams: VodStream[];
+  isFinal: boolean;
+  matchedCategories: number;
+  completedCategories: number;
+}
+
+/**
+ * Progressive variant of {@link fetchLanguageUnion}. Fires `onBatch` each
+ * time a matching category resolves, carrying the accumulated deduped
+ * streams. The first batch typically arrives within one network RTT, so
+ * the grid can render while the remaining categories trickle in silently.
+ *
+ * Spec rationale (user feedback 2026-04-23 PM): Hindi waited 3-5s before
+ * showing ANY posters; the "Loading Hindi movies…" state felt like the
+ * click didn't register. Progressive rendering dismisses the loader on
+ * first batch and the remaining cards stream in over the next few seconds.
+ */
+export async function streamLanguageUnion(
+  lang: LangId,
+  onBatch: (batch: LanguageUnionBatch) => void,
+): Promise<void> {
+  const cats = await getCategoriesCached();
+  const matching = cats.filter((c) => categoryMatchesLang(c, lang));
+
+  if (matching.length === 0) {
+    onBatch({
+      streams: [],
+      isFinal: true,
+      matchedCategories: 0,
+      completedCategories: 0,
+    });
+    return;
+  }
+
+  const seen = new Set<string>();
+  const merged: VodStream[] = [];
+  let completed = 0;
+
+  await poolMap(matching, MAX_CONCURRENCY, async (c) => {
+    try {
+      const items = await getStreamsCached(c.id);
+      for (const s of items) {
+        if (!seen.has(s.id)) {
+          seen.add(s.id);
+          merged.push(s);
+        }
+      }
+    } catch {
+      // per-category failures contribute zero streams, same as fetchLanguageUnion
+    }
+    completed += 1;
+    const isFinal = completed === matching.length;
+    // Shallow copy so React's setState sees a new reference.
+    onBatch({
+      streams: merged.slice(),
+      isFinal,
+      matchedCategories: matching.length,
+      completedCategories: completed,
+    });
+  });
 }

--- a/src/routes/MoviesRoute.test.tsx
+++ b/src/routes/MoviesRoute.test.tsx
@@ -35,11 +35,13 @@ vi.mock("@noriginmedia/norigin-spatial-navigation", () => ({
   setFocus: vi.fn(),
 }));
 
-const fetchLanguageUnionMock = vi.hoisted(() => vi.fn());
+const streamLanguageUnionMock = vi.hoisted(() => vi.fn());
 const invalidateLanguageUnionCacheMock = vi.hoisted(() => vi.fn());
+const lookupCachedStreamMock = vi.hoisted(() => vi.fn(() => undefined));
 vi.mock("../features/movies/languageUnion", () => ({
-  fetchLanguageUnion: fetchLanguageUnionMock,
+  streamLanguageUnion: streamLanguageUnionMock,
   invalidateLanguageUnionCache: invalidateLanguageUnionCacheMock,
+  lookupCachedStream: lookupCachedStreamMock,
 }));
 
 const fetchHistoryMock = vi.hoisted(() => vi.fn());
@@ -126,8 +128,10 @@ describe("MoviesRoute", () => {
   beforeEach(() => {
     useFocusableSpy.mockClear();
     openPlayerMock.mockClear();
-    fetchLanguageUnionMock.mockReset();
+    streamLanguageUnionMock.mockReset();
     invalidateLanguageUnionCacheMock.mockReset();
+    lookupCachedStreamMock.mockReset();
+    lookupCachedStreamMock.mockReturnValue(undefined);
     fetchHistoryMock.mockReset();
     fetchHistoryMock.mockResolvedValue([]);
     langRef.current = "all";
@@ -135,20 +139,20 @@ describe("MoviesRoute", () => {
   });
 
   it("shows skeleton while the language union is pending", () => {
-    fetchLanguageUnionMock.mockReturnValue(new Promise(() => {}));
+    streamLanguageUnionMock.mockReturnValue(new Promise(() => {}));
     const { container } = render(<MoviesRoute />);
     expect(container.querySelectorAll(".skeleton").length).toBeGreaterThan(0);
   });
 
   it("renders ErrorShell when the union fetch rejects", async () => {
-    fetchLanguageUnionMock.mockRejectedValue(new Error("network down"));
+    streamLanguageUnionMock.mockRejectedValue(new Error("network down"));
     render(<MoviesRoute />);
     expect(await screen.findByRole("alert")).toBeInTheDocument();
     expect(screen.getByText(/can't load movies/i)).toBeInTheDocument();
   });
 
   it("Retry re-runs the union fetch — does not call window.location.reload", async () => {
-    fetchLanguageUnionMock.mockRejectedValueOnce(new Error("oops"));
+    streamLanguageUnionMock.mockRejectedValueOnce(new Error("oops"));
     render(<MoviesRoute />);
     await screen.findByRole("alert");
 
@@ -158,10 +162,17 @@ describe("MoviesRoute", () => {
       value: { ...window.location, reload: reloadSpy },
     });
 
-    fetchLanguageUnionMock.mockResolvedValueOnce({
-      streams: mockStreams,
-      matchedCategories: 1,
-    });
+    streamLanguageUnionMock.mockImplementationOnce(
+      (_lang: string, onBatch: (b: unknown) => void) => {
+        onBatch({
+          streams: mockStreams,
+          isFinal: true,
+          matchedCategories: 1,
+          completedCategories: 1,
+        });
+        return Promise.resolve();
+      },
+    );
     await userEvent.click(screen.getByRole("button", { name: /retry/i }));
 
     await waitFor(() => {
@@ -169,14 +180,21 @@ describe("MoviesRoute", () => {
     });
     expect(reloadSpy).not.toHaveBeenCalled();
     expect(invalidateLanguageUnionCacheMock).toHaveBeenCalled();
-    expect(fetchLanguageUnionMock).toHaveBeenCalledTimes(2);
+    expect(streamLanguageUnionMock).toHaveBeenCalledTimes(2);
   });
 
   it("renders movie cards once the union resolves", async () => {
-    fetchLanguageUnionMock.mockResolvedValue({
-      streams: mockStreams,
-      matchedCategories: 2,
-    });
+    streamLanguageUnionMock.mockImplementation(
+      (_lang: string, onBatch: (b: unknown) => void) => {
+        onBatch({
+          streams: mockStreams,
+          isFinal: true,
+          matchedCategories: 2,
+          completedCategories: 2,
+        });
+        return Promise.resolve();
+      },
+    );
     render(<MoviesRoute />);
     expect(
       await screen.findByRole("button", { name: /die hard/i }),
@@ -185,10 +203,17 @@ describe("MoviesRoute", () => {
   });
 
   it("clicking a movie card opens the player with the vod kind + item title", async () => {
-    fetchLanguageUnionMock.mockResolvedValue({
-      streams: mockStreams,
-      matchedCategories: 1,
-    });
+    streamLanguageUnionMock.mockImplementation(
+      (_lang: string, onBatch: (b: unknown) => void) => {
+        onBatch({
+          streams: mockStreams,
+          isFinal: true,
+          matchedCategories: 1,
+          completedCategories: 1,
+        });
+        return Promise.resolve();
+      },
+    );
     render(<MoviesRoute />);
     const card = await screen.findByRole("button", { name: /die hard/i });
     await userEvent.click(card);
@@ -201,10 +226,17 @@ describe("MoviesRoute", () => {
 
   it("renders the language-switch empty state when the union is empty", async () => {
     langRef.current = "telugu";
-    fetchLanguageUnionMock.mockResolvedValue({
-      streams: [],
-      matchedCategories: 0,
-    });
+    streamLanguageUnionMock.mockImplementation(
+      (_lang: string, onBatch: (b: unknown) => void) => {
+        onBatch({
+          streams: [],
+          isFinal: true,
+          matchedCategories: 0,
+          completedCategories: 0,
+        });
+        return Promise.resolve();
+      },
+    );
     render(<MoviesRoute />);
     expect(
       await screen.findByText(/no telugu movies in this catalog/i),
@@ -216,10 +248,17 @@ describe("MoviesRoute", () => {
   });
 
   it("renders the sort toolbar with Newest default + movie count", async () => {
-    fetchLanguageUnionMock.mockResolvedValue({
-      streams: mockStreams,
-      matchedCategories: 1,
-    });
+    streamLanguageUnionMock.mockImplementation(
+      (_lang: string, onBatch: (b: unknown) => void) => {
+        onBatch({
+          streams: mockStreams,
+          isFinal: true,
+          matchedCategories: 1,
+          completedCategories: 1,
+        });
+        return Promise.resolve();
+      },
+    );
     render(<MoviesRoute />);
     await screen.findByRole("button", { name: /die hard/i });
     const newestBtn = screen.getByRole("button", { name: /^newest$/i });
@@ -228,20 +267,34 @@ describe("MoviesRoute", () => {
   });
 
   it("exposes Year as a sort option", async () => {
-    fetchLanguageUnionMock.mockResolvedValue({
-      streams: mockStreams,
-      matchedCategories: 1,
-    });
+    streamLanguageUnionMock.mockImplementation(
+      (_lang: string, onBatch: (b: unknown) => void) => {
+        onBatch({
+          streams: mockStreams,
+          isFinal: true,
+          matchedCategories: 1,
+          completedCategories: 1,
+        });
+        return Promise.resolve();
+      },
+    );
     render(<MoviesRoute />);
     await screen.findByRole("button", { name: /die hard/i });
     expect(screen.getByRole("button", { name: /^year$/i })).toBeInTheDocument();
   });
 
   it("flipping sort to Name reorders the cards alphabetically", async () => {
-    fetchLanguageUnionMock.mockResolvedValue({
-      streams: mockStreams,
-      matchedCategories: 1,
-    });
+    streamLanguageUnionMock.mockImplementation(
+      (_lang: string, onBatch: (b: unknown) => void) => {
+        onBatch({
+          streams: mockStreams,
+          isFinal: true,
+          matchedCategories: 1,
+          completedCategories: 1,
+        });
+        return Promise.resolve();
+      },
+    );
     render(<MoviesRoute />);
     await screen.findByRole("button", { name: /die hard/i });
     await userEvent.click(screen.getByRole("button", { name: /^name$/i }));
@@ -253,10 +306,17 @@ describe("MoviesRoute", () => {
   });
 
   it("registers CONTENT_AREA_MOVIES focus key + per-card VOD_CARD_* keys", async () => {
-    fetchLanguageUnionMock.mockResolvedValue({
-      streams: mockStreams,
-      matchedCategories: 1,
-    });
+    streamLanguageUnionMock.mockImplementation(
+      (_lang: string, onBatch: (b: unknown) => void) => {
+        onBatch({
+          streams: mockStreams,
+          isFinal: true,
+          matchedCategories: 1,
+          completedCategories: 1,
+        });
+        return Promise.resolve();
+      },
+    );
     render(<MoviesRoute />);
     await screen.findByRole("button", { name: /die hard/i });
     const keys = useFocusableSpy.mock.calls

--- a/src/routes/MoviesRoute.tsx
+++ b/src/routes/MoviesRoute.tsx
@@ -36,8 +36,9 @@ import { MovieGrid } from "../features/movies/MovieGrid";
 import { MovieDetailSheet } from "../features/movies/MovieDetailSheet";
 import { ResumeHero } from "../features/movies/ResumeHero";
 import {
-  fetchLanguageUnion,
+  streamLanguageUnion,
   invalidateLanguageUnionCache,
+  lookupCachedStream,
 } from "../features/movies/languageUnion";
 import {
   getSortPref,
@@ -138,20 +139,23 @@ export function MoviesRoute() {
   useEffect(() => {
     let cancelled = false;
 
-    fetchLanguageUnion(lang)
-      .then(({ streams: fetched }) => {
-        if (cancelled) return;
-        setStreams(fetched);
-        setLoading(false);
-        setError(false);
+    streamLanguageUnion(lang, ({ streams: fetched, isFinal }) => {
+      if (cancelled) return;
+      setStreams(fetched);
+      setLoading(false);
+      setError(false);
+      // Dismiss the transitioning dim as soon as we have content to show,
+      // or when the union is fully loaded (even if 0 results). The grid
+      // keeps growing silently as remaining categories resolve.
+      if (fetched.length > 0 || isFinal) {
         setTransitioning(false);
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setLoading(false);
-        setError(true);
-        setTransitioning(false);
-      });
+      }
+    }).catch(() => {
+      if (cancelled) return;
+      setLoading(false);
+      setError(true);
+      setTransitioning(false);
+    });
 
     return () => {
       cancelled = true;
@@ -257,13 +261,21 @@ export function MoviesRoute() {
     };
   }, [resumeCandidate]);
 
-  const resumeTitle =
-    resumeCandidate?.content_name ??
-    (resumeCandidate &&
-    resumeTitleBackfill?.id === String(resumeCandidate.content_id)
-      ? resumeTitleBackfill.name
-      : null) ??
-    "your movie";
+  // Three-tier fallback: stored content_name → already-cached stream name
+  // (from any prior language union that happened to contain this id) →
+  // async /api/vod/info backfill → generic label. `streams` is in the deps
+  // list on purpose — its identity flips whenever a new category resolves,
+  // which is the signal that `lookupCachedStream` may now return a hit.
+  const resumeTitle = useMemo(() => {
+    void streams; // reactivity trigger for the module-level cache below
+    if (!resumeCandidate) return "your movie";
+    if (resumeCandidate.content_name) return resumeCandidate.content_name;
+    const candidateId = String(resumeCandidate.content_id);
+    const cached = lookupCachedStream(candidateId);
+    if (cached) return cached.name;
+    if (resumeTitleBackfill?.id === candidateId) return resumeTitleBackfill.name;
+    return "your movie";
+  }, [resumeCandidate, resumeTitleBackfill, streams]);
 
   const handleResume = useCallback(() => {
     if (!resumeCandidate) return;


### PR DESCRIPTION
## Summary

Three regressions flagged in prod testing 2026-04-23 PM.

### 1. Resume hero stuck on "your movie" — **schema bug**

Root cause: backend's `/api/vod/info` returns `duration` as a display **string** (`"2h 15min"`), but the client's `VodInfoSchema` declared `duration: z.number()`. Every `fetchVodInfo` silently threw on the zod parse → backfill never populated → fallback label stayed visible forever.

Fix:
- Align `VodInfoSchema` with the backend's `CatalogItemDetail` — `duration: z.string().optional()`, added `durationSecs` for numeric needs, made `name` optional as a safety net.
- Added a sync lookup index `resolvedStreamsIndex` populated as each `getStreamsCached` promise resolves. ResumeHero's title now falls back in order:
  1. `history.content_name`
  2. cached stream name from any prior language union that happened to contain the id
  3. async `/api/vod/info` backfill
  4. generic `"your movie"`

### 2. Hero Down was stuck

`onArrowPress` on the ResumeHero returned `true` for every direction, including Down. `true` means "I consumed the event, don't navigate" — so norigin never traversed to the LanguageRail. Now we consume only dead directions (Up / Left / Right) and return `false` for Down.

### 3. Language switch + sort felt frozen for several seconds

The union used to wait for ALL matching categories before rendering any cards. Hindi (~25 matching categories) blocked the grid for 3-5s behind the "Loading Hindi movies…" pulse.

Added `streamLanguageUnion` — a drip-feed variant that fires `onBatch` after each category resolves, carrying the accumulated deduped streams. MoviesRoute's effect updates `streams` progressively and dismisses the `transitioning` dim as soon as the **first batch** arrives. Remaining categories trickle in silently while the grid is already interactive.

## Checks
- `npm run typecheck` — clean
- `npm test` — 265/265
- `npm run lint` — clean (3 pre-existing coverage/ warnings)

## Test plan

- [ ] ResumeHero title shows the real movie name (was "your movie") for the paused Hindi movie
- [ ] Focused hero → press Down → focus moves to the LanguageRail
- [ ] Focused hero → press Up / Left / Right → small bump animates, focus stays
- [ ] Click Hindi chip → posters start appearing in < 1s, dim lifts, more categories load silently over a few seconds
- [ ] Click a sort option while a union is loading → reorders the subset already rendered (grid remains interactive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)