### PR TITLE
fix(movies): hero Down actually works now + focus reliably seeded on cold mount

### DIFF
--- a/src/features/movies/ResumeHero.tsx
+++ b/src/features/movies/ResumeHero.tsx
@@ -15,7 +15,7 @@
  * seeds focus here instead of the first poster.
  */
 import type { RefObject } from "react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useFocusable } from "@noriginmedia/norigin-spatial-navigation";
 
 export interface ResumeHeroProps {
@@ -23,6 +23,14 @@ export interface ResumeHeroProps {
   /** Seconds remaining in the movie (duration − progress). */
   remainingSeconds: number;
   onSelect: () => void;
+  /**
+   * When true, the hero grabs norigin focus on mount via focusSelf().
+   * The parent decides this based on whether the initial seed should
+   * land on the hero vs the first poster. focusSelf is tied to the
+   * component's own registration so there's no "target not yet
+   * registered" race — unlike setFocus("RESUME_HERO") from the parent.
+   */
+  shouldAutoFocus?: boolean;
 }
 
 function formatRemaining(seconds: number): string {
@@ -39,30 +47,45 @@ export function ResumeHero({
   title,
   remainingSeconds,
   onSelect,
+  shouldAutoFocus = false,
 }: ResumeHeroProps) {
   // Bounce-on-dead-direction. The hero sits at the top-most row and is full
   // width, so Up / Left / Right have no neighbour. Without feedback, those
   // presses look like the button is broken (observed in prod 2026-04-23 PM).
-  // onArrowPress fires before norigin navigates; for Down we let it pass
-  // through untouched (target = LanguageRail).
   const [bouncePulse, setBouncePulse] = useState(0);
 
-  const { ref, focused } = useFocusable<HTMLButtonElement>({
+  // norigin contract (verified by reading `SpatialNavigation.onArrowPress`
+  // in dist/index.js): `return false` PREVENTS the default navigation;
+  // any other return value (including `true` and `undefined`) lets norigin
+  // navigate. A previous iteration of this file inverted that assumption
+  // and silently blocked Down from walking to the LanguageRail.
+  //
+  // We always return `true`: Up/Left/Right have no neighbour so the
+  // navigation is a no-op anyway, Down walks to the rail as intended.
+  const { ref, focused, focusSelf } = useFocusable<HTMLButtonElement>({
     focusKey: "RESUME_HERO",
     onEnterPress: onSelect,
     onArrowPress: (direction) => {
-      // Dead directions (no neighbour) → bounce + consume the event so
-      // norigin doesn't traverse.
       if (direction === "up" || direction === "left" || direction === "right") {
         setBouncePulse((p) => p + 1);
-        return true;
       }
-      // Down has a real target (LanguageRail) — let norigin navigate.
-      // Returning `true` here previously pinned focus on the hero and
-      // broke the only working direction (observed in prod 2026-04-23 PM).
-      return false;
+      return true;
     },
   });
+
+  // Fire focusSelf exactly once on mount when the parent requested it.
+  // Using focusSelf (not setFocus) avoids the "target not registered yet"
+  // race we hit when the parent called setFocus("RESUME_HERO") before the
+  // hero's useFocusable had a chance to register with norigin.
+  const autoFocusedRef = useRef(false);
+  useEffect(() => {
+    if (shouldAutoFocus && !autoFocusedRef.current) {
+      autoFocusedRef.current = true;
+      focusSelf();
+    }
+    // focusSelf identity changes every render; intentionally omit.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldAutoFocus]);
 
   return (
     <div

--- a/src/routes/MoviesRoute.tsx
+++ b/src/routes/MoviesRoute.tsx
@@ -287,28 +287,54 @@ export function MoviesRoute() {
   }, [resumeCandidate, resumeTitle, openPlayer]);
 
   // ─── Focus seeding ────────────────────────────────────────────────────────
-  // Cold mount seeds to the hero when a resume candidate exists (2-input
-  // resume path), else to the first poster (2-input play path). Language
-  // change always seeds to the first poster — the user is actively browsing,
-  // so resume should not pull focus back.
-  const lastSeededLangRef = useRef<LangId | null>(null);
+  // Two distinct paths:
+  //   * Initial seed — fire once per route mount. Prefers the hero (via
+  //     ResumeHero's `autoFocus` prop and its own focusSelf, which avoids
+  //     the "target not registered yet" race we hit with setFocus from
+  //     this effect). Falls back to the first poster when there is no
+  //     resume candidate.
+  //   * Language-change seed — always seed the first poster. The user is
+  //     actively browsing, so a background resume-arrival must not pull
+  //     focus back to the hero mid-browse.
+  //
+  // `heroShouldAutoFocus` is computed from refs so it stays stable across
+  // re-renders once the hero mount grabs focus. It flips to `true` only on
+  // the render where we decide the hero is the initial seed target.
   const didInitialSeedRef = useRef<boolean>(false);
+  const lastSeededLangRef = useRef<LangId>(lang);
+  const [heroShouldAutoFocus, setHeroShouldAutoFocus] = useState(false);
+
   useEffect(() => {
-    if (sortedStreams.length === 0) return;
-    const langChanged = lastSeededLangRef.current !== lang;
-    const isInitialSeed = !didInitialSeedRef.current;
-    if (!langChanged && !isInitialSeed) return;
+    // Initial seed path
+    if (!didInitialSeedRef.current) {
+      if (resumeCandidate) {
+        didInitialSeedRef.current = true;
+        lastSeededLangRef.current = lang;
+        // Hero's own focusSelf handles registration timing. This setState
+        // is a one-shot guarded by a ref so it cannot loop — the rule
+        // can't tell the difference between cascading updates and one-time
+        // imperatives.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setHeroShouldAutoFocus(true);
+        return;
+      }
+      if (sortedStreams.length > 0) {
+        didInitialSeedRef.current = true;
+        lastSeededLangRef.current = lang;
+        const firstId = sortedStreams[0]!.id;
+        const t = setTimeout(() => setFocus(`VOD_CARD_${firstId}`), 0);
+        return () => clearTimeout(t);
+      }
+      return;
+    }
 
-    lastSeededLangRef.current = lang;
-    didInitialSeedRef.current = true;
-
-    // Initial mount + resume available → seed hero. Otherwise seed first card.
-    const target =
-      isInitialSeed && resumeCandidate
-        ? "RESUME_HERO"
-        : `VOD_CARD_${sortedStreams[0]!.id}`;
-    const t = setTimeout(() => setFocus(target), 0);
-    return () => clearTimeout(t);
+    // Language-change seed path
+    if (lastSeededLangRef.current !== lang && sortedStreams.length > 0) {
+      lastSeededLangRef.current = lang;
+      const firstId = sortedStreams[0]!.id;
+      const t = setTimeout(() => setFocus(`VOD_CARD_${firstId}`), 0);
+      return () => clearTimeout(t);
+    }
   }, [lang, sortedStreams, resumeCandidate]);
 
   // ─── Handlers ─────────────────────────────────────────────────────────────
@@ -396,6 +422,7 @@ export function MoviesRoute() {
                   resumeCandidate.progress_seconds
                 }
                 onSelect={handleResume}
+                shouldAutoFocus={heroShouldAutoFocus}
               />
             ) : null}
 


### PR DESCRIPTION
## Summary

PR #80 introduced two regressions that only surfaced when the page was actually loaded in prod. Both fixed here.

### 1. Hero Down was blocked (silent)

Read the minified norigin v2.1.0 source (`node_modules/@noriginmedia/norigin-spatial-navigation/dist/index.js`, `SpatialNavigation.prototype.onKeyEvent`) to confirm the contract:

> `onArrowPress` returning `false` **prevents** the default navigation. Any other return value allows it.

PR #80 had inverted that — returning `false` for Down, which blocked the walk to the LanguageRail. This PR always returns `true`; the bounce animation fires from the callback body regardless.

### 2. Focus was not visibly seeded on cold mount

The effect bailed out when `sortedStreams.length === 0`, so:
- If history arrived before streams → the hero was visible but nothing was focused (page looked dead).
- Even after streams arrived, `setFocus("RESUME_HERO")` raced with the hero's `useFocusable` registration and intermittently missed.

Rework:
- `ResumeHero` takes a new `shouldAutoFocus` prop and calls its own `focusSelf()` on mount — tied to the component's registration lifecycle, so no race.
- `MoviesRoute` seeds the hero the moment `resumeCandidate` is ready, without waiting for streams. Falls back to the first poster when there is no resume. Language change always seeds the first poster (never the hero).

## Checks
- `npm run build` — clean (ran the **full** Docker-equivalent build locally, not just `tsc --noEmit`, so the `tsc -b` step that tripped #80's Deploy can't surprise us again)
- `npm test` — 265/265
- `npm run lint` — clean

## Test plan

- [ ] Cold load `/movies` with partial-watch history → hero shows and **focus is immediately visible on the hero** (copper ring)
- [ ] Press Down on hero → focus walks to the LanguageRail
- [ ] Press Up / Left / Right → subtle bump, focus stays
- [ ] Press Enter on hero → movie resumes
- [ ] Reload with no resume history → focus lands on first poster

🤖 Generated with [Claude Code](https://claude.com/claude-code)