### PR TITLE
fix(nav): global D-pad focus-recovery watcher (Phase 0.5)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,11 @@ import {
   useNavigate,
   useLocation,
 } from "react-router-dom";
-import { setFocus } from "@noriginmedia/norigin-spatial-navigation";
+import {
+  setFocus,
+  getCurrentFocusKey,
+  doesFocusableExist,
+} from "@noriginmedia/norigin-spatial-navigation";
 import { BottomDock, type DockItem } from "./nav/BottomDock";
 import { LiveRoute } from "./routes/LiveRoute";
 import { MoviesRoute } from "./routes/MoviesRoute";
@@ -121,6 +125,63 @@ function AppShell() {
     window.addEventListener("keydown", handleEscape);
     return () => window.removeEventListener("keydown", handleEscape);
   }, [activeTab]);
+
+  // Global D-pad focus-recovery watcher. Any dead-direction arrow press
+  // (Left on the first poster, Right on the rightmost dock tab, Up on the
+  // hero, arrows on an empty state, etc.) can leave norigin's currentFocusKey
+  // pointing at an unmounted key while document.activeElement drifts to
+  // <body>. Subsequent arrows are then no-ops until the user clicks or
+  // reloads — see streamvault-v3-focus-vanish-bug.md.
+  //
+  // Strategy: remember the last focusKey that was genuinely focused, and on
+  // every arrow keyup check whether focus survived. If it didn't, restore
+  // the last known good key; if that key is also gone, fall back to the
+  // active dock tab (same anchor the mount-prime effect uses).
+  //
+  // Runtime cost: two cheap listeners, one ref write per focus change, no
+  // work in the common (focus-is-fine) case.
+  useEffect(() => {
+    if (hideDock) return;
+    const fallbackKey = `DOCK_${activeTab.toUpperCase()}`;
+    let lastGoodKey: string | null = null;
+
+    const onFocusIn = () => {
+      const key = getCurrentFocusKey();
+      if (key && doesFocusableExist(key)) {
+        lastGoodKey = key;
+      }
+    };
+
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (
+        e.key !== "ArrowUp" &&
+        e.key !== "ArrowDown" &&
+        e.key !== "ArrowLeft" &&
+        e.key !== "ArrowRight"
+      ) {
+        return;
+      }
+      const current = getCurrentFocusKey();
+      const stuck =
+        !current ||
+        !doesFocusableExist(current) ||
+        document.activeElement === document.body ||
+        document.activeElement == null;
+      if (!stuck) return;
+      const target =
+        lastGoodKey && doesFocusableExist(lastGoodKey)
+          ? lastGoodKey
+          : fallbackKey;
+      setFocus(target);
+    };
+
+    window.addEventListener("focusin", onFocusIn);
+    window.addEventListener("keyup", onKeyUp);
+    return () => {
+      window.removeEventListener("focusin", onFocusIn);
+      window.removeEventListener("keyup", onKeyUp);
+    };
+  }, [activeTab, hideDock]);
 
   return (
     <div style={{ background: "var(--bg-shell-gradient, var(--bg-base))", minHeight: "100vh" }}>


### PR DESCRIPTION
## Summary

- Fixes the cross-cutting D-pad focus-vanish bug documented in the Movies phase-close handoff: every dead-direction press (Left on first poster / Telugu chip / leftmost dock tab, Right on rightmost dock tab, Up on hero, arrows on empty states) could strand the user until they clicked or reloaded.
- Adds a ~60-line watcher to `AppShell` that tracks the last genuinely-focused norigin key and, on every arrow `keyup`, restores focus if it got lost — falling back to the active dock tab if the last-good key is itself gone.
- Zero component changes. Zero work in the common (focus-is-fine) case.

## Why this shape

Option A from the focus-vanish writeup. Option B (`isFocusBoundary` on every edge container) targets the root cause but touches 6–8 components, each with its own directional-boundary decision — risk of new regressions in places that currently navigate correctly. We can layer B on surgically later if A leaves gaps.

## Test plan

- [ ] ResumeHero: press Up / Left / Right — bounce fires, focus stays on hero.
- [ ] First movie poster: press Left — focus stays on poster (or bounces, not lost).
- [ ] Telugu chip (leftmost on LanguageRail): press Left — focus retained.
- [ ] Movies dock tab (leftmost): press Left — focus retained.
- [ ] Settings dock tab (rightmost): press Right — focus retained.
- [ ] Sequence: Hero → Down → Up → Up — focus lands sanely.
- [ ] Empty state (if reproducible): arrows don't strand the user.
- [ ] Regression: happy-path arrow nav still works (move between posters, dock tabs, rail chips).

## Follow-ups (parked)

- Playwright E2E for this class of bug — deferred until Series/Player ship so we write one test harness covering all surfaces together. Tracked via handoff memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)