### PR TITLE
feat(player): Phase 6a — three-band control bar + D-pad flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,11 @@ import {
   useNavigate,
   useLocation,
 } from "react-router-dom";
-import { setFocus } from "@noriginmedia/norigin-spatial-navigation";
+import {
+  setFocus,
+  getCurrentFocusKey,
+  doesFocusableExist,
+} from "@noriginmedia/norigin-spatial-navigation";
 import { BottomDock, type DockItem } from "./nav/BottomDock";
 import { LiveRoute } from "./routes/LiveRoute";
 import { MoviesRoute } from "./routes/MoviesRoute";
@@ -121,6 +125,63 @@ function AppShell() {
     window.addEventListener("keydown", handleEscape);
     return () => window.removeEventListener("keydown", handleEscape);
   }, [activeTab]);
+
+  // Global D-pad focus-recovery watcher. Any dead-direction arrow press
+  // (Left on the first poster, Right on the rightmost dock tab, Up on the
+  // hero, arrows on an empty state, etc.) can leave norigin's currentFocusKey
+  // pointing at an unmounted key while document.activeElement drifts to
+  // <body>. Subsequent arrows are then no-ops until the user clicks or
+  // reloads — see streamvault-v3-focus-vanish-bug.md.
+  //
+  // Strategy: remember the last focusKey that was genuinely focused, and on
+  // every arrow keyup check whether focus survived. If it didn't, restore
+  // the last known good key; if that key is also gone, fall back to the
+  // active dock tab (same anchor the mount-prime effect uses).
+  //
+  // Runtime cost: two cheap listeners, one ref write per focus change, no
+  // work in the common (focus-is-fine) case.
+  useEffect(() => {
+    if (hideDock) return;
+    const fallbackKey = `DOCK_${activeTab.toUpperCase()}`;
+    let lastGoodKey: string | null = null;
+
+    const onFocusIn = () => {
+      const key = getCurrentFocusKey();
+      if (key && doesFocusableExist(key)) {
+        lastGoodKey = key;
+      }
+    };
+
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (
+        e.key !== "ArrowUp" &&
+        e.key !== "ArrowDown" &&
+        e.key !== "ArrowLeft" &&
+        e.key !== "ArrowRight"
+      ) {
+        return;
+      }
+      const current = getCurrentFocusKey();
+      const stuck =
+        !current ||
+        !doesFocusableExist(current) ||
+        document.activeElement === document.body ||
+        document.activeElement == null;
+      if (!stuck) return;
+      const target =
+        lastGoodKey && doesFocusableExist(lastGoodKey)
+          ? lastGoodKey
+          : fallbackKey;
+      setFocus(target);
+    };
+
+    window.addEventListener("focusin", onFocusIn);
+    window.addEventListener("keyup", onKeyUp);
+    return () => {
+      window.removeEventListener("focusin", onFocusIn);
+      window.removeEventListener("keyup", onKeyUp);
+    };
+  }, [activeTab, hideDock]);
 
   return (
     <div style={{ background: "var(--bg-shell-gradient, var(--bg-base))", minHeight: "100vh" }}>

--- a/src/player/PlayerControls.test.tsx
+++ b/src/player/PlayerControls.test.tsx
@@ -1,11 +1,14 @@
 /**
- * PlayerControls unit tests.
+ * PlayerControls unit tests — Phase 6a shape.
  *
- * Verifies: play/pause toggle, D-pad seek ±10s, auto-hide timing.
+ * Covers: initial visibility + focus, auto-hide, wake-only first arrow,
+ * Enter short-circuit, Back closes player, seek shortcuts (j/l), Live mode
+ * hides scrubber and skips ±10s, quality popover still selects levels.
  */
 import { render, screen, act, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
 import { PlayerControls } from "./PlayerControls";
+import type { PlayerControlsProps } from "./PlayerControls";
 import type { ReactNode } from "react";
 
 // ─── Mock norigin ─────────────────────────────────────────────────────────────
@@ -20,16 +23,20 @@ vi.mock("@noriginmedia/norigin-spatial-navigation", () => ({
   FocusContext: {
     Provider: ({ children }: { children: ReactNode }) => children,
   },
+  setFocus: vi.fn(),
 }));
 
 // ─── Default props ────────────────────────────────────────────────────────────
 
-function makeProps(overrides = {}) {
+function makeProps(overrides: Partial<PlayerControlsProps> = {}): PlayerControlsProps {
   return {
-    title: "Test Channel",
-    status: "playing" as const,
+    title: "Test Title",
+    kind: "vod",
+    status: "playing",
     currentTime: 30,
     duration: 120,
+    volume: 1,
+    muted: false,
     levels: [],
     audioTracks: [],
     subtitleTracks: [],
@@ -40,6 +47,7 @@ function makeProps(overrides = {}) {
     onPause: vi.fn(),
     onSeek: vi.fn(),
     onClose: vi.fn(),
+    onToggleMute: vi.fn(),
     onSelectLevel: vi.fn(),
     onSelectAudioTrack: vi.fn(),
     onSelectSubtitleTrack: vi.fn(),
@@ -58,141 +66,219 @@ describe("PlayerControls", () => {
     vi.useRealTimers();
   });
 
-  // Controls start hidden — user must interact to reveal them. Tests need
-  // to fire a keydown first to surface the control surface.
-  function reveal() {
-    act(() => {
-      fireEvent.keyDown(window, { key: "ArrowDown" });
-    });
-  }
-
-  it("renders play/pause button", () => {
+  it("renders Play/Pause, Back button, and title on mount (spec §4.1)", () => {
     const props = makeProps();
     render(<PlayerControls {...props} />);
-    reveal();
-    expect(screen.getByRole("button", { name: /pause/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Pause" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Back" })).toBeTruthy();
+    expect(screen.getByText("Test Title")).toBeTruthy();
   });
 
-  it("calls onPause when pause button is clicked (playing state)", () => {
-    const props = makeProps({ status: "playing" });
-    render(<PlayerControls {...props} />);
-    reveal();
-
-    screen.getByRole("button", { name: /pause/i }).click();
-    expect(props.onPause).toHaveBeenCalledOnce();
-  });
-
-  it("calls onPlay when play button is clicked (paused state)", () => {
+  it("shows Play label when paused", () => {
     const props = makeProps({ status: "paused" });
     render(<PlayerControls {...props} />);
-    reveal();
-
-    // Use exact match to avoid matching "Close player" button
-    screen.getByRole("button", { name: "Play" }).click();
-    expect(props.onPlay).toHaveBeenCalledOnce();
+    expect(screen.getByRole("button", { name: "Play" })).toBeTruthy();
   });
 
-  it("seeks -10s on ArrowLeft key", () => {
-    const onSeek = vi.fn();
-    const props = makeProps({ currentTime: 30, onSeek });
-    render(<PlayerControls {...props} />);
-
-    fireEvent.keyDown(window, { key: "ArrowLeft" });
-    expect(onSeek).toHaveBeenCalledWith(20);
-  });
-
-  it("seeks +10s on ArrowRight key", () => {
-    const onSeek = vi.fn();
-    const props = makeProps({ currentTime: 30, onSeek });
-    render(<PlayerControls {...props} />);
-
-    fireEvent.keyDown(window, { key: "ArrowRight" });
-    expect(onSeek).toHaveBeenCalledWith(40);
-  });
-
-  it("auto-hides controls after 3 seconds of idle", () => {
+  it("auto-hides controls after 3s idle", () => {
     const props = makeProps();
     render(<PlayerControls {...props} />);
+    const el = screen.getByTestId("player-controls");
+    expect(el.getAttribute("aria-hidden")).toBe("false");
 
-    // Controls start HIDDEN on mount — user hasn't touched the remote yet.
-    expect(screen.queryByTestId("player-controls")).toBeNull();
-
-    // Reveal via a key press.
-    reveal();
-    expect(screen.queryByTestId("player-controls")).toBeTruthy();
-
-    // Advance past the 3s auto-hide threshold
     act(() => {
       vi.advanceTimersByTime(3100);
     });
-
-    // Controls should be hidden again
-    expect(screen.queryByTestId("player-controls")).toBeNull();
+    expect(el.getAttribute("aria-hidden")).toBe("true");
   });
 
-  it("shows controls again on keydown after auto-hide", () => {
+  it("wakes on first arrow press without triggering navigation", () => {
     const props = makeProps();
     render(<PlayerControls {...props} />);
 
-    // Hide controls
     act(() => {
       vi.advanceTimersByTime(3100);
     });
-    expect(screen.queryByTestId("player-controls")).toBeNull();
+    expect(screen.getByTestId("player-controls").getAttribute("aria-hidden")).toBe(
+      "true",
+    );
 
-    // Any key press should show controls
+    act(() => {
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+    });
+    expect(screen.getByTestId("player-controls").getAttribute("aria-hidden")).toBe(
+      "false",
+    );
+    // onSeek must NOT fire — the first arrow is wake-only (spec §4.3).
+    expect(props.onSeek).not.toHaveBeenCalled();
+  });
+
+  it("Enter short-circuits pause even when controls are hidden (spec §4.3)", () => {
+    const props = makeProps({ status: "playing" });
+    render(<PlayerControls {...props} />);
+
+    act(() => {
+      vi.advanceTimersByTime(3100);
+    });
     act(() => {
       fireEvent.keyDown(window, { key: "Enter" });
     });
-    expect(screen.getByTestId("player-controls")).toBeTruthy();
+    expect(props.onPause).toHaveBeenCalledOnce();
+    expect(screen.getByTestId("player-controls").getAttribute("aria-hidden")).toBe(
+      "false",
+    );
   });
 
-  it("calls onClose when Escape key is pressed with no menu open", () => {
-    const onClose = vi.fn();
-    const props = makeProps({ onClose });
+  it("Space and k also toggle play/pause", () => {
+    const props = makeProps({ status: "playing" });
     render(<PlayerControls {...props} />);
 
-    fireEvent.keyDown(window, { key: "Escape" });
-    expect(onClose).toHaveBeenCalledOnce();
-  });
-
-  it("shows quality menu when levels are provided and quality button is clicked", () => {
-    const levels = [
-      { index: 0, height: 720, bitrate: 2000000, name: "720p" },
-      { index: 1, height: 1080, bitrate: 4000000, name: "1080p" },
-    ];
-    const props = makeProps({ levels });
-    render(<PlayerControls {...props} />);
-    reveal();
-
-    const qualityBtn = screen.getByRole("button", { name: /quality/i });
     act(() => {
-      qualityBtn.click();
+      fireEvent.keyDown(window, { key: " " });
     });
+    expect(props.onPause).toHaveBeenCalledTimes(1);
 
-    expect(screen.getByRole("button", { name: "720p" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "1080p" })).toBeTruthy();
+    act(() => {
+      fireEvent.keyDown(window, { key: "k" });
+    });
+    expect(props.onPause).toHaveBeenCalledTimes(2);
   });
 
-  it("calls onSelectLevel and closes menu when a quality level is selected", () => {
+  it("j / l seek -10s / +10s on VOD", () => {
+    const props = makeProps({ currentTime: 30, kind: "vod" });
+    render(<PlayerControls {...props} />);
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "j" });
+    });
+    expect(props.onSeek).toHaveBeenCalledWith(20);
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "l" });
+    });
+    expect(props.onSeek).toHaveBeenCalledWith(40);
+  });
+
+  it("j / l do NOT seek on Live (no seekable window)", () => {
+    const props = makeProps({ currentTime: 30, kind: "live" });
+    render(<PlayerControls {...props} />);
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "j" });
+    });
+    act(() => {
+      fireEvent.keyDown(window, { key: "l" });
+    });
+    expect(props.onSeek).not.toHaveBeenCalled();
+  });
+
+  it("Escape closes the player when no popover is open", () => {
+    const props = makeProps();
+    render(<PlayerControls {...props} />);
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+    expect(props.onClose).toHaveBeenCalledOnce();
+  });
+
+  it("renders ● Live badge and hides scrubber on Live kind", () => {
+    const props = makeProps({ kind: "live" });
+    const { container } = render(<PlayerControls {...props} />);
+    expect(screen.getByLabelText("Live")).toBeTruthy();
+    expect(container.querySelector("[role='progressbar']")).toBeNull();
+  });
+
+  it("renders scrubber for VOD", () => {
+    const props = makeProps({ kind: "vod" });
+    const { container } = render(<PlayerControls {...props} />);
+    expect(container.querySelector("[role='progressbar']")).toBeTruthy();
+  });
+
+  it("skips ±10s buttons (focusable:false) on Live", () => {
+    const props = makeProps({ kind: "live" });
+    render(<PlayerControls {...props} />);
+    const seekBack = screen.getByRole("button", { name: "Back 10 seconds" });
+    const seekFwd = screen.getByRole("button", { name: "Forward 10 seconds" });
+    expect(seekBack.getAttribute("aria-disabled")).toBe("true");
+    expect(seekFwd.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("quality popover selects a level and closes", () => {
     const onSelectLevel = vi.fn() as Mock;
-    const levels = [{ index: 0, height: 720, bitrate: 2000000, name: "720p" }];
+    const levels = [
+      { index: 0, height: 720, bitrate: 2_000_000, name: "720p" },
+      { index: 1, height: 1080, bitrate: 4_000_000, name: "1080p" },
+    ];
     const props = makeProps({ levels, onSelectLevel });
     render(<PlayerControls {...props} />);
-    reveal();
 
-    // Open quality menu
     act(() => {
       screen.getByRole("button", { name: /quality/i }).click();
     });
 
-    // Select 720p
+    // Highest-first order (spec §5.3): 1080p is listed before 720p.
+    const items = screen.getAllByRole("option");
+    expect(items.length).toBeGreaterThan(0);
+
     act(() => {
       screen.getByRole("button", { name: "720p" }).click();
     });
-
     expect(onSelectLevel).toHaveBeenCalledWith(0);
-    // Menu should be closed
     expect(screen.queryByRole("button", { name: "720p" })).toBeNull();
+  });
+
+  it("subtitles popover renders Off + tracks", () => {
+    const subtitleTracks = [
+      { index: 0, name: "English", lang: "en" },
+      { index: 1, name: "Telugu", lang: "te" },
+    ];
+    const props = makeProps({ subtitleTracks });
+    render(<PlayerControls {...props} />);
+
+    act(() => {
+      screen.getByRole("button", { name: /subtitles/i }).click();
+    });
+    expect(screen.getByRole("button", { name: "Off" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "English" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Telugu" })).toBeTruthy();
+  });
+
+  it("audio popover hidden when only one track (spec: aria-disabled if 1 track)", () => {
+    const audioTracks = [{ index: 0, name: "English", lang: "en" }];
+    const props = makeProps({ audioTracks });
+    render(<PlayerControls {...props} />);
+    expect(screen.queryByRole("button", { name: /audio/i })).toBeNull();
+  });
+
+  it("volume button toggles mute on Enter", () => {
+    const props = makeProps();
+    render(<PlayerControls {...props} />);
+    act(() => {
+      screen.getByRole("button", { name: "Mute" }).click();
+    });
+    expect(props.onToggleMute).toHaveBeenCalledOnce();
+  });
+
+  it("Escape closes popover first, player second", () => {
+    const levels = [{ index: 0, height: 720, bitrate: 2_000_000, name: "720p" }];
+    const props = makeProps({ levels });
+    render(<PlayerControls {...props} />);
+
+    act(() => {
+      screen.getByRole("button", { name: /quality/i }).click();
+    });
+    expect(screen.getByRole("button", { name: "720p" })).toBeTruthy();
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+    expect(screen.queryByRole("button", { name: "720p" })).toBeNull();
+    expect(props.onClose).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+    expect(props.onClose).toHaveBeenCalledOnce();
   });
 });

--- a/src/player/PlayerControls.tsx
+++ b/src/player/PlayerControls.tsx
@@ -1,19 +1,47 @@
 /**
- * PlayerControls — overlay UI for the video player.
+ * PlayerControls — three-band overlay per docs/ux/05-player.md.
  *
- * Constraints (v3):
- *  - position: absolute inside PlayerShell — NOT fixed (avoid transform-ancestor breakage).
- *  - No transition-all, no Framer Motion, no backdrop-filter (TV perf).
- *  - Auto-hides after 3s of no input; reappears on any key/mouse event.
- *  - D-pad seek: ArrowLeft = -10s, ArrowRight = +10s.
- *  - Copper focus outline via .focus-ring.
+ *   TOP BAR       ← Back · Title · [S2E5 "Title"] · live timestamp / ● LIVE
+ *   SCRUBBER      progress + current/total time (hidden on Live, replaced by badge)
+ *   CONTROL BAR   ⏯ · ◀◀ ▶▶ · 🔉 · Audio ▾ · Subs ▾ · Quality ▾
+ *                 (prev/next episode + channel wiring is a Phase 6b follow-on)
+ *
+ * Phase 6a ships the structural shell: bands, focus flow, auto-hide, Enter
+ * short-circuit. Popover list-walk + Left/Right advance, volume slider,
+ * hold-to-scrub and amber failure overlay come in 6b / 6c.
  */
-import type { RefObject } from "react";
+import type { RefObject, CSSProperties } from "react";
 import { useEffect, useRef, useState, useCallback } from "react";
-import { useFocusable, FocusContext } from "@noriginmedia/norigin-spatial-navigation";
-import type { HlsLevel, HlsAudioTrack, HlsSubtitleTrack } from "./useHlsPlayer";
+import {
+  useFocusable,
+  FocusContext,
+  setFocus,
+} from "@noriginmedia/norigin-spatial-navigation";
+import type {
+  HlsLevel,
+  HlsAudioTrack,
+  HlsSubtitleTrack,
+  PlayerStatus,
+} from "./useHlsPlayer";
+import type { PlayerKind } from "./PlayerProvider";
+
+// ─── Focus keys (exported for tests + call sites) ────────────────────────────
+
+export const FK = {
+  BACK: "PLAYER_BACK",
+  PLAY_PAUSE: "PLAYER_PLAY_PAUSE",
+  SEEK_BACK: "PLAYER_SEEK_BACK",
+  SEEK_FORWARD: "PLAYER_SEEK_FORWARD",
+  VOLUME: "PLAYER_VOLUME",
+  AUDIO: "PLAYER_AUDIO",
+  SUBTITLES: "PLAYER_SUBTITLES",
+  QUALITY: "PLAYER_QUALITY",
+} as const;
 
 const AUTO_HIDE_MS = 3000;
+const FADE_MS = 300;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function formatTime(seconds: number): string {
   if (!isFinite(seconds) || isNaN(seconds)) return "0:00";
@@ -25,7 +53,39 @@ function formatTime(seconds: number): string {
   return h > 0 ? `${h}:${mm}:${ss}` : `${m}:${ss}`;
 }
 
-// ─── Menu overlay (quality / audio / subtitles) ──────────────────────────────
+function volumeIcon(volume: number, muted: boolean): string {
+  if (muted || volume <= 0) return "🔇";
+  if (volume < 0.67) return "🔉";
+  return "🔊";
+}
+
+// ─── Props ───────────────────────────────────────────────────────────────────
+
+export interface PlayerControlsProps {
+  title: string;
+  kind: PlayerKind;
+  status: PlayerStatus;
+  currentTime: number;
+  duration: number;
+  volume: number;
+  muted: boolean;
+  levels: HlsLevel[];
+  audioTracks: HlsAudioTrack[];
+  subtitleTracks: HlsSubtitleTrack[];
+  currentLevel?: number;
+  currentAudioTrack?: number;
+  currentSubtitleTrack?: number;
+  onPlay: () => void;
+  onPause: () => void;
+  onSeek: (time: number) => void;
+  onClose: () => void;
+  onToggleMute: () => void;
+  onSelectLevel: (idx: number) => void;
+  onSelectAudioTrack: (idx: number) => void;
+  onSelectSubtitleTrack: (idx: number) => void;
+}
+
+// ─── Menu item used by the existing dropdown popovers ────────────────────────
 
 interface MenuItemProps {
   label: string;
@@ -42,7 +102,7 @@ function MenuItem({ label, isActive, focusKey: fk, onSelect }: MenuItemProps) {
   const highlighted = isActive || focused;
 
   return (
-    <li style={{ listStyle: "none" }}>
+    <li style={{ listStyle: "none" }} role="option" aria-selected={isActive}>
       <button
         ref={ref as RefObject<HTMLButtonElement>}
         type="button"
@@ -68,33 +128,87 @@ function MenuItem({ label, isActive, focusKey: fk, onSelect }: MenuItemProps) {
   );
 }
 
-// ─── PlayerControls ──────────────────────────────────────────────────────────
+// ─── Control-bar button ──────────────────────────────────────────────────────
 
-export interface PlayerControlsProps {
-  title: string;
-  status: "idle" | "loading" | "playing" | "paused" | "buffering" | "seeking" | "error";
-  currentTime: number;
-  duration: number;
-  levels: HlsLevel[];
-  audioTracks: HlsAudioTrack[];
-  subtitleTracks: HlsSubtitleTrack[];
-  currentLevel?: number;
-  currentAudioTrack?: number;
-  currentSubtitleTrack?: number;
-  onPlay: () => void;
-  onPause: () => void;
-  onSeek: (time: number) => void;
-  onClose: () => void;
-  onSelectLevel: (idx: number) => void;
-  onSelectAudioTrack: (idx: number) => void;
-  onSelectSubtitleTrack: (idx: number) => void;
+interface ControlButtonProps {
+  focusKey: string;
+  label: string;
+  icon: string;
+  focusable?: boolean;
+  onPress: () => void;
+  isEdgeLeft?: boolean;
+  isEdgeRight?: boolean;
+  ariaExpanded?: boolean;
+  ariaHasPopup?: boolean;
+  extraStyle?: CSSProperties;
 }
+
+function ControlButton({
+  focusKey,
+  label,
+  icon,
+  focusable = true,
+  onPress,
+  isEdgeLeft = false,
+  isEdgeRight = false,
+  ariaExpanded,
+  ariaHasPopup,
+  extraStyle,
+}: ControlButtonProps) {
+  const { ref, focused } = useFocusable({
+    focusKey,
+    focusable,
+    onEnterPress: onPress,
+    // Up from any control bar button → Back (spec §4.2).
+    // Edge Left/Right blocks default nav so focus doesn't wander (spec: no wrap).
+    // Down is a no-op — nothing below the control bar.
+    // All returns false only when we explicitly handle the direction.
+    onArrowPress: (direction) => {
+      if (direction === "up") {
+        setFocus(FK.BACK);
+        return false;
+      }
+      if (direction === "down") return false;
+      if (direction === "left" && isEdgeLeft) return false;
+      if (direction === "right" && isEdgeRight) return false;
+      return true;
+    },
+  });
+
+  return (
+    <button
+      ref={ref as RefObject<HTMLButtonElement>}
+      type="button"
+      className="focus-ring"
+      aria-label={label}
+      aria-disabled={!focusable}
+      aria-expanded={ariaExpanded}
+      aria-haspopup={ariaHasPopup}
+      onClick={focusable ? onPress : undefined}
+      tabIndex={focusable ? 0 : -1}
+      style={{
+        ...controlButtonStyle,
+        opacity: focusable ? 1 : 0.35,
+        outline: focused ? "2px solid var(--accent-copper)" : undefined,
+        cursor: focusable ? "pointer" : "default",
+        ...extraStyle,
+      }}
+    >
+      {icon}
+    </button>
+  );
+}
+
+// ─── PlayerControls ──────────────────────────────────────────────────────────
 
 export function PlayerControls({
   title,
+  kind,
   status,
   currentTime,
   duration,
+  volume,
+  muted,
   levels,
   audioTracks,
   subtitleTracks,
@@ -105,20 +219,27 @@ export function PlayerControls({
   onPause,
   onSeek,
   onClose,
+  onToggleMute,
   onSelectLevel,
   onSelectAudioTrack,
   onSelectSubtitleTrack,
 }: PlayerControlsProps) {
-  // Controls start HIDDEN (user wants full-bleed video when idle) and reveal
-  // on any key / remote / mouse input. After AUTO_HIDE_MS of no activity they
-  // fade back out.
-  const [visible, setVisible] = useState(false);
-  const [openMenu, setOpenMenu] = useState<"quality" | "audio" | "subtitles" | null>(null);
+  // Controls open visible (spec §4.1), then fade after AUTO_HIDE_MS idle.
+  const [visible, setVisible] = useState(true);
+  const [openMenu, setOpenMenu] = useState<"audio" | "subtitles" | "quality" | null>(null);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Use a ref for visibility inside capture-phase handler so we don't depend
+  // on stale state captured by the effect closure.
+  const visibleRef = useRef(visible);
+  visibleRef.current = visible;
 
-  const { ref: containerRef, focusKey } = useFocusable({
+  const { ref: containerRef, focusKey: containerFocusKey } = useFocusable({
     focusKey: "PLAYER_CONTROLS",
+    trackChildren: true,
   });
+
+  const isPlaying = status === "playing";
+  const isLive = kind === "live";
 
   const scheduleHide = useCallback(() => {
     if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
@@ -128,373 +249,488 @@ export function PlayerControls({
     }, AUTO_HIDE_MS);
   }, []);
 
-  const showControls = useCallback(() => {
+  const wake = useCallback(() => {
     setVisible(true);
     scheduleHide();
   }, [scheduleHide]);
 
-  // Wire keyboard + remote events. Any keypress surfaces the controls; the
-  // auto-hide timer restarts with each interaction. Media-key handling covers
-  // TV remotes that emit MediaPlayPause / MediaFastForward / MediaRewind.
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      showControls();
+  const togglePlayPause = useCallback(() => {
+    if (isPlaying) {
+      onPause();
+    } else {
+      onPlay();
+    }
+  }, [isPlaying, onPlay, onPause]);
 
-      if (e.key === "ArrowLeft" || e.key === "MediaRewind" || e.key === "j") {
-        e.preventDefault();
-        onSeek(currentTime - 10);
-      } else if (
-        e.key === "ArrowRight" ||
-        e.key === "MediaFastForward" ||
-        e.key === "l"
-      ) {
-        e.preventDefault();
-        onSeek(currentTime + 10);
-      } else if (
-        e.key === "MediaPlayPause" ||
-        e.key === " " ||
-        e.key === "k"
-      ) {
-        e.preventDefault();
-        if (status === "playing") {
-          onPause();
-        } else {
-          onPlay();
-        }
-      } else if (e.key === "Escape" || e.key === "Back" || e.key === "GoBack") {
+  // Initial focus on Play/Pause when the player opens (spec §4.1).
+  useEffect(() => {
+    setFocus(FK.PLAY_PAUSE);
+    scheduleHide();
+    return () => {
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+    };
+    // Intentionally mount-only — the focus grab is a one-shot. Re-seeding
+    // focus on every status flip would fight the D-pad.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Capture-phase key interceptor: when controls are hidden, swallow arrow
+  // keys (wake-only — spec §4.3) and short-circuit Enter to toggle play/pause
+  // (spec §4.3 exception). Also handles media keys (TV remote) and Escape.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      // Escape / Back always closes (or closes the topmost popover first).
+      if (e.key === "Escape" || e.key === "Back" || e.key === "GoBack") {
         e.preventDefault();
         if (openMenu) {
           setOpenMenu(null);
         } else {
           onClose();
         }
+        return;
+      }
+
+      // Media keys + keyboard shortcuts — YouTube-style bindings. These work
+      // regardless of visibility because they're explicit "do thing" keys,
+      // not navigation.
+      if (e.key === "MediaPlayPause" || e.key === " " || e.key === "k") {
+        e.preventDefault();
+        togglePlayPause();
+        wake();
+        return;
+      }
+      if ((e.key === "MediaRewind" || e.key === "j") && !isLive) {
+        e.preventDefault();
+        onSeek(currentTime - 10);
+        wake();
+        return;
+      }
+      if ((e.key === "MediaFastForward" || e.key === "l") && !isLive) {
+        e.preventDefault();
+        onSeek(currentTime + 10);
+        wake();
+        return;
+      }
+
+      const isArrow =
+        e.key === "ArrowUp" ||
+        e.key === "ArrowDown" ||
+        e.key === "ArrowLeft" ||
+        e.key === "ArrowRight";
+      const isEnter = e.key === "Enter" || e.key === "OK";
+
+      if (!visibleRef.current) {
+        if (isArrow) {
+          // Wake-only: swallow this press so norigin doesn't navigate.
+          // The next press registers normally.
+          e.preventDefault();
+          e.stopPropagation();
+          wake();
+          return;
+        }
+        if (isEnter) {
+          // Spec §4.3: Enter while hidden short-circuits pause/play regardless
+          // of whichever control was last focused. Block norigin from also
+          // firing the focused button's onEnter (would double-toggle).
+          e.preventDefault();
+          e.stopPropagation();
+          togglePlayPause();
+          wake();
+          return;
+        }
+      } else {
+        // Visible: any key resets the idle timer. Let norigin handle nav.
+        if (isArrow || isEnter) wake();
       }
     };
-    const handleMouseMove = () => showControls();
 
-    window.addEventListener("keydown", handleKeyDown);
-    window.addEventListener("mousemove", handleMouseMove);
+    const onMouseMove = () => wake();
+
+    // Capture phase so we can preempt norigin's window listener.
+    window.addEventListener("keydown", onKeyDown, true);
+    window.addEventListener("mousemove", onMouseMove);
     return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("keydown", onKeyDown, true);
+      window.removeEventListener("mousemove", onMouseMove);
     };
-  }, [
-    currentTime,
-    onSeek,
-    onClose,
-    onPlay,
-    onPause,
-    status,
-    openMenu,
-    showControls,
-  ]);
+  }, [onClose, onSeek, currentTime, isLive, openMenu, togglePlayPause, wake]);
 
-  // Start auto-hide on mount
-  useEffect(() => {
-    scheduleHide();
-    return () => {
-      if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
-    };
-  }, [scheduleHide]);
-
-  const isPlaying = status === "playing";
   const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
 
-  const togglePlayPause = () => {
-    showControls();
-    if (isPlaying) {
-      onPause();
-    } else {
-      onPlay();
-    }
-  };
+  // ── Focusables for top bar ────────────────────────────────────────────────
 
-  const { ref: playPauseRef } = useFocusable({
-    focusKey: "PLAYER_PLAY_PAUSE",
-    onEnterPress: togglePlayPause,
-  });
-
-  const { ref: qualityRef } = useFocusable({
-    focusKey: "PLAYER_QUALITY",
-    onEnterPress: () => {
-      showControls();
-      setOpenMenu((m) => (m === "quality" ? null : "quality"));
+  const { ref: backRef, focused: backFocused } = useFocusable({
+    focusKey: FK.BACK,
+    onEnterPress: onClose,
+    onArrowPress: (direction) => {
+      // Down from Back → Play/Pause (spec §4.2 — predictable return).
+      // Up/Left/Right are no-ops (nothing to navigate to).
+      if (direction === "down") {
+        setFocus(FK.PLAY_PAUSE);
+        return false;
+      }
+      return false;
     },
   });
 
-  const { ref: audioRef } = useFocusable({
-    focusKey: "PLAYER_AUDIO",
-    onEnterPress: () => {
-      showControls();
-      setOpenMenu((m) => (m === "audio" ? null : "audio"));
-    },
-  });
+  // ── Control bar button handlers ──────────────────────────────────────────
 
-  const { ref: subtitlesRef } = useFocusable({
-    focusKey: "PLAYER_SUBTITLES",
-    onEnterPress: () => {
-      showControls();
-      setOpenMenu((m) => (m === "subtitles" ? null : "subtitles"));
-    },
-  });
+  const handleSeekBack = useCallback(() => onSeek(currentTime - 10), [onSeek, currentTime]);
+  const handleSeekForward = useCallback(() => onSeek(currentTime + 10), [onSeek, currentTime]);
+  const openAudio = useCallback(() => setOpenMenu((m) => (m === "audio" ? null : "audio")), []);
+  const openSubs = useCallback(() => setOpenMenu((m) => (m === "subtitles" ? null : "subtitles")), []);
+  const openQuality = useCallback(() => setOpenMenu((m) => (m === "quality" ? null : "quality")), []);
 
-  if (!visible) {
-    return null;
-  }
+  // ── Adaptive control focusability ─────────────────────────────────────────
+  // Spec §3: disabled controls use focusable:false so D-pad walks past them.
+  //   Live: no ±10s (can't seek a live stream without a buffer window).
+  //   All kinds in 6a: Play/Pause is always the left edge (prev/next deferred).
+  //   Quality is the right edge — right-nav blocked there.
+  //   Volume / Audio / Subs are always focusable; their popovers are empty
+  //   when no data but the button itself should still accept Enter.
+
+  const seekable = !isLive;
+  const audioHasOptions = audioTracks.length > 1;
+  const subsAvailable = subtitleTracks.length > 0;
+  const qualityAvailable = levels.length > 0;
+
+  // Compute the rightmost focusable control so we know who should block the
+  // Right edge (spec §4.2: no wrap). Walk the list in visual order.
+  const orderedKeys: string[] = [
+    FK.PLAY_PAUSE,
+    seekable ? FK.SEEK_BACK : null,
+    seekable ? FK.SEEK_FORWARD : null,
+    FK.VOLUME,
+    audioHasOptions ? FK.AUDIO : null,
+    subsAvailable ? FK.SUBTITLES : null,
+    qualityAvailable ? FK.QUALITY : null,
+  ].filter((k): k is NonNullable<typeof k> => k !== null);
+  const leftEdgeKey = orderedKeys[0];
+  const rightEdgeKey = orderedKeys[orderedKeys.length - 1];
 
   return (
-    <FocusContext.Provider value={focusKey}>
-      {/* Controls container — position: absolute inside PlayerShell (NOT fixed) */}
+    <FocusContext.Provider value={containerFocusKey}>
       <div
         ref={containerRef as RefObject<HTMLDivElement>}
         data-testid="player-controls"
+        aria-hidden={!visible}
         style={{
           position: "absolute",
           inset: 0,
+          pointerEvents: visible ? "auto" : "none",
+          opacity: visible ? 1 : 0,
+          transition: `opacity ${FADE_MS}ms ease-out`,
           display: "flex",
           flexDirection: "column",
-          justifyContent: "flex-end",
-          background:
-            "linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.4) 40%, transparent 70%)",
-          padding: "var(--space-6)",
-          boxSizing: "border-box",
+          justifyContent: "space-between",
         }}
       >
-        {/* Title */}
-        <p
-          style={{
-            margin: "0 0 var(--space-4) 0",
-            fontSize: "var(--text-title-size)",
-            fontWeight: 600,
-            color: "var(--text-primary)",
-          }}
-        >
-          {title}
-        </p>
-
-        {/* Progress bar */}
-        <div
-          role="progressbar"
-          aria-valuemin={0}
-          aria-valuemax={100}
-          aria-valuenow={Math.round(progress)}
-          aria-label="Video progress"
-          style={{
-            height: "4px",
-            background: "rgba(255,255,255,0.2)",
-            borderRadius: "2px",
-            marginBottom: "var(--space-3)",
-            position: "relative",
-          }}
-        >
-          <div
-            style={{
-              position: "absolute",
-              left: 0,
-              top: 0,
-              height: "100%",
-              width: `${progress}%`,
-              background: "var(--accent-copper)",
-              borderRadius: "2px",
-            }}
-          />
-        </div>
-
-        {/* Time + Controls row */}
+        {/* ─── TOP BAR ─────────────────────────────────────────────────── */}
         <div
           style={{
             display: "flex",
             alignItems: "center",
             gap: "var(--space-4)",
+            padding: "var(--space-4) var(--space-6)",
+            background:
+              "linear-gradient(to bottom, rgba(0,0,0,0.65) 0%, rgba(0,0,0,0.25) 70%, transparent 100%)",
           }}
         >
-          {/* Play/Pause */}
           <button
-            ref={playPauseRef as RefObject<HTMLButtonElement>}
+            ref={backRef as RefObject<HTMLButtonElement>}
             type="button"
             className="focus-ring"
-            aria-label={isPlaying ? "Pause" : "Play"}
-            onClick={togglePlayPause}
-            style={controlButtonStyle}
-          >
-            {isPlaying ? "⏸" : "▶"}
-          </button>
-
-          {/* Time display */}
-          <span
+            aria-label="Back"
+            onClick={onClose}
             style={{
-              fontVariantNumeric: "tabular-nums",
-              fontSize: "var(--text-label-size)",
-              color: "var(--text-secondary)",
+              ...controlButtonStyle,
+              outline: backFocused ? "2px solid var(--accent-copper)" : undefined,
             }}
           >
-            {formatTime(currentTime)}
-            {duration > 0 ? ` / ${formatTime(duration)}` : ""}
+            ←
+          </button>
+          <span
+            style={{
+              fontSize: "var(--text-title-size)",
+              fontWeight: 600,
+              color: "var(--text-primary)",
+              flex: 1,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {title}
           </span>
-
-          {/* Status badge */}
-          {(status === "buffering" || status === "loading") && (
+          {isLive ? (
             <span
-              aria-live="polite"
+              aria-label="Live"
               style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "var(--space-2)",
                 fontSize: "var(--text-label-size)",
-                color: "var(--accent-copper)",
                 letterSpacing: "var(--text-label-tracking)",
                 textTransform: "uppercase",
+                color: "var(--text-primary)",
+                padding: "var(--space-1) var(--space-3)",
+                borderRadius: "var(--radius-sm)",
+                background: "rgba(0,0,0,0.45)",
               }}
             >
-              Buffering…
+              <span
+                style={{
+                  width: "8px",
+                  height: "8px",
+                  borderRadius: "50%",
+                  background: "#E5484D",
+                  display: "inline-block",
+                }}
+              />
+              Live
+            </span>
+          ) : (
+            <span
+              style={{
+                fontVariantNumeric: "tabular-nums",
+                fontSize: "var(--text-body-size)",
+                color: "var(--text-secondary)",
+              }}
+            >
+              {formatTime(currentTime)}
+              {duration > 0 ? ` / ${formatTime(duration)}` : ""}
             </span>
           )}
+        </div>
 
-          {/* Spacer */}
-          <div style={{ flex: 1 }} />
-
-          {/* Quality switcher */}
-          {levels.length > 0 && (
-            <div style={{ position: "relative" }}>
-              <button
-                ref={qualityRef as RefObject<HTMLButtonElement>}
-                type="button"
-                className="focus-ring"
-                aria-label="Quality"
-                aria-haspopup="listbox"
-                aria-expanded={openMenu === "quality"}
-                onClick={() => {
-                  showControls();
-                  setOpenMenu((m) => (m === "quality" ? null : "quality"));
+        {/* ─── BOTTOM STACK: scrubber + control bar ─────────────────────── */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "var(--space-3)",
+            padding: "var(--space-4) var(--space-6)",
+            background:
+              "linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.45) 60%, transparent 100%)",
+          }}
+        >
+          {/* Scrubber band — hidden on Live (LIVE badge renders in top bar). */}
+          {!isLive && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--space-3)",
+                fontSize: "var(--text-label-size)",
+                color: "var(--text-secondary)",
+                fontVariantNumeric: "tabular-nums",
+              }}
+            >
+              <span>{formatTime(currentTime)}</span>
+              <div
+                role="progressbar"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={Math.round(progress)}
+                aria-label="Video progress"
+                style={{
+                  flex: 1,
+                  height: "4px",
+                  background: "rgba(255,255,255,0.2)",
+                  borderRadius: "2px",
+                  position: "relative",
                 }}
-                style={controlButtonStyle}
               >
-                {currentLevel >= 0 && levels[currentLevel]
-                  ? levels[currentLevel]!.name
-                  : "Auto"}
-              </button>
-              {openMenu === "quality" && (
-                <ul style={menuStyle}>
-                  <MenuItem
-                    label="Auto"
-                    isActive={currentLevel === -1}
-                    focusKey="PLAYER_QUALITY_AUTO"
-                    onSelect={() => {
-                      onSelectLevel(-1);
-                      setOpenMenu(null);
-                    }}
-                  />
-                  {levels.map((level) => (
-                    <MenuItem
-                      key={level.index}
-                      label={level.name}
-                      isActive={currentLevel === level.index}
-                      focusKey={`PLAYER_QUALITY_${level.index}`}
-                      onSelect={() => {
-                        onSelectLevel(level.index);
-                        setOpenMenu(null);
-                      }}
-                    />
-                  ))}
-                </ul>
-              )}
+                <div
+                  style={{
+                    position: "absolute",
+                    left: 0,
+                    top: 0,
+                    height: "100%",
+                    width: `${progress}%`,
+                    background: "var(--accent-copper)",
+                    borderRadius: "2px",
+                  }}
+                />
+              </div>
+              <span>{duration > 0 ? formatTime(duration) : "—"}</span>
             </div>
           )}
 
-          {/* Audio track switcher */}
-          {audioTracks.length > 1 && (
-            <div style={{ position: "relative" }}>
-              <button
-                ref={audioRef as RefObject<HTMLButtonElement>}
-                type="button"
-                className="focus-ring"
-                aria-label="Audio track"
-                aria-haspopup="listbox"
-                aria-expanded={openMenu === "audio"}
-                onClick={() => {
-                  showControls();
-                  setOpenMenu((m) => (m === "audio" ? null : "audio"));
-                }}
-                style={controlButtonStyle}
-              >
-                {currentAudioTrack >= 0 && audioTracks[currentAudioTrack]
-                  ? audioTracks[currentAudioTrack]!.name
-                  : "Audio"}
-              </button>
-              {openMenu === "audio" && (
-                <ul style={menuStyle}>
-                  {audioTracks.map((track) => (
-                    <MenuItem
-                      key={track.index}
-                      label={track.name || track.lang || `Audio ${track.index}`}
-                      isActive={currentAudioTrack === track.index}
-                      focusKey={`PLAYER_AUDIO_${track.index}`}
-                      onSelect={() => {
-                        onSelectAudioTrack(track.index);
-                        setOpenMenu(null);
-                      }}
-                    />
-                  ))}
-                </ul>
-              )}
-            </div>
-          )}
-
-          {/* Subtitle switcher */}
-          {subtitleTracks.length > 0 && (
-            <div style={{ position: "relative" }}>
-              <button
-                ref={subtitlesRef as RefObject<HTMLButtonElement>}
-                type="button"
-                className="focus-ring"
-                aria-label="Subtitles"
-                aria-haspopup="listbox"
-                aria-expanded={openMenu === "subtitles"}
-                onClick={() => {
-                  showControls();
-                  setOpenMenu((m) => (m === "subtitles" ? null : "subtitles"));
-                }}
-                style={controlButtonStyle}
-              >
-                {currentSubtitleTrack >= 0 && subtitleTracks[currentSubtitleTrack]
-                  ? subtitleTracks[currentSubtitleTrack]!.name
-                  : "Subtitles"}
-              </button>
-              {openMenu === "subtitles" && (
-                <ul style={menuStyle}>
-                  <MenuItem
-                    label="Off"
-                    isActive={currentSubtitleTrack === -1}
-                    focusKey="PLAYER_SUBTITLES_OFF"
-                    onSelect={() => {
-                      onSelectSubtitleTrack(-1);
-                      setOpenMenu(null);
-                    }}
-                  />
-                  {subtitleTracks.map((track) => (
-                    <MenuItem
-                      key={track.index}
-                      label={track.name || track.lang || `Sub ${track.index}`}
-                      isActive={currentSubtitleTrack === track.index}
-                      focusKey={`PLAYER_SUBTITLE_${track.index}`}
-                      onSelect={() => {
-                        onSelectSubtitleTrack(track.index);
-                        setOpenMenu(null);
-                      }}
-                    />
-                  ))}
-                </ul>
-              )}
-            </div>
-          )}
-
-          {/* Close button */}
-          <button
-            type="button"
-            className="focus-ring"
-            aria-label="Close player"
-            onClick={onClose}
-            style={controlButtonStyle}
+          {/* Control bar */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "var(--space-3)",
+            }}
           >
-            ✕
-          </button>
+            <ControlButton
+              focusKey={FK.PLAY_PAUSE}
+              label={isPlaying ? "Pause" : "Play"}
+              icon={isPlaying ? "⏸" : "▶"}
+              onPress={togglePlayPause}
+              isEdgeLeft={leftEdgeKey === FK.PLAY_PAUSE}
+              isEdgeRight={rightEdgeKey === FK.PLAY_PAUSE}
+            />
+
+            <ControlButton
+              focusKey={FK.SEEK_BACK}
+              label="Back 10 seconds"
+              icon="◀◀"
+              focusable={seekable}
+              onPress={handleSeekBack}
+              isEdgeLeft={leftEdgeKey === FK.SEEK_BACK}
+              isEdgeRight={rightEdgeKey === FK.SEEK_BACK}
+            />
+            <ControlButton
+              focusKey={FK.SEEK_FORWARD}
+              label="Forward 10 seconds"
+              icon="▶▶"
+              focusable={seekable}
+              onPress={handleSeekForward}
+              isEdgeLeft={leftEdgeKey === FK.SEEK_FORWARD}
+              isEdgeRight={rightEdgeKey === FK.SEEK_FORWARD}
+            />
+
+            {/* Spacer pushes the right-hand selectors to the edge */}
+            <div style={{ flex: 1 }} />
+
+            <ControlButton
+              focusKey={FK.VOLUME}
+              label={muted ? "Unmute" : "Mute"}
+              icon={volumeIcon(volume, muted)}
+              onPress={onToggleMute}
+              isEdgeLeft={leftEdgeKey === FK.VOLUME}
+              isEdgeRight={rightEdgeKey === FK.VOLUME}
+            />
+
+            {audioHasOptions && (
+              <div style={{ position: "relative" }}>
+                <ControlButton
+                  focusKey={FK.AUDIO}
+                  label="Audio track"
+                  icon={`🎧 ${
+                    currentAudioTrack >= 0 && audioTracks[currentAudioTrack]
+                      ? audioTracks[currentAudioTrack]!.name
+                      : "Audio"
+                  }`}
+                  onPress={openAudio}
+                  ariaExpanded={openMenu === "audio"}
+                  ariaHasPopup
+                  isEdgeLeft={leftEdgeKey === FK.AUDIO}
+                  isEdgeRight={rightEdgeKey === FK.AUDIO}
+                />
+                {openMenu === "audio" && (
+                  <ul style={menuStyle} role="listbox" aria-label="Audio tracks">
+                    {audioTracks.map((track) => (
+                      <MenuItem
+                        key={track.index}
+                        label={track.name || track.lang || `Audio ${track.index}`}
+                        isActive={currentAudioTrack === track.index}
+                        focusKey={`PLAYER_AUDIO_${track.index}`}
+                        onSelect={() => {
+                          onSelectAudioTrack(track.index);
+                          setOpenMenu(null);
+                        }}
+                      />
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+
+            {subsAvailable && (
+              <div style={{ position: "relative" }}>
+                <ControlButton
+                  focusKey={FK.SUBTITLES}
+                  label="Subtitles"
+                  icon={`CC ${
+                    currentSubtitleTrack >= 0 && subtitleTracks[currentSubtitleTrack]
+                      ? subtitleTracks[currentSubtitleTrack]!.name
+                      : "Off"
+                  }`}
+                  onPress={openSubs}
+                  ariaExpanded={openMenu === "subtitles"}
+                  ariaHasPopup
+                  isEdgeLeft={leftEdgeKey === FK.SUBTITLES}
+                  isEdgeRight={rightEdgeKey === FK.SUBTITLES}
+                />
+                {openMenu === "subtitles" && (
+                  <ul style={menuStyle} role="listbox" aria-label="Subtitles">
+                    <MenuItem
+                      label="Off"
+                      isActive={currentSubtitleTrack === -1}
+                      focusKey="PLAYER_SUBTITLES_OFF"
+                      onSelect={() => {
+                        onSelectSubtitleTrack(-1);
+                        setOpenMenu(null);
+                      }}
+                    />
+                    {subtitleTracks.map((track) => (
+                      <MenuItem
+                        key={track.index}
+                        label={track.name || track.lang || `Sub ${track.index}`}
+                        isActive={currentSubtitleTrack === track.index}
+                        focusKey={`PLAYER_SUBTITLE_${track.index}`}
+                        onSelect={() => {
+                          onSelectSubtitleTrack(track.index);
+                          setOpenMenu(null);
+                        }}
+                      />
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+
+            {qualityAvailable && (
+              <div style={{ position: "relative" }}>
+                <ControlButton
+                  focusKey={FK.QUALITY}
+                  label="Quality"
+                  icon={`⚙ ${
+                    currentLevel >= 0 && levels[currentLevel]
+                      ? levels[currentLevel]!.name
+                      : "Auto"
+                  }`}
+                  onPress={openQuality}
+                  ariaExpanded={openMenu === "quality"}
+                  ariaHasPopup
+                  isEdgeLeft={leftEdgeKey === FK.QUALITY}
+                  isEdgeRight={rightEdgeKey === FK.QUALITY}
+                />
+                {openMenu === "quality" && (
+                  <ul style={menuStyle} role="listbox" aria-label="Quality">
+                    <MenuItem
+                      label="Auto"
+                      isActive={currentLevel === -1}
+                      focusKey="PLAYER_QUALITY_AUTO"
+                      onSelect={() => {
+                        onSelectLevel(-1);
+                        setOpenMenu(null);
+                      }}
+                    />
+                    {/* Spec §5.3: highest-first (most common intent = "lower it") */}
+                    {[...levels]
+                      .sort((a, b) => b.height - a.height)
+                      .map((level) => (
+                        <MenuItem
+                          key={level.index}
+                          label={level.name}
+                          isActive={currentLevel === level.index}
+                          focusKey={`PLAYER_QUALITY_${level.index}`}
+                          onSelect={() => {
+                            onSelectLevel(level.index);
+                            setOpenMenu(null);
+                          }}
+                        />
+                      ))}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </FocusContext.Provider>
@@ -503,18 +739,18 @@ export function PlayerControls({
 
 // ─── Styles ─────────────────────────────────────────────────────────────────
 
-const controlButtonStyle: React.CSSProperties = {
+const controlButtonStyle: CSSProperties = {
   background: "rgba(255,255,255,0.15)",
   color: "var(--text-primary)",
   border: "none",
   borderRadius: "var(--radius-sm)",
   padding: "var(--space-2) var(--space-3)",
-  cursor: "pointer",
   fontSize: "var(--text-body-size)",
   minWidth: "36px",
+  minHeight: "36px",
 };
 
-const menuStyle: React.CSSProperties = {
+const menuStyle: CSSProperties = {
   position: "absolute",
   bottom: "calc(100% + var(--space-2))",
   right: 0,
@@ -522,7 +758,7 @@ const menuStyle: React.CSSProperties = {
   borderRadius: "var(--radius-md)",
   padding: "var(--space-2)",
   margin: 0,
-  minWidth: "120px",
+  minWidth: "160px",
   display: "flex",
   flexDirection: "column",
   gap: "var(--space-1)",

--- a/src/player/PlayerShell.test.tsx
+++ b/src/player/PlayerShell.test.tsx
@@ -49,6 +49,7 @@ vi.mock("@noriginmedia/norigin-spatial-navigation", () => ({
   FocusContext: {
     Provider: ({ children }: { children: ReactNode }) => children,
   },
+  setFocus: vi.fn(),
 }));
 
 // ─── Test wrapper ─────────────────────────────────────────────────────────────

--- a/src/player/PlayerShell.tsx
+++ b/src/player/PlayerShell.tsx
@@ -7,11 +7,11 @@
  *  - NO CSS transform on this element (breaks position:fixed children).
  *  - NO backdrop-filter (TV perf kill).
  *  - NO transition-all.
- *  - Full-screen overlay, no HTML5 controls — we render PlayerControls.
+ *  - Full-screen overlay, no HTML5 controls — PlayerControls owns the UI.
  *  - FocusContext wrapper so D-pad works inside the player.
  */
 import type { RefObject } from "react";
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect, useCallback } from "react";
 import { useFocusable, FocusContext } from "@noriginmedia/norigin-spatial-navigation";
 import { usePlayerStore } from "./PlayerProvider";
 import { useHlsPlayer } from "./useHlsPlayer";
@@ -23,7 +23,7 @@ export function PlayerShell() {
 
   const src = state.status === "open" ? state.src : undefined;
   const title = state.status === "open" ? state.title : "";
-  const kind = state.status === "open" ? state.kind : undefined;
+  const kind = state.status === "open" ? state.kind : "vod";
 
   const {
     status,
@@ -35,6 +35,7 @@ export function PlayerShell() {
     play,
     pause,
     seek,
+    setVolume,
     selectLevel,
     selectAudioTrack,
     selectSubtitleTrack,
@@ -43,29 +44,60 @@ export function PlayerShell() {
   const [currentLevel, setCurrentLevel] = useState(-1);
   const [currentAudioTrack, setCurrentAudioTrack] = useState(-1);
   const [currentSubtitleTrack, setCurrentSubtitleTrack] = useState(-1);
-
-  // Reset track selection when a new src loads — derive from src change
-  // by initializing to -1. Actual updates happen via callbacks below.
+  const [volume, setVolumeState] = useState(1);
+  const [muted, setMuted] = useState(false);
+  const lastVolumeBeforeMute = useRef(1);
 
   const { ref: shellRef, focusKey } = useFocusable({
     focusKey: "PLAYER_SHELL",
     isFocusBoundary: true,
   });
 
-  const handleSelectLevel = (idx: number) => {
-    selectLevel(idx);
-    setCurrentLevel(idx);
-  };
+  // Reset track / level state when a new src loads so stale "720p" labels
+  // don't stick around through channel switches.
+  useEffect(() => {
+    setCurrentLevel(-1);
+    setCurrentAudioTrack(-1);
+    setCurrentSubtitleTrack(-1);
+  }, [src]);
 
-  const handleSelectAudioTrack = (idx: number) => {
-    selectAudioTrack(idx);
-    setCurrentAudioTrack(idx);
-  };
+  const handleSelectLevel = useCallback(
+    (idx: number) => {
+      selectLevel(idx);
+      setCurrentLevel(idx);
+    },
+    [selectLevel],
+  );
 
-  const handleSelectSubtitleTrack = (idx: number) => {
-    selectSubtitleTrack(idx);
-    setCurrentSubtitleTrack(idx);
-  };
+  const handleSelectAudioTrack = useCallback(
+    (idx: number) => {
+      selectAudioTrack(idx);
+      setCurrentAudioTrack(idx);
+    },
+    [selectAudioTrack],
+  );
+
+  const handleSelectSubtitleTrack = useCallback(
+    (idx: number) => {
+      selectSubtitleTrack(idx);
+      setCurrentSubtitleTrack(idx);
+    },
+    [selectSubtitleTrack],
+  );
+
+  const handleToggleMute = useCallback(() => {
+    if (muted) {
+      setMuted(false);
+      const v = lastVolumeBeforeMute.current || 1;
+      setVolumeState(v);
+      setVolume(v);
+    } else {
+      lastVolumeBeforeMute.current = volume;
+      setMuted(true);
+      setVolumeState(0);
+      setVolume(0);
+    }
+  }, [muted, volume, setVolume]);
 
   if (state.status === "idle") {
     return null;
@@ -84,9 +116,6 @@ export function PlayerShell() {
           background: "#000",
         }}
       >
-        {/* Video element — no HTML5 controls.
-            Captions are provided by hls.js subtitle tracks (dynamic).
-            eslint-disable-next-line jsx-a11y/media-has-caption */}
         {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
         <video
           ref={videoRef}
@@ -129,7 +158,8 @@ export function PlayerShell() {
           </div>
         )}
 
-        {/* Error state */}
+        {/* Playback-failure overlay — full treatment ships in Phase 6c. For now
+            keep the minimal close-out so error states don't leave users stuck. */}
         {status === "error" && (
           <div
             style={{
@@ -168,13 +198,16 @@ export function PlayerShell() {
           </div>
         )}
 
-        {/* Controls overlay — absolute, NOT fixed */}
+        {/* Controls overlay */}
         {status !== "error" && (
           <PlayerControls
             title={title}
+            kind={kind}
             status={status}
             currentTime={currentTime}
             duration={duration}
+            volume={volume}
+            muted={muted}
             levels={levels}
             audioTracks={audioTracks}
             subtitleTracks={subtitleTracks}
@@ -185,6 +218,7 @@ export function PlayerShell() {
             onPause={pause}
             onSeek={seek}
             onClose={close}
+            onToggleMute={handleToggleMute}
             onSelectLevel={handleSelectLevel}
             onSelectAudioTrack={handleSelectAudioTrack}
             onSelectSubtitleTrack={handleSelectSubtitleTrack}
@@ -192,7 +226,6 @@ export function PlayerShell() {
         )}
       </div>
 
-      {/* Spinner keyframe — injected once */}
       <style>{`
         @keyframes sv-spin {
           to { transform: rotate(360deg); }


### PR DESCRIPTION
## Summary

Rewrites the player overlay per `docs/ux/05-player.md` §2-§4, §7, §8 — the structural shell for Phase 6. Popover polish and failure overlay land as follow-on PRs per the handoff plan.

### Ships

- **Three glass bands**: top bar (Back + title + timestamp or ● Live badge), scrubber with left/right time captions, control bar with Play/Pause · ±10s · Volume · Audio · Subs · Quality.
- **D-pad flow** (spec §4.1–4.2): initial focus on Play/Pause, Up from any control → Back, Down from Back → Play/Pause, Left/Right walks the bar with explicit edge blocks (no wrap).
- **Auto-hide** (spec §4.3): 3s idle, 300ms fade. First arrow is wake-only; **Enter short-circuits play/pause** even when hidden. Capture-phase keydown preempts norigin so wake presses don't double-fire.
- **Live mode** (spec §8): scrubber hidden, ● Live badge in top bar, ±10s rendered `focusable:false` so D-pad skips them, `j`/`l` seek shortcuts disabled.
- **Quality popover** orders levels **highest-first** per §5.3. Popovers expose `role="listbox"` / `role="option"` with `aria-selected`.
- **Volume** toggles mute with icon swap (🔇/🔉/🔊) — full vertical slider ships in 6b.

### Deferred (acknowledged in handoff budget, 3-5 PRs for Phase 6)

- **6b**: prev/next episode + channel wiring, hold-to-scrub, full popover list-walk with Left/Right-advance, volume slider popover.
- **6c**: amber failure overlay with tier-lock copy, `markTierLocked` write integration, `prefers-reduced-motion`.

### Norigin safety

All `onArrowPress` handlers return `true` by default; only explicitly return `false` to block nav (Up/Down redirect, edge blocks). Aligns with the focus-vanish bug guidance — the global recovery watcher can absorb anything we don't explicitly handle.

## Test plan

- [x] `npm test` — 272/272 (was 265; added 7 player tests)
- [x] `npm run typecheck` — clean
- [ ] Prod deploy + user validation round (Gate 3 per handoff)
- [ ] Verify on Fire TV: D-pad flow, Enter short-circuit, auto-hide timing
- [ ] Verify Live vs VOD: ± 10s skip on Live, scrubber hidden on Live
- [ ] Verify Quality popover opens highest-first

🤖 Generated with [Claude Code](https://claude.com/claude-code)