### PR TITLE
fix(nav): focus boundaries on DOCK + CONTENT_AREA_* (Phase 0.5 part 2)

### DIFF
--- a/src/nav/BottomDock.tsx
+++ b/src/nav/BottomDock.tsx
@@ -28,7 +28,18 @@ export function BottomDock({
 }: BottomDockProps) {
   // FIX: M1 — useFocusable returns { ref, focusKey, focused, focusSelf, ... };
   // pass focusKey (a string) to FocusContext.Provider value.
-  const { ref, focusKey } = useFocusable({ focusKey: "DOCK" });
+  // isFocusBoundary absorbs dead-direction bubble-ups at the dock's edges —
+  // Left on the leftmost tab, Right on the rightmost, Down (nothing below).
+  // Without this, norigin's smartNavigate recurses up to SN:ROOT and in some
+  // layouts lands on setFocus(undefined), blurring the current tab and
+  // leaving currentFocusKey null (see streamvault-v3-focus-vanish-bug.md).
+  // Up is not a boundary: DockTab's onArrowPress handles Up explicitly via
+  // setFocus(CONTENT_AREA_*) and returns false to block default navigation.
+  const { ref, focusKey } = useFocusable({
+    focusKey: "DOCK",
+    isFocusBoundary: true,
+    focusBoundaryDirections: ["left", "right", "down"],
+  });
 
   return (
     <FocusContext.Provider value={focusKey}>

--- a/src/routes/FavoritesRoute.tsx
+++ b/src/routes/FavoritesRoute.tsx
@@ -193,6 +193,11 @@ export function FavoritesRoute() {
     focusKey: "CONTENT_AREA_FAVORITES",
     focusable: false,
     trackChildren: true,
+    // Absorb dead-direction bubble-ups at the route's outer edges; Down
+    // stays open so rows can still reach BottomDock. See
+    // streamvault-v3-focus-vanish-bug.md.
+    isFocusBoundary: true,
+    focusBoundaryDirections: ["left", "right", "up"],
   });
   const navigate = useNavigate();
   const { favorites, loading, error, toggle, reload } = useFavorites();

--- a/src/routes/HistoryRoute.tsx
+++ b/src/routes/HistoryRoute.tsx
@@ -212,6 +212,11 @@ export function HistoryRoute() {
     focusKey: "CONTENT_AREA_HISTORY",
     focusable: false,
     trackChildren: true,
+    // Absorb dead-direction bubble-ups at the route's outer edges; Down
+    // stays open so rows can still reach BottomDock. See
+    // streamvault-v3-focus-vanish-bug.md.
+    isFocusBoundary: true,
+    focusBoundaryDirections: ["left", "right", "up"],
   });
   const navigate = useNavigate();
   const { history, loading, error, remove, reload } = useWatchHistory();

--- a/src/routes/LiveRoute.tsx
+++ b/src/routes/LiveRoute.tsx
@@ -104,6 +104,11 @@ export function LiveRoute() {
     focusKey: "CONTENT_AREA_LIVE",
     focusable: false,
     trackChildren: true,
+    // Absorb dead-direction bubble-ups at the route's outer edges; Down
+    // stays open so the bottom row can still reach BottomDock. See
+    // streamvault-v3-focus-vanish-bug.md.
+    isFocusBoundary: true,
+    focusBoundaryDirections: ["left", "right", "up"],
   });
   const { openPlayer } = usePlayerOpener();
 

--- a/src/routes/MoviesRoute.tsx
+++ b/src/routes/MoviesRoute.tsx
@@ -112,6 +112,12 @@ export function MoviesRoute() {
     focusKey: "CONTENT_AREA_MOVIES",
     focusable: false,
     trackChildren: true,
+    // Absorb dead-direction bubble-ups at the route's outer edges (Left on
+    // first poster / Telugu chip, Right on last poster / English chip, Up
+    // on hero). Down is not a boundary so the grid's bottom row can still
+    // navigate into BottomDock. See streamvault-v3-focus-vanish-bug.md.
+    isFocusBoundary: true,
+    focusBoundaryDirections: ["left", "right", "up"],
   });
 
   const { openPlayer } = usePlayerOpener();

--- a/src/routes/SearchRoute.tsx
+++ b/src/routes/SearchRoute.tsx
@@ -118,6 +118,11 @@ export function SearchRoute() {
     focusKey: "CONTENT_AREA_SEARCH",
     focusable: false,
     trackChildren: true,
+    // Absorb dead-direction bubble-ups at the route's outer edges; Down
+    // stays open so results can still reach BottomDock. See
+    // streamvault-v3-focus-vanish-bug.md.
+    isFocusBoundary: true,
+    focusBoundaryDirections: ["left", "right", "up"],
   });
 
   const [query, setQuery] = useState("");

--- a/src/routes/SettingsRoute.tsx
+++ b/src/routes/SettingsRoute.tsx
@@ -249,6 +249,11 @@ export function SettingsRoute() {
     focusKey: "CONTENT_AREA_SETTINGS",
     focusable: false,
     trackChildren: true,
+    // Absorb dead-direction bubble-ups at the route's outer edges; Down
+    // stays open so rows can still reach BottomDock. See
+    // streamvault-v3-focus-vanish-bug.md.
+    isFocusBoundary: true,
+    focusBoundaryDirections: ["left", "right", "up"],
   });
 
   // onLoggedOut is a no-op here — the redirect in AccountSection handles navigation.


### PR DESCRIPTION
## Summary

PR #83's global watcher caught the ResumeHero case but user reported the grid, rail, dock, and other pages still lost focus on dead-direction presses. Root cause: norigin's `smartNavigate` bubbles up to `SN:ROOT` on dead-direction presses, either silently no-op-ing (no feedback → feels broken) or falling into `setFocus(undefined)` which blurs the current component outright.

This PR absorbs those presses at the first sensible parent level with `isFocusBoundary`:

| Container | `focusBoundaryDirections` |
|---|---|
| `DOCK` | `['left', 'right', 'down']` |
| `CONTENT_AREA_MOVIES` | `['left', 'right', 'up']` |
| `CONTENT_AREA_LIVE` | `['left', 'right', 'up']` |
| `CONTENT_AREA_SEARCH` | `['left', 'right', 'up']` |
| `CONTENT_AREA_SETTINGS` | `['left', 'right', 'up']` |
| `CONTENT_AREA_FAVORITES` | `['left', 'right', 'up']` |
| `CONTENT_AREA_HISTORY` | `['left', 'right', 'up']` |

- Down stays open on `CONTENT_AREA_*` so the grid's bottom row still reaches the dock.
- Up stays open on `DOCK` so `DockTab`'s `onArrowPress`-driven jump to the content area keeps working.
- PR #83's global recovery watcher is kept as defense-in-depth — nothing removed.

## Known gap

- `CONTENT_AREA_SERIES` NOT touched — Series has uncommitted Phase 4 WIP in the working tree that would conflict. Same 2-line `isFocusBoundary: true, focusBoundaryDirections: ['left', 'right', 'up']` snippet should be added to `SeriesRoute.tsx`'s `useFocusable` block when Phase 4 lands.

## Test plan

- [ ] First poster + Left — focus stays on poster
- [ ] Last poster + Right (in a partial row, or rightmost column) — focus stays
- [ ] Telugu chip + Left — focus stays on chip
- [ ] English chip + Right — focus stays
- [ ] Movies dock tab + Left — focus stays
- [ ] Settings dock tab + Right — focus stays
- [ ] Hero + Up — bounce fires (hero's own onArrowPress handles this)
- [ ] Hero + Left/Right — bounce fires
- [ ] Regression: grid bottom row + Down → lands on DOCK_MOVIES
- [ ] Regression: DOCK + Up → lands inside CONTENT_AREA_*
- [ ] Regression: left-right poster-to-poster nav still works
- [ ] Regression: chip-to-chip nav still works

## Tests

265/265 unit tests green. Route tests use `expect.objectContaining({ focusKey: "..." })` and `expect(keys).toContain(...)` which tolerate the added options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)