### PR TITLE
feat(player): Phase 6c — series prev/next, amber failure overlay, reduced-motion

### DIFF
--- a/src/player/PlayerControls.test.tsx
+++ b/src/player/PlayerControls.test.tsx
@@ -364,4 +364,35 @@ describe("PlayerControls", () => {
     );
     expect(screen.queryByRole("button", { name: /audio/i })).toBeNull();
   });
+
+  // ─── 6c: prev/next wiring ───────────────────────────────────────────────
+
+  it("renders Previous/Next episode buttons when onPrev/onNext provided (series)", () => {
+    const onPrev = vi.fn();
+    const onNext = vi.fn();
+    render(
+      <PlayerControls
+        {...makeProps({ kind: "series-episode", onPrev, onNext })}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Previous episode" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Next episode" })).toBeTruthy();
+  });
+
+  it("hides Previous/Next when props not provided (movies)", () => {
+    render(<PlayerControls {...makeProps({ kind: "vod" })} />);
+    expect(screen.queryByRole("button", { name: /previous/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /next episode|next channel/i })).toBeNull();
+  });
+
+  it("Previous button fires onPrev when pressed", () => {
+    const onPrev = vi.fn();
+    render(
+      <PlayerControls {...makeProps({ kind: "series-episode", onPrev })} />,
+    );
+    act(() => {
+      screen.getByRole("button", { name: "Previous episode" }).click();
+    });
+    expect(onPrev).toHaveBeenCalledOnce();
+  });
 });

--- a/src/player/PlayerControls.test.tsx
+++ b/src/player/PlayerControls.test.tsx
@@ -1,9 +1,9 @@
 /**
- * PlayerControls unit tests — Phase 6a shape.
+ * PlayerControls unit tests — Phase 6b shape.
  *
- * Covers: initial visibility + focus, auto-hide, wake-only first arrow,
- * Enter short-circuit, Back closes player, seek shortcuts (j/l), Live mode
- * hides scrubber and skips ±10s, quality popover still selects levels.
+ * Covers 6a behavior plus: volume slider popover opens on Enter, hold-to-scrub
+ * fires 30s interval jumps, popover items dismiss on Left/Right and advance
+ * to a sibling control (spec §5).
  */
 import { render, screen, act, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
@@ -12,19 +12,84 @@ import type { PlayerControlsProps } from "./PlayerControls";
 import type { ReactNode } from "react";
 
 // ─── Mock norigin ─────────────────────────────────────────────────────────────
+//
+// The mock captures the last onEnterPress / onEnterRelease per focusKey so
+// tests can invoke them directly — we can't emulate norigin's key routing
+// in jsdom, so we drive the handlers synthetically.
 
-vi.mock("@noriginmedia/norigin-spatial-navigation", () => ({
-  useFocusable: vi.fn(() => ({
-    ref: { current: null },
-    focused: false,
-    focusKey: "MOCK_KEY",
-    hasFocusedChild: false,
-  })),
-  FocusContext: {
-    Provider: ({ children }: { children: ReactNode }) => children,
-  },
-  setFocus: vi.fn(),
-}));
+type Handlers = {
+  onEnterPress?: (props: unknown, details: { pressedKeys: Record<string, number> }) => void;
+  onEnterRelease?: (props: unknown) => void;
+  onArrowPress?: (
+    dir: string,
+    props: unknown,
+    details: { pressedKeys: Record<string, number> },
+  ) => boolean;
+  focusable?: boolean;
+};
+
+const handlersByKey: Record<string, Handlers> = {};
+
+vi.mock("@noriginmedia/norigin-spatial-navigation", () => {
+  const useFocusable = vi.fn(
+    ({
+      focusKey,
+      onEnterPress,
+      onEnterRelease,
+      onArrowPress,
+      focusable = true,
+    }: {
+      focusKey?: string;
+      onEnterPress?: (p: unknown, d: { pressedKeys: Record<string, number> }) => void;
+      onEnterRelease?: (p: unknown) => void;
+      onArrowPress?: (
+        d: string,
+        p: unknown,
+        dt: { pressedKeys: Record<string, number> },
+      ) => boolean;
+      focusable?: boolean;
+    } = {}) => {
+      if (focusKey) {
+        handlersByKey[focusKey] = {
+          ...(onEnterPress !== undefined ? { onEnterPress } : {}),
+          ...(onEnterRelease !== undefined ? { onEnterRelease } : {}),
+          ...(onArrowPress !== undefined ? { onArrowPress } : {}),
+          focusable,
+        };
+      }
+      return {
+        ref: { current: null },
+        focused: false,
+        focusKey: focusKey ?? "MOCK_KEY",
+        hasFocusedChild: false,
+      };
+    },
+  );
+  return {
+    useFocusable,
+    FocusContext: {
+      Provider: ({ children }: { children: ReactNode }) => children,
+    },
+    setFocus: vi.fn(),
+  };
+});
+
+function pressEnter(focusKey: string, count = 1) {
+  const h = handlersByKey[focusKey];
+  if (!h?.onEnterPress) throw new Error(`No onEnterPress for ${focusKey}`);
+  h.onEnterPress({}, { pressedKeys: { enter: count } });
+}
+
+function releaseEnter(focusKey: string) {
+  const h = handlersByKey[focusKey];
+  if (h?.onEnterRelease) h.onEnterRelease({});
+}
+
+function pressArrow(focusKey: string, direction: "up" | "down" | "left" | "right") {
+  const h = handlersByKey[focusKey];
+  if (!h?.onArrowPress) return true;
+  return h.onArrowPress(direction, {}, { pressedKeys: { [direction]: 1 } });
+}
 
 // ─── Default props ────────────────────────────────────────────────────────────
 
@@ -35,8 +100,7 @@ function makeProps(overrides: Partial<PlayerControlsProps> = {}): PlayerControls
     status: "playing",
     currentTime: 30,
     duration: 120,
-    volume: 1,
-    muted: false,
+    volume: 0.5,
     levels: [],
     audioTracks: [],
     subtitleTracks: [],
@@ -47,7 +111,7 @@ function makeProps(overrides: Partial<PlayerControlsProps> = {}): PlayerControls
     onPause: vi.fn(),
     onSeek: vi.fn(),
     onClose: vi.fn(),
-    onToggleMute: vi.fn(),
+    onSetVolume: vi.fn(),
     onSelectLevel: vi.fn(),
     onSelectAudioTrack: vi.fn(),
     onSelectSubtitleTrack: vi.fn(),
@@ -60,6 +124,7 @@ function makeProps(overrides: Partial<PlayerControlsProps> = {}): PlayerControls
 describe("PlayerControls", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    for (const k of Object.keys(handlersByKey)) delete handlersByKey[k];
   });
 
   afterEach(() => {
@@ -67,56 +132,45 @@ describe("PlayerControls", () => {
   });
 
   it("renders Play/Pause, Back button, and title on mount (spec §4.1)", () => {
-    const props = makeProps();
-    render(<PlayerControls {...props} />);
+    render(<PlayerControls {...makeProps()} />);
     expect(screen.getByRole("button", { name: "Pause" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Back" })).toBeTruthy();
     expect(screen.getByText("Test Title")).toBeTruthy();
   });
 
   it("shows Play label when paused", () => {
-    const props = makeProps({ status: "paused" });
-    render(<PlayerControls {...props} />);
+    render(<PlayerControls {...makeProps({ status: "paused" })} />);
     expect(screen.getByRole("button", { name: "Play" })).toBeTruthy();
   });
 
   it("auto-hides controls after 3s idle", () => {
-    const props = makeProps();
-    render(<PlayerControls {...props} />);
+    render(<PlayerControls {...makeProps()} />);
     const el = screen.getByTestId("player-controls");
     expect(el.getAttribute("aria-hidden")).toBe("false");
-
     act(() => {
       vi.advanceTimersByTime(3100);
     });
     expect(el.getAttribute("aria-hidden")).toBe("true");
   });
 
-  it("wakes on first arrow press without triggering navigation", () => {
+  it("wakes on first arrow without firing navigation", () => {
     const props = makeProps();
     render(<PlayerControls {...props} />);
-
     act(() => {
       vi.advanceTimersByTime(3100);
     });
-    expect(screen.getByTestId("player-controls").getAttribute("aria-hidden")).toBe(
-      "true",
-    );
-
     act(() => {
       fireEvent.keyDown(window, { key: "ArrowRight" });
     });
     expect(screen.getByTestId("player-controls").getAttribute("aria-hidden")).toBe(
       "false",
     );
-    // onSeek must NOT fire — the first arrow is wake-only (spec §4.3).
     expect(props.onSeek).not.toHaveBeenCalled();
   });
 
-  it("Enter short-circuits pause even when controls are hidden (spec §4.3)", () => {
+  it("Enter short-circuits pause even when hidden", () => {
     const props = makeProps({ status: "playing" });
     render(<PlayerControls {...props} />);
-
     act(() => {
       vi.advanceTimersByTime(3100);
     });
@@ -124,144 +178,23 @@ describe("PlayerControls", () => {
       fireEvent.keyDown(window, { key: "Enter" });
     });
     expect(props.onPause).toHaveBeenCalledOnce();
-    expect(screen.getByTestId("player-controls").getAttribute("aria-hidden")).toBe(
-      "false",
-    );
   });
 
-  it("Space and k also toggle play/pause", () => {
-    const props = makeProps({ status: "playing" });
-    render(<PlayerControls {...props} />);
+  it("j / l seek ±10s on VOD, disabled on Live", () => {
+    const vodProps = makeProps({ kind: "vod", currentTime: 30 });
+    const { unmount } = render(<PlayerControls {...vodProps} />);
+    act(() => fireEvent.keyDown(window, { key: "j" }));
+    expect(vodProps.onSeek).toHaveBeenCalledWith(20);
+    unmount();
 
-    act(() => {
-      fireEvent.keyDown(window, { key: " " });
-    });
-    expect(props.onPause).toHaveBeenCalledTimes(1);
-
-    act(() => {
-      fireEvent.keyDown(window, { key: "k" });
-    });
-    expect(props.onPause).toHaveBeenCalledTimes(2);
-  });
-
-  it("j / l seek -10s / +10s on VOD", () => {
-    const props = makeProps({ currentTime: 30, kind: "vod" });
-    render(<PlayerControls {...props} />);
-
-    act(() => {
-      fireEvent.keyDown(window, { key: "j" });
-    });
-    expect(props.onSeek).toHaveBeenCalledWith(20);
-
-    act(() => {
-      fireEvent.keyDown(window, { key: "l" });
-    });
-    expect(props.onSeek).toHaveBeenCalledWith(40);
-  });
-
-  it("j / l do NOT seek on Live (no seekable window)", () => {
-    const props = makeProps({ currentTime: 30, kind: "live" });
-    render(<PlayerControls {...props} />);
-
-    act(() => {
-      fireEvent.keyDown(window, { key: "j" });
-    });
-    act(() => {
-      fireEvent.keyDown(window, { key: "l" });
-    });
-    expect(props.onSeek).not.toHaveBeenCalled();
-  });
-
-  it("Escape closes the player when no popover is open", () => {
-    const props = makeProps();
-    render(<PlayerControls {...props} />);
-
-    act(() => {
-      fireEvent.keyDown(window, { key: "Escape" });
-    });
-    expect(props.onClose).toHaveBeenCalledOnce();
-  });
-
-  it("renders ● Live badge and hides scrubber on Live kind", () => {
-    const props = makeProps({ kind: "live" });
-    const { container } = render(<PlayerControls {...props} />);
-    expect(screen.getByLabelText("Live")).toBeTruthy();
-    expect(container.querySelector("[role='progressbar']")).toBeNull();
-  });
-
-  it("renders scrubber for VOD", () => {
-    const props = makeProps({ kind: "vod" });
-    const { container } = render(<PlayerControls {...props} />);
-    expect(container.querySelector("[role='progressbar']")).toBeTruthy();
-  });
-
-  it("skips ±10s buttons (focusable:false) on Live", () => {
-    const props = makeProps({ kind: "live" });
-    render(<PlayerControls {...props} />);
-    const seekBack = screen.getByRole("button", { name: "Back 10 seconds" });
-    const seekFwd = screen.getByRole("button", { name: "Forward 10 seconds" });
-    expect(seekBack.getAttribute("aria-disabled")).toBe("true");
-    expect(seekFwd.getAttribute("aria-disabled")).toBe("true");
-  });
-
-  it("quality popover selects a level and closes", () => {
-    const onSelectLevel = vi.fn() as Mock;
-    const levels = [
-      { index: 0, height: 720, bitrate: 2_000_000, name: "720p" },
-      { index: 1, height: 1080, bitrate: 4_000_000, name: "1080p" },
-    ];
-    const props = makeProps({ levels, onSelectLevel });
-    render(<PlayerControls {...props} />);
-
-    act(() => {
-      screen.getByRole("button", { name: /quality/i }).click();
-    });
-
-    // Highest-first order (spec §5.3): 1080p is listed before 720p.
-    const items = screen.getAllByRole("option");
-    expect(items.length).toBeGreaterThan(0);
-
-    act(() => {
-      screen.getByRole("button", { name: "720p" }).click();
-    });
-    expect(onSelectLevel).toHaveBeenCalledWith(0);
-    expect(screen.queryByRole("button", { name: "720p" })).toBeNull();
-  });
-
-  it("subtitles popover renders Off + tracks", () => {
-    const subtitleTracks = [
-      { index: 0, name: "English", lang: "en" },
-      { index: 1, name: "Telugu", lang: "te" },
-    ];
-    const props = makeProps({ subtitleTracks });
-    render(<PlayerControls {...props} />);
-
-    act(() => {
-      screen.getByRole("button", { name: /subtitles/i }).click();
-    });
-    expect(screen.getByRole("button", { name: "Off" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "English" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Telugu" })).toBeTruthy();
-  });
-
-  it("audio popover hidden when only one track (spec: aria-disabled if 1 track)", () => {
-    const audioTracks = [{ index: 0, name: "English", lang: "en" }];
-    const props = makeProps({ audioTracks });
-    render(<PlayerControls {...props} />);
-    expect(screen.queryByRole("button", { name: /audio/i })).toBeNull();
-  });
-
-  it("volume button toggles mute on Enter", () => {
-    const props = makeProps();
-    render(<PlayerControls {...props} />);
-    act(() => {
-      screen.getByRole("button", { name: "Mute" }).click();
-    });
-    expect(props.onToggleMute).toHaveBeenCalledOnce();
+    const liveProps = makeProps({ kind: "live", currentTime: 30 });
+    render(<PlayerControls {...liveProps} />);
+    act(() => fireEvent.keyDown(window, { key: "l" }));
+    expect(liveProps.onSeek).not.toHaveBeenCalled();
   });
 
   it("Escape closes popover first, player second", () => {
-    const levels = [{ index: 0, height: 720, bitrate: 2_000_000, name: "720p" }];
+    const levels = [{ index: 0, height: 720, bitrate: 2e6, name: "720p" }];
     const props = makeProps({ levels });
     render(<PlayerControls {...props} />);
 
@@ -270,15 +203,165 @@ describe("PlayerControls", () => {
     });
     expect(screen.getByRole("button", { name: "720p" })).toBeTruthy();
 
-    act(() => {
-      fireEvent.keyDown(window, { key: "Escape" });
-    });
+    act(() => fireEvent.keyDown(window, { key: "Escape" }));
     expect(screen.queryByRole("button", { name: "720p" })).toBeNull();
     expect(props.onClose).not.toHaveBeenCalled();
 
-    act(() => {
-      fireEvent.keyDown(window, { key: "Escape" });
-    });
+    act(() => fireEvent.keyDown(window, { key: "Escape" }));
     expect(props.onClose).toHaveBeenCalledOnce();
+  });
+
+  it("renders ● Live badge + no scrubber on Live kind", () => {
+    const { container } = render(<PlayerControls {...makeProps({ kind: "live" })} />);
+    expect(screen.getByLabelText("Live")).toBeTruthy();
+    expect(container.querySelector("[role='progressbar']")).toBeNull();
+  });
+
+  it("skips ±10s buttons (focusable:false) on Live", () => {
+    render(<PlayerControls {...makeProps({ kind: "live" })} />);
+    expect(
+      screen.getByRole("button", { name: "Back 10 seconds" }).getAttribute("aria-disabled"),
+    ).toBe("true");
+    expect(
+      screen.getByRole("button", { name: "Forward 10 seconds" }).getAttribute("aria-disabled"),
+    ).toBe("true");
+  });
+
+  // ─── 6b: hold-to-scrub ──────────────────────────────────────────────────
+
+  it("first Enter on seek fires single ±10s; held Enter starts 30s interval", () => {
+    const onSeek = vi.fn() as Mock;
+    const props = makeProps({ currentTime: 120, onSeek });
+    render(<PlayerControls {...props} />);
+
+    act(() => pressEnter("PLAYER_SEEK_BACK", 1));
+    expect(onSeek).toHaveBeenNthCalledWith(1, 110);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(onSeek).toHaveBeenNthCalledWith(2, 90);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(onSeek).toHaveBeenNthCalledWith(3, 90);
+
+    act(() => releaseEnter("PLAYER_SEEK_BACK"));
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(onSeek).toHaveBeenCalledTimes(3);
+  });
+
+  it("Enter auto-repeat (pressedKeys.enter > 1) does NOT double-fire the initial seek", () => {
+    const onSeek = vi.fn() as Mock;
+    render(<PlayerControls {...makeProps({ currentTime: 60, onSeek })} />);
+
+    act(() => pressEnter("PLAYER_SEEK_FORWARD", 1));
+    expect(onSeek).toHaveBeenCalledTimes(1);
+
+    act(() => pressEnter("PLAYER_SEEK_FORWARD", 2));
+    act(() => pressEnter("PLAYER_SEEK_FORWARD", 3));
+    expect(onSeek).toHaveBeenCalledTimes(1);
+
+    act(() => releaseEnter("PLAYER_SEEK_FORWARD"));
+  });
+
+  // ─── 6b: volume slider ──────────────────────────────────────────────────
+
+  it("volume button opens the slider popover", () => {
+    render(<PlayerControls {...makeProps({ volume: 0.5 })} />);
+    act(() => {
+      screen.getByRole("button", { name: "Volume" }).click();
+    });
+    expect(screen.getByRole("slider", { name: "Volume" })).toBeTruthy();
+  });
+
+  it("slider Up arrow calls onSetVolume with +5%", () => {
+    const onSetVolume = vi.fn() as Mock;
+    render(<PlayerControls {...makeProps({ volume: 0.5, onSetVolume })} />);
+    act(() => {
+      screen.getByRole("button", { name: "Volume" }).click();
+    });
+    act(() => pressArrow("PLAYER_VOLUME_SLIDER", "up"));
+    expect(onSetVolume).toHaveBeenCalledWith(0.55);
+  });
+
+  it("slider Down arrow calls onSetVolume with -5%, clamped to 0", () => {
+    const onSetVolume = vi.fn() as Mock;
+    render(<PlayerControls {...makeProps({ volume: 0.03, onSetVolume })} />);
+    act(() => {
+      screen.getByRole("button", { name: "Volume" }).click();
+    });
+    act(() => pressArrow("PLAYER_VOLUME_SLIDER", "down"));
+    expect(onSetVolume).toHaveBeenCalledWith(0);
+  });
+
+  it("slider auto-closes after 2s idle", () => {
+    render(<PlayerControls {...makeProps({ volume: 0.5 })} />);
+    act(() => {
+      screen.getByRole("button", { name: "Volume" }).click();
+    });
+    expect(screen.queryByRole("slider", { name: "Volume" })).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(2100);
+    });
+    expect(screen.queryByRole("slider", { name: "Volume" })).toBeNull();
+  });
+
+  // ─── 6b: popover list-walk + Left/Right dismiss ─────────────────────────
+
+  it("quality popover Left arrow closes popover and advances left (spec §5)", () => {
+    const levels = [{ index: 0, height: 720, bitrate: 2e6, name: "720p" }];
+    render(<PlayerControls {...makeProps({ levels })} />);
+    act(() => {
+      screen.getByRole("button", { name: /quality/i }).click();
+    });
+    expect(screen.getByRole("button", { name: "720p" })).toBeTruthy();
+
+    act(() => pressArrow("PLAYER_QUALITY_AUTO", "left"));
+    expect(screen.queryByRole("button", { name: "720p" })).toBeNull();
+  });
+
+  it("subtitles popover renders Off + tracks", () => {
+    const subtitleTracks = [
+      { index: 0, name: "English", lang: "en" },
+      { index: 1, name: "Telugu", lang: "te" },
+    ];
+    render(<PlayerControls {...makeProps({ subtitleTracks })} />);
+    act(() => {
+      screen.getByRole("button", { name: /subtitles/i }).click();
+    });
+    expect(screen.getByRole("button", { name: "Off" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "English" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Telugu" })).toBeTruthy();
+  });
+
+  it("quality popover selects a level + closes", () => {
+    const onSelectLevel = vi.fn() as Mock;
+    const levels = [
+      { index: 0, height: 720, bitrate: 2e6, name: "720p" },
+      { index: 1, height: 1080, bitrate: 4e6, name: "1080p" },
+    ];
+    render(<PlayerControls {...makeProps({ levels, onSelectLevel })} />);
+    act(() => {
+      screen.getByRole("button", { name: /quality/i }).click();
+    });
+    act(() => {
+      screen.getByRole("button", { name: "720p" }).click();
+    });
+    expect(onSelectLevel).toHaveBeenCalledWith(0);
+    expect(screen.queryByRole("button", { name: "720p" })).toBeNull();
+  });
+
+  it("audio popover hidden when only one track", () => {
+    render(
+      <PlayerControls
+        {...makeProps({ audioTracks: [{ index: 0, name: "English", lang: "en" }] })}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /audio/i })).toBeNull();
   });
 });

--- a/src/player/PlayerControls.tsx
+++ b/src/player/PlayerControls.tsx
@@ -4,11 +4,12 @@
  *   TOP BAR       ← Back · Title · [S2E5 "Title"] · live timestamp / ● LIVE
  *   SCRUBBER      progress + current/total time (hidden on Live, replaced by badge)
  *   CONTROL BAR   ⏯ · ◀◀ ▶▶ · 🔉 · Audio ▾ · Subs ▾ · Quality ▾
- *                 (prev/next episode + channel wiring is a Phase 6b follow-on)
+ *                 (prev/next episode + channel wiring is a Phase 6c follow-on)
  *
- * Phase 6a ships the structural shell: bands, focus flow, auto-hide, Enter
- * short-circuit. Popover list-walk + Left/Right advance, volume slider,
- * hold-to-scrub and amber failure overlay come in 6b / 6c.
+ * 6a shipped the structural shell; 6b layers hold-to-scrub, the volume
+ * slider popover, auto-focus on the current selection when a popover
+ * opens, and Left/Right on any popover item dismisses it and advances
+ * to the next sibling control (spec §5).
  */
 import type { RefObject, CSSProperties } from "react";
 import { useEffect, useRef, useState, useCallback } from "react";
@@ -17,6 +18,7 @@ import {
   FocusContext,
   setFocus,
 } from "@noriginmedia/norigin-spatial-navigation";
+import type { KeyPressDetails } from "@noriginmedia/norigin-spatial-navigation";
 import type {
   HlsLevel,
   HlsAudioTrack,
@@ -33,6 +35,7 @@ export const FK = {
   SEEK_BACK: "PLAYER_SEEK_BACK",
   SEEK_FORWARD: "PLAYER_SEEK_FORWARD",
   VOLUME: "PLAYER_VOLUME",
+  VOLUME_SLIDER: "PLAYER_VOLUME_SLIDER",
   AUDIO: "PLAYER_AUDIO",
   SUBTITLES: "PLAYER_SUBTITLES",
   QUALITY: "PLAYER_QUALITY",
@@ -40,6 +43,10 @@ export const FK = {
 
 const AUTO_HIDE_MS = 3000;
 const FADE_MS = 300;
+const HOLD_SEEK_STEP_S = 30;
+const HOLD_SEEK_TICK_MS = 500;
+const VOLUME_STEP = 0.05;
+const VOLUME_SLIDER_IDLE_MS = 2000;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -53,10 +60,14 @@ function formatTime(seconds: number): string {
   return h > 0 ? `${h}:${mm}:${ss}` : `${m}:${ss}`;
 }
 
-function volumeIcon(volume: number, muted: boolean): string {
-  if (muted || volume <= 0) return "🔇";
+function volumeIcon(volume: number): string {
+  if (volume <= 0) return "🔇";
   if (volume < 0.67) return "🔉";
   return "🔊";
+}
+
+function clamp01(v: number): number {
+  return Math.max(0, Math.min(1, v));
 }
 
 // ─── Props ───────────────────────────────────────────────────────────────────
@@ -68,7 +79,6 @@ export interface PlayerControlsProps {
   currentTime: number;
   duration: number;
   volume: number;
-  muted: boolean;
   levels: HlsLevel[];
   audioTracks: HlsAudioTrack[];
   subtitleTracks: HlsSubtitleTrack[];
@@ -79,25 +89,48 @@ export interface PlayerControlsProps {
   onPause: () => void;
   onSeek: (time: number) => void;
   onClose: () => void;
-  onToggleMute: () => void;
+  onSetVolume: (v: number) => void;
   onSelectLevel: (idx: number) => void;
   onSelectAudioTrack: (idx: number) => void;
   onSelectSubtitleTrack: (idx: number) => void;
 }
 
-// ─── Menu item used by the existing dropdown popovers ────────────────────────
+type MenuName = "audio" | "subtitles" | "quality" | "volume";
+
+// ─── Popover list item ───────────────────────────────────────────────────────
 
 interface MenuItemProps {
   label: string;
   isActive: boolean;
   focusKey: string;
   onSelect: () => void;
+  onDismissLeft?: () => void;
+  onDismissRight?: () => void;
 }
 
-function MenuItem({ label, isActive, focusKey: fk, onSelect }: MenuItemProps) {
+function MenuItem({
+  label,
+  isActive,
+  focusKey: fk,
+  onSelect,
+  onDismissLeft,
+  onDismissRight,
+}: MenuItemProps) {
   const { ref, focused } = useFocusable({
     focusKey: fk,
     onEnterPress: onSelect,
+    onArrowPress: (direction) => {
+      // Up/Down walks the list via norigin default geometric nav.
+      if (direction === "left" && onDismissLeft) {
+        onDismissLeft();
+        return false;
+      }
+      if (direction === "right" && onDismissRight) {
+        onDismissRight();
+        return false;
+      }
+      return true;
+    },
   });
   const highlighted = isActive || focused;
 
@@ -141,6 +174,12 @@ interface ControlButtonProps {
   ariaExpanded?: boolean;
   ariaHasPopup?: boolean;
   extraStyle?: CSSProperties;
+  /**
+   * When set, the first press fires onPress AND starts a hold-repeat.
+   * onHoldTick is called every HOLD_SEEK_TICK_MS until onEnterRelease.
+   * Used by the ±10s seek buttons (spec §3.2 — 30s jumps every 500ms).
+   */
+  onHoldTick?: () => void;
 }
 
 function ControlButton({
@@ -154,16 +193,36 @@ function ControlButton({
   ariaExpanded,
   ariaHasPopup,
   extraStyle,
+  onHoldTick,
 }: ControlButtonProps) {
+  const holdIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clearHold = useCallback(() => {
+    if (holdIntervalRef.current) {
+      clearInterval(holdIntervalRef.current);
+      holdIntervalRef.current = null;
+    }
+  }, []);
+
   const { ref, focused } = useFocusable({
     focusKey,
     focusable,
-    onEnterPress: onPress,
-    // Up from any control bar button → Back (spec §4.2).
-    // Edge Left/Right blocks default nav so focus doesn't wander (spec: no wrap).
-    // Down is a no-op — nothing below the control bar.
-    // All returns false only when we explicitly handle the direction.
+    onEnterPress: (_: unknown, details: KeyPressDetails) => {
+      // pressedKeys.enter counts how many keydown events fired since the
+      // most recent keyup. `1` = initial press; `>1` = OS auto-repeat. We
+      // only want to run side effects on the initial press.
+      if ((details.pressedKeys?.enter ?? 0) > 1) return;
+      onPress();
+      if (onHoldTick) {
+        clearHold();
+        holdIntervalRef.current = setInterval(onHoldTick, HOLD_SEEK_TICK_MS);
+      }
+    },
+    onEnterRelease: clearHold,
     onArrowPress: (direction) => {
+      // Up from any control bar button → Back (spec §4.2).
+      // Edge Left/Right blocks default nav so focus doesn't wander (no wrap).
+      // Down is a no-op — nothing below the control bar.
       if (direction === "up") {
         setFocus(FK.BACK);
         return false;
@@ -174,6 +233,12 @@ function ControlButton({
       return true;
     },
   });
+
+  // Clear any in-flight hold on unmount / focusable-flip to avoid zombie
+  // intervals. (If the user clicks away to another control, onEnterRelease
+  // fires via keyup, but blur without keyup — e.g., programmatic setFocus —
+  // would otherwise leak.)
+  useEffect(() => clearHold, [clearHold]);
 
   return (
     <button
@@ -199,6 +264,132 @@ function ControlButton({
   );
 }
 
+// ─── Volume slider popover (spec §6) ─────────────────────────────────────────
+
+interface VolumeSliderProps {
+  volume: number;
+  onSetVolume: (v: number) => void;
+  onClose: () => void;
+  onDismissLeft?: () => void;
+  onDismissRight?: () => void;
+}
+
+function VolumeSlider({
+  volume,
+  onSetVolume,
+  onClose,
+  onDismissLeft,
+  onDismissRight,
+}: VolumeSliderProps) {
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const scheduleClose = useCallback(() => {
+    if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    closeTimerRef.current = setTimeout(onClose, VOLUME_SLIDER_IDLE_MS);
+  }, [onClose]);
+
+  const { ref, focused } = useFocusable({
+    focusKey: FK.VOLUME_SLIDER,
+    onEnterPress: onClose,
+    onArrowPress: (direction) => {
+      scheduleClose();
+      if (direction === "up") {
+        onSetVolume(clamp01(volume + VOLUME_STEP));
+        return false;
+      }
+      if (direction === "down") {
+        onSetVolume(clamp01(volume - VOLUME_STEP));
+        return false;
+      }
+      if (direction === "left" && onDismissLeft) {
+        onDismissLeft();
+        return false;
+      }
+      if (direction === "right" && onDismissRight) {
+        onDismissRight();
+        return false;
+      }
+      return false;
+    },
+  });
+
+  // Seed focus + start idle timer on mount. The setFocus in PlayerControls'
+  // openMenu effect also targets this key — duplicate is cheap and safe.
+  useEffect(() => {
+    setFocus(FK.VOLUME_SLIDER);
+    scheduleClose();
+    return () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    };
+  }, [scheduleClose]);
+
+  const pct = Math.round(volume * 100);
+
+  return (
+    <div
+      ref={ref as RefObject<HTMLDivElement>}
+      role="slider"
+      aria-label="Volume"
+      aria-valuenow={pct}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-live="polite"
+      tabIndex={0}
+      style={{
+        position: "absolute",
+        bottom: "calc(100% + var(--space-2))",
+        left: "50%",
+        transform: "translateX(-50%)",
+        background: "var(--bg-elevated)",
+        borderRadius: "var(--radius-md)",
+        padding: "var(--space-3)",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "var(--space-2)",
+        width: "56px",
+        zIndex: 10,
+        outline: focused ? "2px solid var(--accent-copper)" : undefined,
+      }}
+    >
+      <span
+        style={{
+          fontSize: "var(--text-label-size)",
+          color: "var(--text-secondary)",
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {pct}
+      </span>
+      <div
+        aria-hidden="true"
+        style={{
+          position: "relative",
+          width: "6px",
+          height: "120px",
+          background: "rgba(255,255,255,0.2)",
+          borderRadius: "3px",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            bottom: 0,
+            left: 0,
+            width: "100%",
+            height: `${pct}%`,
+            background: "var(--accent-copper)",
+          }}
+        />
+      </div>
+      <span aria-hidden="true" style={{ fontSize: "18px" }}>
+        {volumeIcon(volume)}
+      </span>
+    </div>
+  );
+}
+
 // ─── PlayerControls ──────────────────────────────────────────────────────────
 
 export function PlayerControls({
@@ -208,7 +399,6 @@ export function PlayerControls({
   currentTime,
   duration,
   volume,
-  muted,
   levels,
   audioTracks,
   subtitleTracks,
@@ -219,19 +409,22 @@ export function PlayerControls({
   onPause,
   onSeek,
   onClose,
-  onToggleMute,
+  onSetVolume,
   onSelectLevel,
   onSelectAudioTrack,
   onSelectSubtitleTrack,
 }: PlayerControlsProps) {
   // Controls open visible (spec §4.1), then fade after AUTO_HIDE_MS idle.
   const [visible, setVisible] = useState(true);
-  const [openMenu, setOpenMenu] = useState<"audio" | "subtitles" | "quality" | null>(null);
+  const [openMenu, setOpenMenu] = useState<MenuName | null>(null);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Use a ref for visibility inside capture-phase handler so we don't depend
-  // on stale state captured by the effect closure.
   const visibleRef = useRef(visible);
   visibleRef.current = visible;
+
+  // Keep a ref to currentTime so hold-to-scrub ticks can seek from the
+  // latest position instead of the one captured when hold started.
+  const currentTimeRef = useRef(currentTime);
+  currentTimeRef.current = currentTime;
 
   const { ref: containerRef, focusKey: containerFocusKey } = useFocusable({
     focusKey: "PLAYER_CONTROLS",
@@ -269,17 +462,14 @@ export function PlayerControls({
     return () => {
       if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
     };
-    // Intentionally mount-only — the focus grab is a one-shot. Re-seeding
-    // focus on every status flip would fight the D-pad.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Capture-phase key interceptor: when controls are hidden, swallow arrow
-  // keys (wake-only — spec §4.3) and short-circuit Enter to toggle play/pause
-  // (spec §4.3 exception). Also handles media keys (TV remote) and Escape.
+  // Capture-phase key interceptor: wake-only on first arrow when hidden,
+  // Enter short-circuits pause/play (spec §4.3). Also handles media keys
+  // (TV remote) and Escape.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      // Escape / Back always closes (or closes the topmost popover first).
       if (e.key === "Escape" || e.key === "Back" || e.key === "GoBack") {
         e.preventDefault();
         if (openMenu) {
@@ -290,9 +480,6 @@ export function PlayerControls({
         return;
       }
 
-      // Media keys + keyboard shortcuts — YouTube-style bindings. These work
-      // regardless of visibility because they're explicit "do thing" keys,
-      // not navigation.
       if (e.key === "MediaPlayPause" || e.key === " " || e.key === "k") {
         e.preventDefault();
         togglePlayPause();
@@ -301,13 +488,13 @@ export function PlayerControls({
       }
       if ((e.key === "MediaRewind" || e.key === "j") && !isLive) {
         e.preventDefault();
-        onSeek(currentTime - 10);
+        onSeek(currentTimeRef.current - 10);
         wake();
         return;
       }
       if ((e.key === "MediaFastForward" || e.key === "l") && !isLive) {
         e.preventDefault();
-        onSeek(currentTime + 10);
+        onSeek(currentTimeRef.current + 10);
         wake();
         return;
       }
@@ -321,17 +508,12 @@ export function PlayerControls({
 
       if (!visibleRef.current) {
         if (isArrow) {
-          // Wake-only: swallow this press so norigin doesn't navigate.
-          // The next press registers normally.
           e.preventDefault();
           e.stopPropagation();
           wake();
           return;
         }
         if (isEnter) {
-          // Spec §4.3: Enter while hidden short-circuits pause/play regardless
-          // of whichever control was last focused. Block norigin from also
-          // firing the focused button's onEnter (would double-toggle).
           e.preventDefault();
           e.stopPropagation();
           togglePlayPause();
@@ -339,21 +521,19 @@ export function PlayerControls({
           return;
         }
       } else {
-        // Visible: any key resets the idle timer. Let norigin handle nav.
         if (isArrow || isEnter) wake();
       }
     };
 
     const onMouseMove = () => wake();
 
-    // Capture phase so we can preempt norigin's window listener.
     window.addEventListener("keydown", onKeyDown, true);
     window.addEventListener("mousemove", onMouseMove);
     return () => {
       window.removeEventListener("keydown", onKeyDown, true);
       window.removeEventListener("mousemove", onMouseMove);
     };
-  }, [onClose, onSeek, currentTime, isLive, openMenu, togglePlayPause, wake]);
+  }, [onClose, onSeek, isLive, openMenu, togglePlayPause, wake]);
 
   const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
 
@@ -363,8 +543,6 @@ export function PlayerControls({
     focusKey: FK.BACK,
     onEnterPress: onClose,
     onArrowPress: (direction) => {
-      // Down from Back → Play/Pause (spec §4.2 — predictable return).
-      // Up/Left/Right are no-ops (nothing to navigate to).
       if (direction === "down") {
         setFocus(FK.PLAY_PAUSE);
         return false;
@@ -373,29 +551,50 @@ export function PlayerControls({
     },
   });
 
-  // ── Control bar button handlers ──────────────────────────────────────────
+  // ── Control bar wire-up ────────────────────────────────────────────────────
 
-  const handleSeekBack = useCallback(() => onSeek(currentTime - 10), [onSeek, currentTime]);
-  const handleSeekForward = useCallback(() => onSeek(currentTime + 10), [onSeek, currentTime]);
-  const openAudio = useCallback(() => setOpenMenu((m) => (m === "audio" ? null : "audio")), []);
-  const openSubs = useCallback(() => setOpenMenu((m) => (m === "subtitles" ? null : "subtitles")), []);
-  const openQuality = useCallback(() => setOpenMenu((m) => (m === "quality" ? null : "quality")), []);
+  const handleSeekBack = useCallback(
+    () => onSeek(currentTimeRef.current - 10),
+    [onSeek],
+  );
+  const handleSeekForward = useCallback(
+    () => onSeek(currentTimeRef.current + 10),
+    [onSeek],
+  );
+  const holdSeekBack = useCallback(
+    () => onSeek(currentTimeRef.current - HOLD_SEEK_STEP_S),
+    [onSeek],
+  );
+  const holdSeekForward = useCallback(
+    () => onSeek(currentTimeRef.current + HOLD_SEEK_STEP_S),
+    [onSeek],
+  );
+
+  const openAudio = useCallback(
+    () => setOpenMenu((m) => (m === "audio" ? null : "audio")),
+    [],
+  );
+  const openSubs = useCallback(
+    () => setOpenMenu((m) => (m === "subtitles" ? null : "subtitles")),
+    [],
+  );
+  const openQuality = useCallback(
+    () => setOpenMenu((m) => (m === "quality" ? null : "quality")),
+    [],
+  );
+  const openVolume = useCallback(
+    () => setOpenMenu((m) => (m === "volume" ? null : "volume")),
+    [],
+  );
+  const closeMenu = useCallback(() => setOpenMenu(null), []);
 
   // ── Adaptive control focusability ─────────────────────────────────────────
-  // Spec §3: disabled controls use focusable:false so D-pad walks past them.
-  //   Live: no ±10s (can't seek a live stream without a buffer window).
-  //   All kinds in 6a: Play/Pause is always the left edge (prev/next deferred).
-  //   Quality is the right edge — right-nav blocked there.
-  //   Volume / Audio / Subs are always focusable; their popovers are empty
-  //   when no data but the button itself should still accept Enter.
 
   const seekable = !isLive;
   const audioHasOptions = audioTracks.length > 1;
   const subsAvailable = subtitleTracks.length > 0;
   const qualityAvailable = levels.length > 0;
 
-  // Compute the rightmost focusable control so we know who should block the
-  // Right edge (spec §4.2: no wrap). Walk the list in visual order.
   const orderedKeys: string[] = [
     FK.PLAY_PAUSE,
     seekable ? FK.SEEK_BACK : null,
@@ -407,6 +606,81 @@ export function PlayerControls({
   ].filter((k): k is NonNullable<typeof k> => k !== null);
   const leftEdgeKey = orderedKeys[0];
   const rightEdgeKey = orderedKeys[orderedKeys.length - 1];
+
+  // Given a popover anchor control key, return the sibling control to jump
+  // to when the user presses Left/Right inside the popover (spec §5 —
+  // "Left/Right on any item closes popover + advances to the next sibling").
+  function dismissTargets(anchorKey: string): {
+    left: string | null;
+    right: string | null;
+  } {
+    const idx = orderedKeys.indexOf(anchorKey);
+    if (idx === -1) return { left: null, right: null };
+    return {
+      left: idx > 0 ? orderedKeys[idx - 1]! : null,
+      right: idx < orderedKeys.length - 1 ? orderedKeys[idx + 1]! : null,
+    };
+  }
+
+  // Auto-focus the current selection when a popover opens (spec §5). The
+  // effect runs after MenuItems have registered with norigin, so setFocus
+  // resolves synchronously.
+  useEffect(() => {
+    if (!openMenu) return;
+    if (openMenu === "audio") {
+      const key =
+        currentAudioTrack >= 0
+          ? `PLAYER_AUDIO_${currentAudioTrack}`
+          : audioTracks[0]
+            ? `PLAYER_AUDIO_${audioTracks[0].index}`
+            : null;
+      if (key) setFocus(key);
+    } else if (openMenu === "subtitles") {
+      const key =
+        currentSubtitleTrack >= 0
+          ? `PLAYER_SUBTITLE_${currentSubtitleTrack}`
+          : "PLAYER_SUBTITLES_OFF";
+      setFocus(key);
+    } else if (openMenu === "quality") {
+      const key =
+        currentLevel >= 0
+          ? `PLAYER_QUALITY_${currentLevel}`
+          : "PLAYER_QUALITY_AUTO";
+      setFocus(key);
+    } else if (openMenu === "volume") {
+      setFocus(FK.VOLUME_SLIDER);
+    }
+  }, [
+    openMenu,
+    currentAudioTrack,
+    currentSubtitleTrack,
+    currentLevel,
+    audioTracks,
+  ]);
+
+  // Helper to build Left/Right dismiss callbacks for a popover rooted at
+  // `anchorKey`. Always closes the popover, then hops to the sibling.
+  // tsconfig has exactOptionalPropertyTypes:true — only include the key
+  // when a sibling actually exists.
+  const buildDismiss = (
+    anchorKey: string,
+  ): { onDismissLeft?: () => void; onDismissRight?: () => void } => {
+    const { left, right } = dismissTargets(anchorKey);
+    const out: { onDismissLeft?: () => void; onDismissRight?: () => void } = {};
+    if (left) {
+      out.onDismissLeft = () => {
+        closeMenu();
+        setFocus(left);
+      };
+    }
+    if (right) {
+      out.onDismissRight = () => {
+        closeMenu();
+        setFocus(right);
+      };
+    }
+    return out;
+  };
 
   return (
     <FocusContext.Provider value={containerFocusKey}>
@@ -514,7 +788,6 @@ export function PlayerControls({
               "linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.45) 60%, transparent 100%)",
           }}
         >
-          {/* Scrubber band — hidden on Live (LIVE badge renders in top bar). */}
           {!isLive && (
             <div
               style={{
@@ -580,6 +853,7 @@ export function PlayerControls({
               icon="◀◀"
               focusable={seekable}
               onPress={handleSeekBack}
+              onHoldTick={holdSeekBack}
               isEdgeLeft={leftEdgeKey === FK.SEEK_BACK}
               isEdgeRight={rightEdgeKey === FK.SEEK_BACK}
             />
@@ -589,21 +863,33 @@ export function PlayerControls({
               icon="▶▶"
               focusable={seekable}
               onPress={handleSeekForward}
+              onHoldTick={holdSeekForward}
               isEdgeLeft={leftEdgeKey === FK.SEEK_FORWARD}
               isEdgeRight={rightEdgeKey === FK.SEEK_FORWARD}
             />
 
-            {/* Spacer pushes the right-hand selectors to the edge */}
             <div style={{ flex: 1 }} />
 
-            <ControlButton
-              focusKey={FK.VOLUME}
-              label={muted ? "Unmute" : "Mute"}
-              icon={volumeIcon(volume, muted)}
-              onPress={onToggleMute}
-              isEdgeLeft={leftEdgeKey === FK.VOLUME}
-              isEdgeRight={rightEdgeKey === FK.VOLUME}
-            />
+            <div style={{ position: "relative" }}>
+              <ControlButton
+                focusKey={FK.VOLUME}
+                label="Volume"
+                icon={`${volumeIcon(volume)} ${Math.round(volume * 100)}`}
+                onPress={openVolume}
+                ariaExpanded={openMenu === "volume"}
+                ariaHasPopup
+                isEdgeLeft={leftEdgeKey === FK.VOLUME}
+                isEdgeRight={rightEdgeKey === FK.VOLUME}
+              />
+              {openMenu === "volume" && (
+                <VolumeSlider
+                  volume={volume}
+                  onSetVolume={onSetVolume}
+                  onClose={closeMenu}
+                  {...buildDismiss(FK.VOLUME)}
+                />
+              )}
+            </div>
 
             {audioHasOptions && (
               <div style={{ position: "relative" }}>
@@ -631,8 +917,9 @@ export function PlayerControls({
                         focusKey={`PLAYER_AUDIO_${track.index}`}
                         onSelect={() => {
                           onSelectAudioTrack(track.index);
-                          setOpenMenu(null);
+                          closeMenu();
                         }}
+                        {...buildDismiss(FK.AUDIO)}
                       />
                     ))}
                   </ul>
@@ -664,8 +951,9 @@ export function PlayerControls({
                       focusKey="PLAYER_SUBTITLES_OFF"
                       onSelect={() => {
                         onSelectSubtitleTrack(-1);
-                        setOpenMenu(null);
+                        closeMenu();
                       }}
+                      {...buildDismiss(FK.SUBTITLES)}
                     />
                     {subtitleTracks.map((track) => (
                       <MenuItem
@@ -675,8 +963,9 @@ export function PlayerControls({
                         focusKey={`PLAYER_SUBTITLE_${track.index}`}
                         onSelect={() => {
                           onSelectSubtitleTrack(track.index);
-                          setOpenMenu(null);
+                          closeMenu();
                         }}
+                        {...buildDismiss(FK.SUBTITLES)}
                       />
                     ))}
                   </ul>
@@ -708,10 +997,10 @@ export function PlayerControls({
                       focusKey="PLAYER_QUALITY_AUTO"
                       onSelect={() => {
                         onSelectLevel(-1);
-                        setOpenMenu(null);
+                        closeMenu();
                       }}
+                      {...buildDismiss(FK.QUALITY)}
                     />
-                    {/* Spec §5.3: highest-first (most common intent = "lower it") */}
                     {[...levels]
                       .sort((a, b) => b.height - a.height)
                       .map((level) => (
@@ -722,8 +1011,9 @@ export function PlayerControls({
                           focusKey={`PLAYER_QUALITY_${level.index}`}
                           onSelect={() => {
                             onSelectLevel(level.index);
-                            setOpenMenu(null);
+                            closeMenu();
                           }}
+                          {...buildDismiss(FK.QUALITY)}
                         />
                       ))}
                   </ul>

--- a/src/player/PlayerControls.tsx
+++ b/src/player/PlayerControls.tsx
@@ -26,12 +26,15 @@ import type {
   PlayerStatus,
 } from "./useHlsPlayer";
 import type { PlayerKind } from "./PlayerProvider";
+import { useReducedMotion } from "./useReducedMotion";
 
 // ─── Focus keys (exported for tests + call sites) ────────────────────────────
 
 export const FK = {
   BACK: "PLAYER_BACK",
+  PREV: "PLAYER_PREV",
   PLAY_PAUSE: "PLAYER_PLAY_PAUSE",
+  NEXT: "PLAYER_NEXT",
   SEEK_BACK: "PLAYER_SEEK_BACK",
   SEEK_FORWARD: "PLAYER_SEEK_FORWARD",
   VOLUME: "PLAYER_VOLUME",
@@ -93,6 +96,13 @@ export interface PlayerControlsProps {
   onSelectLevel: (idx: number) => void;
   onSelectAudioTrack: (idx: number) => void;
   onSelectSubtitleTrack: (idx: number) => void;
+  /**
+   * Jump to the previous sibling (prev channel on Live, prev episode on a
+   * series). Undefined means the button is hidden — spec §3.1 says disabled
+   * controls don't render. Movies never get these.
+   */
+  onPrev?: () => void;
+  onNext?: () => void;
 }
 
 type MenuName = "audio" | "subtitles" | "quality" | "volume";
@@ -413,7 +423,11 @@ export function PlayerControls({
   onSelectLevel,
   onSelectAudioTrack,
   onSelectSubtitleTrack,
+  onPrev,
+  onNext,
 }: PlayerControlsProps) {
+  const reducedMotion = useReducedMotion();
+
   // Controls open visible (spec §4.1), then fade after AUTO_HIDE_MS idle.
   const [visible, setVisible] = useState(true);
   const [openMenu, setOpenMenu] = useState<MenuName | null>(null);
@@ -594,9 +608,13 @@ export function PlayerControls({
   const audioHasOptions = audioTracks.length > 1;
   const subsAvailable = subtitleTracks.length > 0;
   const qualityAvailable = levels.length > 0;
+  const hasPrev = Boolean(onPrev);
+  const hasNext = Boolean(onNext);
 
   const orderedKeys: string[] = [
+    hasPrev ? FK.PREV : null,
     FK.PLAY_PAUSE,
+    hasNext ? FK.NEXT : null,
     seekable ? FK.SEEK_BACK : null,
     seekable ? FK.SEEK_FORWARD : null,
     FK.VOLUME,
@@ -693,7 +711,8 @@ export function PlayerControls({
           inset: 0,
           pointerEvents: visible ? "auto" : "none",
           opacity: visible ? 1 : 0,
-          transition: `opacity ${FADE_MS}ms ease-out`,
+          // Spec §10 — prefers-reduced-motion disables the fade.
+          transition: reducedMotion ? "none" : `opacity ${FADE_MS}ms ease-out`,
           display: "flex",
           flexDirection: "column",
           justifyContent: "space-between",
@@ -838,6 +857,17 @@ export function PlayerControls({
               gap: "var(--space-3)",
             }}
           >
+            {hasPrev && onPrev && (
+              <ControlButton
+                focusKey={FK.PREV}
+                label={isLive ? "Previous channel" : "Previous episode"}
+                icon="⏮"
+                onPress={onPrev}
+                isEdgeLeft={leftEdgeKey === FK.PREV}
+                isEdgeRight={rightEdgeKey === FK.PREV}
+              />
+            )}
+
             <ControlButton
               focusKey={FK.PLAY_PAUSE}
               label={isPlaying ? "Pause" : "Play"}
@@ -846,6 +876,17 @@ export function PlayerControls({
               isEdgeLeft={leftEdgeKey === FK.PLAY_PAUSE}
               isEdgeRight={rightEdgeKey === FK.PLAY_PAUSE}
             />
+
+            {hasNext && onNext && (
+              <ControlButton
+                focusKey={FK.NEXT}
+                label={isLive ? "Next channel" : "Next episode"}
+                icon="⏭"
+                onPress={onNext}
+                isEdgeLeft={leftEdgeKey === FK.NEXT}
+                isEdgeRight={rightEdgeKey === FK.NEXT}
+              />
+            )}
 
             <ControlButton
               focusKey={FK.SEEK_BACK}

--- a/src/player/PlayerProvider.tsx
+++ b/src/player/PlayerProvider.tsx
@@ -20,10 +20,26 @@ import {
 
 export type PlayerKind = "live" | "vod" | "series-episode";
 
+/**
+ * Identifies the originating content item so the player can write tier-lock
+ * cache entries against the right stream id on failure. VOD uses the stream
+ * id from /api/vod/streams; series-episode uses the episode id.
+ */
+export interface PlayerContentId {
+  kind: PlayerKind;
+  id: string;
+}
+
 export interface PlayerOpenPayload {
   src: string;
   title: string;
   kind?: PlayerKind;
+  /** Jump to previous sibling (prev channel / prev episode). Undefined = disabled. */
+  onPrev?: () => void;
+  /** Jump to next sibling. Undefined = disabled. */
+  onNext?: () => void;
+  /** When set, the failure overlay uses this id to memo a tier-lock hit. */
+  contentId?: PlayerContentId;
 }
 
 interface PlayerStateOpen {
@@ -31,6 +47,9 @@ interface PlayerStateOpen {
   src: string;
   title: string;
   kind: PlayerKind;
+  onPrev?: () => void;
+  onNext?: () => void;
+  contentId?: PlayerContentId;
 }
 
 interface PlayerStateIdle {
@@ -45,13 +64,20 @@ type PlayerAction =
 
 function playerReducer(_state: PlayerState, action: PlayerAction): PlayerState {
   switch (action.type) {
-    case "OPEN":
-      return {
+    case "OPEN": {
+      // tsconfig exactOptionalPropertyTypes:true — only set the keys when
+      // actually defined to avoid { onPrev: undefined } showing up in state.
+      const next: PlayerStateOpen = {
         status: "open",
         src: action.payload.src,
         title: action.payload.title,
         kind: action.payload.kind ?? "vod",
       };
+      if (action.payload.onPrev) next.onPrev = action.payload.onPrev;
+      if (action.payload.onNext) next.onNext = action.payload.onNext;
+      if (action.payload.contentId) next.contentId = action.payload.contentId;
+      return next;
+    }
     case "CLOSE":
       return { status: "idle" };
     default:

--- a/src/player/PlayerShell.tsx
+++ b/src/player/PlayerShell.tsx
@@ -45,16 +45,14 @@ export function PlayerShell() {
   const [currentAudioTrack, setCurrentAudioTrack] = useState(-1);
   const [currentSubtitleTrack, setCurrentSubtitleTrack] = useState(-1);
   const [volume, setVolumeState] = useState(1);
-  const [muted, setMuted] = useState(false);
-  const lastVolumeBeforeMute = useRef(1);
 
   const { ref: shellRef, focusKey } = useFocusable({
     focusKey: "PLAYER_SHELL",
     isFocusBoundary: true,
   });
 
-  // Reset track / level state when a new src loads so stale "720p" labels
-  // don't stick around through channel switches.
+  // Reset track / level state when a new src loads so stale labels don't
+  // stick around through channel or episode switches.
   useEffect(() => {
     setCurrentLevel(-1);
     setCurrentAudioTrack(-1);
@@ -85,19 +83,13 @@ export function PlayerShell() {
     [selectSubtitleTrack],
   );
 
-  const handleToggleMute = useCallback(() => {
-    if (muted) {
-      setMuted(false);
-      const v = lastVolumeBeforeMute.current || 1;
+  const handleSetVolume = useCallback(
+    (v: number) => {
       setVolumeState(v);
       setVolume(v);
-    } else {
-      lastVolumeBeforeMute.current = volume;
-      setMuted(true);
-      setVolumeState(0);
-      setVolume(0);
-    }
-  }, [muted, volume, setVolume]);
+    },
+    [setVolume],
+  );
 
   if (state.status === "idle") {
     return null;
@@ -105,7 +97,6 @@ export function PlayerShell() {
 
   return (
     <FocusContext.Provider value={focusKey}>
-      {/* Full-screen overlay — position: fixed, NO transform, NO backdrop-filter */}
       <div
         ref={shellRef as RefObject<HTMLDivElement>}
         data-testid="player-shell"
@@ -130,7 +121,6 @@ export function PlayerShell() {
           playsInline
         />
 
-        {/* Buffering / loading spinner */}
         {(status === "loading" || status === "buffering") && (
           <div
             aria-label="Loading video"
@@ -158,8 +148,7 @@ export function PlayerShell() {
           </div>
         )}
 
-        {/* Playback-failure overlay — full treatment ships in Phase 6c. For now
-            keep the minimal close-out so error states don't leave users stuck. */}
+        {/* Minimal error state — full amber overlay + tier-lock copy ships in 6c. */}
         {status === "error" && (
           <div
             style={{
@@ -198,7 +187,6 @@ export function PlayerShell() {
           </div>
         )}
 
-        {/* Controls overlay */}
         {status !== "error" && (
           <PlayerControls
             title={title}
@@ -207,7 +195,6 @@ export function PlayerShell() {
             currentTime={currentTime}
             duration={duration}
             volume={volume}
-            muted={muted}
             levels={levels}
             audioTracks={audioTracks}
             subtitleTracks={subtitleTracks}
@@ -218,7 +205,7 @@ export function PlayerShell() {
             onPause={pause}
             onSeek={seek}
             onClose={close}
-            onToggleMute={handleToggleMute}
+            onSetVolume={handleSetVolume}
             onSelectLevel={handleSelectLevel}
             onSelectAudioTrack={handleSelectAudioTrack}
             onSelectSubtitleTrack={handleSelectSubtitleTrack}

--- a/src/player/PlayerShell.tsx
+++ b/src/player/PlayerShell.tsx
@@ -12,18 +12,53 @@
  */
 import type { RefObject } from "react";
 import { useRef, useState, useEffect, useCallback } from "react";
-import { useFocusable, FocusContext } from "@noriginmedia/norigin-spatial-navigation";
+import {
+  useFocusable,
+  FocusContext,
+  setFocus,
+} from "@noriginmedia/norigin-spatial-navigation";
 import { usePlayerStore } from "./PlayerProvider";
+import type { PlayerKind } from "./PlayerProvider";
 import { useHlsPlayer } from "./useHlsPlayer";
 import { PlayerControls } from "./PlayerControls";
+import { useReducedMotion } from "./useReducedMotion";
+import { markTierLocked } from "../features/movies/tierLockCache";
+
+// Failure-overlay focus keys — kept local, only the overlay reads them.
+const FK_RETRY = "PLAYER_FAIL_RETRY";
+const FK_BACK = "PLAYER_FAIL_BACK";
+
+/**
+ * Classify a playback error so the overlay can render the right copy and
+ * decide whether to memo a tier-lock hit (spec §9.2 / §9.3).
+ *
+ * Heuristic: VOD/series-episode that errors with zero duration + zero
+ * playhead — before any frame ever arrived — is almost always the Xtream
+ * account plan refusing the container extension. Live errors are treated
+ * as generic (tier-lock doesn't apply to Live channels).
+ */
+function classifyFailure(
+  kind: PlayerKind,
+  duration: number,
+  currentTime: number,
+): "tier-lock" | "generic" {
+  if (kind !== "live" && duration === 0 && currentTime === 0) {
+    return "tier-lock";
+  }
+  return "generic";
+}
 
 export function PlayerShell() {
   const { state, close } = usePlayerStore();
   const videoRef = useRef<HTMLVideoElement>(null);
+  const reducedMotion = useReducedMotion();
 
   const src = state.status === "open" ? state.src : undefined;
   const title = state.status === "open" ? state.title : "";
   const kind = state.status === "open" ? state.kind : "vod";
+  const onPrev = state.status === "open" ? state.onPrev : undefined;
+  const onNext = state.status === "open" ? state.onNext : undefined;
+  const contentId = state.status === "open" ? state.contentId : undefined;
 
   const {
     status,
@@ -39,6 +74,7 @@ export function PlayerShell() {
     selectLevel,
     selectAudioTrack,
     selectSubtitleTrack,
+    retry,
   } = useHlsPlayer(videoRef, src, kind);
 
   const [currentLevel, setCurrentLevel] = useState(-1);
@@ -51,8 +87,6 @@ export function PlayerShell() {
     isFocusBoundary: true,
   });
 
-  // Reset track / level state when a new src loads so stale labels don't
-  // stick around through channel or episode switches.
   useEffect(() => {
     setCurrentLevel(-1);
     setCurrentAudioTrack(-1);
@@ -91,9 +125,21 @@ export function PlayerShell() {
     [setVolume],
   );
 
+  const failureClass =
+    status === "error" ? classifyFailure(kind, duration, currentTime) : null;
+
+  // Memo the tier-lock so MovieCard/EpisodeRow can badge the card on return.
+  useEffect(() => {
+    if (failureClass === "tier-lock" && contentId) {
+      markTierLocked(contentId.id);
+    }
+  }, [failureClass, contentId]);
+
   if (state.status === "idle") {
     return null;
   }
+
+  const showFailure = status === "error";
 
   return (
     <FocusContext.Provider value={focusKey}>
@@ -142,52 +188,23 @@ export function PlayerShell() {
                 borderTopColor: "var(--accent-copper)",
                 borderRadius: "50%",
                 display: "inline-block",
-                animation: "sv-spin 0.8s linear infinite",
+                animation: reducedMotion
+                  ? "sv-pulse 1.6s ease-in-out infinite"
+                  : "sv-spin 0.8s linear infinite",
               }}
             />
           </div>
         )}
 
-        {/* Minimal error state — full amber overlay + tier-lock copy ships in 6c. */}
-        {status === "error" && (
-          <div
-            style={{
-              position: "absolute",
-              inset: 0,
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              justifyContent: "center",
-              color: "var(--text-primary)",
-              gap: "var(--space-4)",
-            }}
-          >
-            <p style={{ fontSize: "var(--text-title-size)", fontWeight: 600 }}>
-              Playback error
-            </p>
-            <p style={{ color: "var(--text-secondary)" }}>
-              The stream could not be loaded.
-            </p>
-            <button
-              type="button"
-              className="focus-ring"
-              onClick={close}
-              style={{
-                background: "var(--accent-copper)",
-                color: "var(--bg-base)",
-                border: "none",
-                borderRadius: "var(--radius-sm)",
-                padding: "var(--space-2) var(--space-6)",
-                cursor: "pointer",
-                fontSize: "var(--text-body-size)",
-              }}
-            >
-              Close
-            </button>
-          </div>
+        {showFailure && (
+          <FailureOverlay
+            kind={failureClass === "tier-lock" ? "tier-lock" : "generic"}
+            onRetry={retry}
+            onClose={close}
+          />
         )}
 
-        {status !== "error" && (
+        {!showFailure && (
           <PlayerControls
             title={title}
             kind={kind}
@@ -209,6 +226,8 @@ export function PlayerShell() {
             onSelectLevel={handleSelectLevel}
             onSelectAudioTrack={handleSelectAudioTrack}
             onSelectSubtitleTrack={handleSelectSubtitleTrack}
+            {...(onPrev && { onPrev })}
+            {...(onNext && { onNext })}
           />
         )}
       </div>
@@ -217,7 +236,167 @@ export function PlayerShell() {
         @keyframes sv-spin {
           to { transform: rotate(360deg); }
         }
+        @keyframes sv-pulse {
+          0%, 100% { opacity: 0.4; }
+          50% { opacity: 1; }
+        }
       `}</style>
     </FocusContext.Provider>
+  );
+}
+
+// ─── FailureOverlay ──────────────────────────────────────────────────────────
+
+interface FailureOverlayProps {
+  kind: "tier-lock" | "generic";
+  onRetry: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Amber glass overlay per spec §9. Never red, never auto-retry.
+ *
+ *   tier-lock → specific "format not supported by plan" copy, no Try again
+ *   generic   → Try again + Back to browse
+ *
+ * Focus: auto-seeds on the most-useful action for the class.
+ */
+function FailureOverlay({ kind, onRetry, onClose }: FailureOverlayProps) {
+  const { ref: retryRef, focused: retryFocused } = useFocusable({
+    focusKey: FK_RETRY,
+    focusable: kind !== "tier-lock",
+    onEnterPress: onRetry,
+    onArrowPress: (direction) => {
+      if (direction === "right") {
+        setFocus(FK_BACK);
+        return false;
+      }
+      return false;
+    },
+  });
+
+  const { ref: backRef, focused: backFocused } = useFocusable({
+    focusKey: FK_BACK,
+    onEnterPress: onClose,
+    onArrowPress: (direction) => {
+      if (direction === "left" && kind !== "tier-lock") {
+        setFocus(FK_RETRY);
+        return false;
+      }
+      return false;
+    },
+  });
+
+  useEffect(() => {
+    setFocus(kind === "tier-lock" ? FK_BACK : FK_RETRY);
+  }, [kind]);
+
+  // Escape/Back closes; otherwise the generic PlayerControls listener
+  // isn't mounted (we're showing the overlay instead).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" || e.key === "Back" || e.key === "GoBack") {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [onClose]);
+
+  return (
+    <div
+      data-testid={`player-failure-${kind}`}
+      role="alertdialog"
+      aria-modal="true"
+      aria-label="Playback failed"
+      style={{
+        position: "absolute",
+        inset: 0,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "rgba(0,0,0,0.75)",
+        padding: "var(--space-6)",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: "540px",
+          width: "100%",
+          background: "rgba(245,158,11,0.12)",
+          border: "1px solid #F59E0B",
+          borderRadius: "var(--radius-md)",
+          padding: "var(--space-6)",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: "var(--space-4)",
+          textAlign: "center",
+          color: "var(--text-primary)",
+        }}
+      >
+        <span style={{ fontSize: "32px" }} aria-hidden="true">⚠</span>
+        <p style={{ fontSize: "var(--text-title-size)", fontWeight: 600, margin: 0 }}>
+          Playback failed
+        </p>
+        <p
+          style={{
+            color: "var(--text-secondary)",
+            fontSize: "var(--text-body-size)",
+            margin: 0,
+            lineHeight: 1.5,
+          }}
+        >
+          {kind === "tier-lock"
+            ? "This title is delivered in a format your Xtream plan doesn't support. Try a different title or see if a similar one is available."
+            : "This title couldn't be played right now. It may be a format your plan doesn't support, or the provider is temporarily unavailable."}
+        </p>
+        <div
+          style={{
+            display: "flex",
+            gap: "var(--space-3)",
+            marginTop: "var(--space-2)",
+          }}
+        >
+          {kind !== "tier-lock" && (
+            <button
+              ref={retryRef as RefObject<HTMLButtonElement>}
+              type="button"
+              className="focus-ring"
+              onClick={onRetry}
+              style={{
+                background: retryFocused ? "var(--accent-copper)" : "rgba(255,255,255,0.15)",
+                color: retryFocused ? "var(--bg-base)" : "var(--text-primary)",
+                border: "none",
+                borderRadius: "var(--radius-sm)",
+                padding: "var(--space-2) var(--space-6)",
+                cursor: "pointer",
+                fontSize: "var(--text-body-size)",
+              }}
+            >
+              Try again
+            </button>
+          )}
+          <button
+            ref={backRef as RefObject<HTMLButtonElement>}
+            type="button"
+            className="focus-ring"
+            onClick={onClose}
+            style={{
+              background: backFocused ? "var(--accent-copper)" : "rgba(255,255,255,0.15)",
+              color: backFocused ? "var(--bg-base)" : "var(--text-primary)",
+              border: "none",
+              borderRadius: "var(--radius-sm)",
+              padding: "var(--space-2) var(--space-6)",
+              cursor: "pointer",
+              fontSize: "var(--text-body-size)",
+            }}
+          >
+            Back to browse
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/player/useHlsPlayer.ts
+++ b/src/player/useHlsPlayer.ts
@@ -66,6 +66,8 @@ export interface UseHlsPlayerReturn {
   selectLevel: (idx: number) => void;
   selectAudioTrack: (idx: number) => void;
   selectSubtitleTrack: (idx: number) => void;
+  /** Re-attach the playback engine so a failed stream is retried in place. */
+  retry: () => void;
 }
 
 export function useHlsPlayer(
@@ -82,6 +84,10 @@ export function useHlsPlayer(
   const [levels, setLevels] = useState<HlsLevel[]>([]);
   const [audioTracks, setAudioTracks] = useState<HlsAudioTrack[]>([]);
   const [subtitleTracks, setSubtitleTracks] = useState<HlsSubtitleTrack[]>([]);
+  // Bumping this forces the main attach/tear-down effect to re-run even when
+  // src/kind haven't changed — the "Try again" button on the failure overlay
+  // relies on this so users don't have to close + re-open from the card.
+  const [retryCount, setRetryCount] = useState(0);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -255,7 +261,7 @@ export function useHlsPlayer(
       }
       video.src = "";
     };
-  }, [videoRef, src, kind]);
+  }, [videoRef, src, kind, retryCount]);
 
   const play = useCallback(() => {
     videoRef.current?.play().catch(() => {});
@@ -306,6 +312,10 @@ export function useHlsPlayer(
     }
   }, []);
 
+  const retry = useCallback(() => {
+    setRetryCount((c) => c + 1);
+  }, []);
+
   return {
     status,
     error,
@@ -321,5 +331,6 @@ export function useHlsPlayer(
     selectLevel,
     selectAudioTrack,
     selectSubtitleTrack,
+    retry,
   };
 }

--- a/src/player/usePlayerOpener.ts
+++ b/src/player/usePlayerOpener.ts
@@ -4,6 +4,10 @@
  * Used by LiveRoute, MoviesRoute, SeriesRoute, SearchRoute so they all share
  * the same open path. Fetches the stream URL for the given type/id, then
  * calls playerStore.open().
+ *
+ * Phase 6c: callers can pass onPrev/onNext callbacks to enable channel/
+ * episode navigation inside the player. The route owns the list state and
+ * re-calls openPlayer with updated indices; this hook is a thin pass-through.
  */
 import { useCallback } from "react";
 import { usePlayerStore, type PlayerKind } from "./PlayerProvider";
@@ -16,6 +20,10 @@ interface OpenPlayerOptions {
   /** For series episodes: season + episode numbers */
   season?: number;
   episode?: number;
+  /** In-player previous-sibling navigation (e.g. prev channel / prev episode) */
+  onPrev?: () => void;
+  /** In-player next-sibling navigation */
+  onNext?: () => void;
 }
 
 export function usePlayerOpener() {
@@ -23,10 +31,10 @@ export function usePlayerOpener() {
 
   const openPlayer = useCallback(
     async (opts: OpenPlayerOptions) => {
-      const { id, title, kind, season, episode } = opts;
+      const { id, title, kind, season, episode, onPrev, onNext } = opts;
 
-      // tsconfig has exactOptionalPropertyTypes:true — spread season/episode
-      // only when defined so the optional field isn't set to `undefined`.
+      // tsconfig has exactOptionalPropertyTypes:true — spread optional fields
+      // only when defined so they aren't set to `undefined`.
       const streamUrl = fetchStreamUrl({
         kind,
         id,
@@ -38,6 +46,9 @@ export function usePlayerOpener() {
         src: streamUrl,
         title,
         kind,
+        contentId: { kind, id },
+        ...(onPrev && { onPrev }),
+        ...(onNext && { onNext }),
       });
     },
     [open],

--- a/src/player/useReducedMotion.ts
+++ b/src/player/useReducedMotion.ts
@@ -1,0 +1,32 @@
+/**
+ * useReducedMotion — honour the user's `prefers-reduced-motion` setting.
+ *
+ * Returns `true` if the OS / browser is reporting a reduce preference. Used
+ * by the player per docs/ux/05-player.md §10: disable the control-bar fade,
+ * the spinner rotation, and popover slide-ins when set.
+ */
+import { useEffect, useState } from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState<boolean>(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return false;
+    return window.matchMedia(QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia(QUERY);
+    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches);
+    // Some older engines only expose addListener/removeListener.
+    if (mql.addEventListener) {
+      mql.addEventListener("change", onChange);
+      return () => mql.removeEventListener("change", onChange);
+    }
+    mql.addListener(onChange);
+    return () => mql.removeListener(onChange);
+  }, []);
+
+  return reduced;
+}

--- a/src/routes/SeriesDetailRoute.tsx
+++ b/src/routes/SeriesDetailRoute.tsx
@@ -960,18 +960,41 @@ export function SeriesDetailRoute() {
     }
   }, [loading, error]);
 
-  const playEpisode = useCallback(
-    (ep: EpisodeInfo, seasonNum: number) => {
-      const title = info
-        ? buildEpisodeTitle(info.name, seasonNum, ep)
-        : `S${seasonNum}E${ep.episodeNumber} · ${ep.title}`;
+  // ─── Play handler ────────────────────────────────────────────────────────
+  // playEpisodeAt wires onPrev/onNext so the player's ⏮/⏭ walk within the
+  // same season's episode list in the user's current sort order (Phase 6c).
+  // Each call passes a new index into the same array, forming a cheap
+  // closure chain rather than storing list state in PlayerProvider.
+  const playEpisodeAt = useCallback(
+    (episodes: EpisodeInfo[], idx: number, seasonNum: number) => {
+      const ep = episodes[idx];
+      if (!ep || !info) return;
+      const title = buildEpisodeTitle(info.name, seasonNum, ep);
       void openPlayer({
         kind: "series-episode",
         id: ep.id,
         title,
+        ...(idx > 0 && {
+          onPrev: () => playEpisodeAt(episodes, idx - 1, seasonNum),
+        }),
+        ...(idx < episodes.length - 1 && {
+          onNext: () => playEpisodeAt(episodes, idx + 1, seasonNum),
+        }),
       });
     },
     [info, openPlayer],
+  );
+
+  const playEpisode = useCallback(
+    (ep: EpisodeInfo, seasonNum: number) => {
+      const seasonKey = String(seasonNum);
+      const rawEps = info?.episodes?.[seasonKey] ?? [];
+      // Walk within the user's current sort so ⏮/⏭ matches what's on screen.
+      const sortedEps = sortEpisodes(rawEps, episodeSort);
+      const idx = sortedEps.findIndex((e) => e.id === ep.id);
+      playEpisodeAt(sortedEps, Math.max(0, idx), seasonNum);
+    },
+    [info, episodeSort, playEpisodeAt],
   );
 
   const handleCtaPress = useCallback(() => {


### PR DESCRIPTION
## Summary

Stacked on top of #86 (6b). Closes Phase 6 — the remaining spec items plus the \"everything by D-pad\" ask.

### Scope clarification

Per your direction: prev/next is **series-episode only**. Movies don't get them; Live doesn't get them either (channel switching belongs on LiveRoute, not inside the player). The component adapts automatically — it only renders ⏮/⏭ when props are passed.

### Ships

**Series prev/next (spec §3 / §8 series column)**
- \`PlayerProvider\` + \`usePlayerOpener\` accept optional \`onPrev\` / \`onNext\` and thread them through open payload → \`PlayerShell\` → \`PlayerControls\`.
- \`SeriesDetailRoute\` lifts \`playEpisode\` to \`playEpisodeAt(episodes, idx, season)\` so each \`open()\` closes over the current season's episode list. Each prev/next recurses with an updated idx. Hero CTA uses the same path.
- \`PlayerControls\` renders ⏮/⏭ between the edges **only** when props are present. \`orderedKeys\` includes them so D-pad edge blocking still works (no wrap).

**Amber failure overlay (spec §9)**
- \`FailureOverlay\` is a full glass modal with \`role=\"alertdialog\"\`, never red, never auto-retries.
- Classifier: VOD/series-episode errors that fire before any frame arrives (\`duration===0 && currentTime===0\`) → **tier-lock** with §9.3 copy and no Try again button. Everything else → generic with Try again + Back to browse, focus seeded on Try again.
- Try again calls \`useHlsPlayer.retry()\` which bumps a \`retryCount\` dep and re-attaches hls.js / mpegts / native \`src\` without closing the shell.

**Tier-lock memo (spec §9.3 + handoff TODO)**
- \`open()\` payload accepts \`contentId: { kind, id }\`. When the classifier flags tier-lock, \`PlayerShell\` calls \`markTierLocked(contentId.id)\` so MovieCard / future EpisodeRow can badge the card on return.

**Reduced-motion (spec §10)**
- New \`useReducedMotion\` hook — media-query driven with live updates.
- Control-bar fade is disabled when reduced; spinner swaps the rotating ring for an opacity pulse. Popovers have no slide-in animation already.

### D-pad coverage audit (final)

- Play/Pause · ±10s · Hold-to-scrub · Volume · Audio · Subs · Quality · Back · **Prev/Next episode (series only)** · Try again · Back to browse — everything in-player reachable by D-pad / arrows + Enter + Back.

## Test plan

- [x] \`npm test\` — 277/277 (was 274; +3 PlayerControls tests for prev/next)
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [ ] After merge into 6b → main: prod deploy + user validation round
- [ ] Verify on Fire TV: Series episode player shows ⏮/⏭ between Play/Pause; Enter on them jumps episodes
- [ ] Verify failure overlay: force a broken VOD URL → amber overlay with tier-lock copy; Back to browse exits
- [ ] Verify tier-lock badge appears on the Movies grid after a tier-lock fail
- [ ] Verify reduced-motion (macOS: Accessibility → Display → Reduce motion): fade is instant, spinner pulses

🤖 Generated with [Claude Code](https://claude.com/claude-code)