### PR TITLE
feat(player): Phase 6c — series prev/next, amber failure overlay, reduced-motion

### DIFF
--- a/src/player/PlayerControls.test.tsx
+++ b/src/player/PlayerControls.test.tsx
@@ -364,4 +364,35 @@ describe("PlayerControls", () => {
     );
     expect(screen.queryByRole("button", { name: /audio/i })).toBeNull();
   });
+
+  // ─── 6c: prev/next wiring ───────────────────────────────────────────────
+
+  it("renders Previous/Next episode buttons when onPrev/onNext provided (series)", () => {
+    const onPrev = vi.fn();
+    const onNext = vi.fn();
+    render(
+      <PlayerControls
+        {...makeProps({ kind: "series-episode", onPrev, onNext })}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Previous episode" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Next episode" })).toBeTruthy();
+  });
+
+  it("hides Previous/Next when props not provided (movies)", () => {
+    render(<PlayerControls {...makeProps({ kind: "vod" })} />);
+    expect(screen.queryByRole("button", { name: /previous/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /next episode|next channel/i })).toBeNull();
+  });
+
+  it("Previous button fires onPrev when pressed", () => {
+    const onPrev = vi.fn();
+    render(
+      <PlayerControls {...makeProps({ kind: "series-episode", onPrev })} />,
+    );
+    act(() => {
+      screen.getByRole("button", { name: "Previous episode" }).click();
+    });
+    expect(onPrev).toHaveBeenCalledOnce();
+  });
 });

--- a/src/player/PlayerControls.tsx
+++ b/src/player/PlayerControls.tsx
@@ -26,12 +26,15 @@ import type {
   PlayerStatus,
 } from "./useHlsPlayer";
 import type { PlayerKind } from "./PlayerProvider";
+import { useReducedMotion } from "./useReducedMotion";
 
 // ─── Focus keys (exported for tests + call sites) ────────────────────────────
 
 export const FK = {
   BACK: "PLAYER_BACK",
+  PREV: "PLAYER_PREV",
   PLAY_PAUSE: "PLAYER_PLAY_PAUSE",
+  NEXT: "PLAYER_NEXT",
   SEEK_BACK: "PLAYER_SEEK_BACK",
   SEEK_FORWARD: "PLAYER_SEEK_FORWARD",
   VOLUME: "PLAYER_VOLUME",
@@ -93,6 +96,13 @@ export interface PlayerControlsProps {
   onSelectLevel: (idx: number) => void;
   onSelectAudioTrack: (idx: number) => void;
   onSelectSubtitleTrack: (idx: number) => void;
+  /**
+   * Jump to the previous sibling (prev channel on Live, prev episode on a
+   * series). Undefined means the button is hidden — spec §3.1 says disabled
+   * controls don't render. Movies never get these.
+   */
+  onPrev?: () => void;
+  onNext?: () => void;
 }
 
 type MenuName = "audio" | "subtitles" | "quality" | "volume";
@@ -413,7 +423,11 @@ export function PlayerControls({
   onSelectLevel,
   onSelectAudioTrack,
   onSelectSubtitleTrack,
+  onPrev,
+  onNext,
 }: PlayerControlsProps) {
+  const reducedMotion = useReducedMotion();
+
   // Controls open visible (spec §4.1), then fade after AUTO_HIDE_MS idle.
   const [visible, setVisible] = useState(true);
   const [openMenu, setOpenMenu] = useState<MenuName | null>(null);
@@ -594,9 +608,13 @@ export function PlayerControls({
   const audioHasOptions = audioTracks.length > 1;
   const subsAvailable = subtitleTracks.length > 0;
   const qualityAvailable = levels.length > 0;
+  const hasPrev = Boolean(onPrev);
+  const hasNext = Boolean(onNext);
 
   const orderedKeys: string[] = [
+    hasPrev ? FK.PREV : null,
     FK.PLAY_PAUSE,
+    hasNext ? FK.NEXT : null,
     seekable ? FK.SEEK_BACK : null,
     seekable ? FK.SEEK_FORWARD : null,
     FK.VOLUME,
@@ -693,7 +711,8 @@ export function PlayerControls({
           inset: 0,
           pointerEvents: visible ? "auto" : "none",
           opacity: visible ? 1 : 0,
-          transition: `opacity ${FADE_MS}ms ease-out`,
+          // Spec §10 — prefers-reduced-motion disables the fade.
+          transition: reducedMotion ? "none" : `opacity ${FADE_MS}ms ease-out`,
           display: "flex",
           flexDirection: "column",
           justifyContent: "space-between",
@@ -838,6 +857,17 @@ export function PlayerControls({
               gap: "var(--space-3)",
             }}
           >
+            {hasPrev && onPrev && (
+              <ControlButton
+                focusKey={FK.PREV}
+                label={isLive ? "Previous channel" : "Previous episode"}
+                icon="⏮"
+                onPress={onPrev}
+                isEdgeLeft={leftEdgeKey === FK.PREV}
+                isEdgeRight={rightEdgeKey === FK.PREV}
+              />
+            )}
+
             <ControlButton
               focusKey={FK.PLAY_PAUSE}
               label={isPlaying ? "Pause" : "Play"}
@@ -846,6 +876,17 @@ export function PlayerControls({
               isEdgeLeft={leftEdgeKey === FK.PLAY_PAUSE}
               isEdgeRight={rightEdgeKey === FK.PLAY_PAUSE}
             />
+
+            {hasNext && onNext && (
+              <ControlButton
+                focusKey={FK.NEXT}
+                label={isLive ? "Next channel" : "Next episode"}
+                icon="⏭"
+                onPress={onNext}
+                isEdgeLeft={leftEdgeKey === FK.NEXT}
+                isEdgeRight={rightEdgeKey === FK.NEXT}
+              />
+            )}
 
             <ControlButton
               focusKey={FK.SEEK_BACK}

--- a/src/player/PlayerProvider.tsx
+++ b/src/player/PlayerProvider.tsx
@@ -20,10 +20,26 @@ import {
 
 export type PlayerKind = "live" | "vod" | "series-episode";
 
+/**
+ * Identifies the originating content item so the player can write tier-lock
+ * cache entries against the right stream id on failure. VOD uses the stream
+ * id from /api/vod/streams; series-episode uses the episode id.
+ */
+export interface PlayerContentId {
+  kind: PlayerKind;
+  id: string;
+}
+
 export interface PlayerOpenPayload {
   src: string;
   title: string;
   kind?: PlayerKind;
+  /** Jump to previous sibling (prev channel / prev episode). Undefined = disabled. */
+  onPrev?: () => void;
+  /** Jump to next sibling. Undefined = disabled. */
+  onNext?: () => void;
+  /** When set, the failure overlay uses this id to memo a tier-lock hit. */
+  contentId?: PlayerContentId;
 }
 
 interface PlayerStateOpen {
@@ -31,6 +47,9 @@ interface PlayerStateOpen {
   src: string;
   title: string;
   kind: PlayerKind;
+  onPrev?: () => void;
+  onNext?: () => void;
+  contentId?: PlayerContentId;
 }
 
 interface PlayerStateIdle {
@@ -45,13 +64,20 @@ type PlayerAction =
 
 function playerReducer(_state: PlayerState, action: PlayerAction): PlayerState {
   switch (action.type) {
-    case "OPEN":
-      return {
+    case "OPEN": {
+      // tsconfig exactOptionalPropertyTypes:true — only set the keys when
+      // actually defined to avoid { onPrev: undefined } showing up in state.
+      const next: PlayerStateOpen = {
         status: "open",
         src: action.payload.src,
         title: action.payload.title,
         kind: action.payload.kind ?? "vod",
       };
+      if (action.payload.onPrev) next.onPrev = action.payload.onPrev;
+      if (action.payload.onNext) next.onNext = action.payload.onNext;
+      if (action.payload.contentId) next.contentId = action.payload.contentId;
+      return next;
+    }
     case "CLOSE":
       return { status: "idle" };
     default:

--- a/src/player/PlayerShell.tsx
+++ b/src/player/PlayerShell.tsx
@@ -12,18 +12,53 @@
  */
 import type { RefObject } from "react";
 import { useRef, useState, useEffect, useCallback } from "react";
-import { useFocusable, FocusContext } from "@noriginmedia/norigin-spatial-navigation";
+import {
+  useFocusable,
+  FocusContext,
+  setFocus,
+} from "@noriginmedia/norigin-spatial-navigation";
 import { usePlayerStore } from "./PlayerProvider";
+import type { PlayerKind } from "./PlayerProvider";
 import { useHlsPlayer } from "./useHlsPlayer";
 import { PlayerControls } from "./PlayerControls";
+import { useReducedMotion } from "./useReducedMotion";
+import { markTierLocked } from "../features/movies/tierLockCache";
+
+// Failure-overlay focus keys — kept local, only the overlay reads them.
+const FK_RETRY = "PLAYER_FAIL_RETRY";
+const FK_BACK = "PLAYER_FAIL_BACK";
+
+/**
+ * Classify a playback error so the overlay can render the right copy and
+ * decide whether to memo a tier-lock hit (spec §9.2 / §9.3).
+ *
+ * Heuristic: VOD/series-episode that errors with zero duration + zero
+ * playhead — before any frame ever arrived — is almost always the Xtream
+ * account plan refusing the container extension. Live errors are treated
+ * as generic (tier-lock doesn't apply to Live channels).
+ */
+function classifyFailure(
+  kind: PlayerKind,
+  duration: number,
+  currentTime: number,
+): "tier-lock" | "generic" {
+  if (kind !== "live" && duration === 0 && currentTime === 0) {
+    return "tier-lock";
+  }
+  return "generic";
+}
 
 export function PlayerShell() {
   const { state, close } = usePlayerStore();
   const videoRef = useRef<HTMLVideoElement>(null);
+  const reducedMotion = useReducedMotion();
 
   const src = state.status === "open" ? state.src : undefined;
   const title = state.status === "open" ? state.title : "";
   const kind = state.status === "open" ? state.kind : "vod";
+  const onPrev = state.status === "open" ? state.onPrev : undefined;
+  const onNext = state.status === "open" ? state.onNext : undefined;
+  const contentId = state.status === "open" ? state.contentId : undefined;
 
   const {
     status,
@@ -39,6 +74,7 @@ export function PlayerShell() {
     selectLevel,
     selectAudioTrack,
     selectSubtitleTrack,
+    retry,
   } = useHlsPlayer(videoRef, src, kind);
 
   const [currentLevel, setCurrentLevel] = useState(-1);
@@ -51,8 +87,6 @@ export function PlayerShell() {
     isFocusBoundary: true,
   });
 
-  // Reset track / level state when a new src loads so stale labels don't
-  // stick around through channel or episode switches.
   useEffect(() => {
     setCurrentLevel(-1);
     setCurrentAudioTrack(-1);
@@ -91,9 +125,21 @@ export function PlayerShell() {
     [setVolume],
   );
 
+  const failureClass =
+    status === "error" ? classifyFailure(kind, duration, currentTime) : null;
+
+  // Memo the tier-lock so MovieCard/EpisodeRow can badge the card on return.
+  useEffect(() => {
+    if (failureClass === "tier-lock" && contentId) {
+      markTierLocked(contentId.id);
+    }
+  }, [failureClass, contentId]);
+
   if (state.status === "idle") {
     return null;
   }
+
+  const showFailure = status === "error";
 
   return (
     <FocusContext.Provider value={focusKey}>
@@ -142,52 +188,23 @@ export function PlayerShell() {
                 borderTopColor: "var(--accent-copper)",
                 borderRadius: "50%",
                 display: "inline-block",
-                animation: "sv-spin 0.8s linear infinite",
+                animation: reducedMotion
+                  ? "sv-pulse 1.6s ease-in-out infinite"
+                  : "sv-spin 0.8s linear infinite",
               }}
             />
           </div>
         )}
 
-        {/* Minimal error state — full amber overlay + tier-lock copy ships in 6c. */}
-        {status === "error" && (
-          <div
-            style={{
-              position: "absolute",
-              inset: 0,
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              justifyContent: "center",
-              color: "var(--text-primary)",
-              gap: "var(--space-4)",
-            }}
-          >
-            <p style={{ fontSize: "var(--text-title-size)", fontWeight: 600 }}>
-              Playback error
-            </p>
-            <p style={{ color: "var(--text-secondary)" }}>
-              The stream could not be loaded.
-            </p>
-            <button
-              type="button"
-              className="focus-ring"
-              onClick={close}
-              style={{
-                background: "var(--accent-copper)",
-                color: "var(--bg-base)",
-                border: "none",
-                borderRadius: "var(--radius-sm)",
-                padding: "var(--space-2) var(--space-6)",
-                cursor: "pointer",
-                fontSize: "var(--text-body-size)",
-              }}
-            >
-              Close
-            </button>
-          </div>
+        {showFailure && (
+          <FailureOverlay
+            kind={failureClass === "tier-lock" ? "tier-lock" : "generic"}
+            onRetry={retry}
+            onClose={close}
+          />
         )}
 
-        {status !== "error" && (
+        {!showFailure && (
           <PlayerControls
             title={title}
             kind={kind}
@@ -209,6 +226,8 @@ export function PlayerShell() {
             onSelectLevel={handleSelectLevel}
             onSelectAudioTrack={handleSelectAudioTrack}
             onSelectSubtitleTrack={handleSelectSubtitleTrack}
+            {...(onPrev && { onPrev })}
+            {...(onNext && { onNext })}
           />
         )}
       </div>
@@ -217,7 +236,167 @@ export function PlayerShell() {
         @keyframes sv-spin {
           to { transform: rotate(360deg); }
         }
+        @keyframes sv-pulse {
+          0%, 100% { opacity: 0.4; }
+          50% { opacity: 1; }
+        }
       `}</style>
     </FocusContext.Provider>
+  );
+}
+
+// ─── FailureOverlay ──────────────────────────────────────────────────────────
+
+interface FailureOverlayProps {
+  kind: "tier-lock" | "generic";
+  onRetry: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Amber glass overlay per spec §9. Never red, never auto-retry.
+ *
+ *   tier-lock → specific "format not supported by plan" copy, no Try again
+ *   generic   → Try again + Back to browse
+ *
+ * Focus: auto-seeds on the most-useful action for the class.
+ */
+function FailureOverlay({ kind, onRetry, onClose }: FailureOverlayProps) {
+  const { ref: retryRef, focused: retryFocused } = useFocusable({
+    focusKey: FK_RETRY,
+    focusable: kind !== "tier-lock",
+    onEnterPress: onRetry,
+    onArrowPress: (direction) => {
+      if (direction === "right") {
+        setFocus(FK_BACK);
+        return false;
+      }
+      return false;
+    },
+  });
+
+  const { ref: backRef, focused: backFocused } = useFocusable({
+    focusKey: FK_BACK,
+    onEnterPress: onClose,
+    onArrowPress: (direction) => {
+      if (direction === "left" && kind !== "tier-lock") {
+        setFocus(FK_RETRY);
+        return false;
+      }
+      return false;
+    },
+  });
+
+  useEffect(() => {
+    setFocus(kind === "tier-lock" ? FK_BACK : FK_RETRY);
+  }, [kind]);
+
+  // Escape/Back closes; otherwise the generic PlayerControls listener
+  // isn't mounted (we're showing the overlay instead).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" || e.key === "Back" || e.key === "GoBack") {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [onClose]);
+
+  return (
+    <div
+      data-testid={`player-failure-${kind}`}
+      role="alertdialog"
+      aria-modal="true"
+      aria-label="Playback failed"
+      style={{
+        position: "absolute",
+        inset: 0,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "rgba(0,0,0,0.75)",
+        padding: "var(--space-6)",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: "540px",
+          width: "100%",
+          background: "rgba(245,158,11,0.12)",
+          border: "1px solid #F59E0B",
+          borderRadius: "var(--radius-md)",
+          padding: "var(--space-6)",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: "var(--space-4)",
+          textAlign: "center",
+          color: "var(--text-primary)",
+        }}
+      >
+        <span style={{ fontSize: "32px" }} aria-hidden="true">⚠</span>
+        <p style={{ fontSize: "var(--text-title-size)", fontWeight: 600, margin: 0 }}>
+          Playback failed
+        </p>
+        <p
+          style={{
+            color: "var(--text-secondary)",
+            fontSize: "var(--text-body-size)",
+            margin: 0,
+            lineHeight: 1.5,
+          }}
+        >
+          {kind === "tier-lock"
+            ? "This title is delivered in a format your Xtream plan doesn't support. Try a different title or see if a similar one is available."
+            : "This title couldn't be played right now. It may be a format your plan doesn't support, or the provider is temporarily unavailable."}
+        </p>
+        <div
+          style={{
+            display: "flex",
+            gap: "var(--space-3)",
+            marginTop: "var(--space-2)",
+          }}
+        >
+          {kind !== "tier-lock" && (
+            <button
+              ref={retryRef as RefObject<HTMLButtonElement>}
+              type="button"
+              className="focus-ring"
+              onClick={onRetry}
+              style={{
+                background: retryFocused ? "var(--accent-copper)" : "rgba(255,255,255,0.15)",
+                color: retryFocused ? "var(--bg-base)" : "var(--text-primary)",
+                border: "none",
+                borderRadius: "var(--radius-sm)",
+                padding: "var(--space-2) var(--space-6)",
+                cursor: "pointer",
+                fontSize: "var(--text-body-size)",
+              }}
+            >
+              Try again
+            </button>
+          )}
+          <button
+            ref={backRef as RefObject<HTMLButtonElement>}
+            type="button"
+            className="focus-ring"
+            onClick={onClose}
+            style={{
+              background: backFocused ? "var(--accent-copper)" : "rgba(255,255,255,0.15)",
+              color: backFocused ? "var(--bg-base)" : "var(--text-primary)",
+              border: "none",
+              borderRadius: "var(--radius-sm)",
+              padding: "var(--space-2) var(--space-6)",
+              cursor: "pointer",
+              fontSize: "var(--text-body-size)",
+            }}
+          >
+            Back to browse
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/player/useHlsPlayer.ts
+++ b/src/player/useHlsPlayer.ts
@@ -66,6 +66,8 @@ export interface UseHlsPlayerReturn {
   selectLevel: (idx: number) => void;
   selectAudioTrack: (idx: number) => void;
   selectSubtitleTrack: (idx: number) => void;
+  /** Re-attach the playback engine so a failed stream is retried in place. */
+  retry: () => void;
 }
 
 export function useHlsPlayer(
@@ -82,6 +84,10 @@ export function useHlsPlayer(
   const [levels, setLevels] = useState<HlsLevel[]>([]);
   const [audioTracks, setAudioTracks] = useState<HlsAudioTrack[]>([]);
   const [subtitleTracks, setSubtitleTracks] = useState<HlsSubtitleTrack[]>([]);
+  // Bumping this forces the main attach/tear-down effect to re-run even when
+  // src/kind haven't changed — the "Try again" button on the failure overlay
+  // relies on this so users don't have to close + re-open from the card.
+  const [retryCount, setRetryCount] = useState(0);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -255,7 +261,7 @@ export function useHlsPlayer(
       }
       video.src = "";
     };
-  }, [videoRef, src, kind]);
+  }, [videoRef, src, kind, retryCount]);
 
   const play = useCallback(() => {
     videoRef.current?.play().catch(() => {});
@@ -306,6 +312,10 @@ export function useHlsPlayer(
     }
   }, []);
 
+  const retry = useCallback(() => {
+    setRetryCount((c) => c + 1);
+  }, []);
+
   return {
     status,
     error,
@@ -321,5 +331,6 @@ export function useHlsPlayer(
     selectLevel,
     selectAudioTrack,
     selectSubtitleTrack,
+    retry,
   };
 }

--- a/src/player/usePlayerOpener.ts
+++ b/src/player/usePlayerOpener.ts
@@ -4,6 +4,10 @@
  * Used by LiveRoute, MoviesRoute, SeriesRoute, SearchRoute so they all share
  * the same open path. Fetches the stream URL for the given type/id, then
  * calls playerStore.open().
+ *
+ * Phase 6c: callers can pass onPrev/onNext callbacks to enable channel/
+ * episode navigation inside the player. The route owns the list state and
+ * re-calls openPlayer with updated indices; this hook is a thin pass-through.
  */
 import { useCallback } from "react";
 import { usePlayerStore, type PlayerKind } from "./PlayerProvider";
@@ -16,6 +20,10 @@ interface OpenPlayerOptions {
   /** For series episodes: season + episode numbers */
   season?: number;
   episode?: number;
+  /** In-player previous-sibling navigation (e.g. prev channel / prev episode) */
+  onPrev?: () => void;
+  /** In-player next-sibling navigation */
+  onNext?: () => void;
 }
 
 export function usePlayerOpener() {
@@ -23,10 +31,10 @@ export function usePlayerOpener() {
 
   const openPlayer = useCallback(
     async (opts: OpenPlayerOptions) => {
-      const { id, title, kind, season, episode } = opts;
+      const { id, title, kind, season, episode, onPrev, onNext } = opts;
 
-      // tsconfig has exactOptionalPropertyTypes:true — spread season/episode
-      // only when defined so the optional field isn't set to `undefined`.
+      // tsconfig has exactOptionalPropertyTypes:true — spread optional fields
+      // only when defined so they aren't set to `undefined`.
       const streamUrl = fetchStreamUrl({
         kind,
         id,
@@ -38,6 +46,9 @@ export function usePlayerOpener() {
         src: streamUrl,
         title,
         kind,
+        contentId: { kind, id },
+        ...(onPrev && { onPrev }),
+        ...(onNext && { onNext }),
       });
     },
     [open],

--- a/src/player/useReducedMotion.ts
+++ b/src/player/useReducedMotion.ts
@@ -1,0 +1,32 @@
+/**
+ * useReducedMotion — honour the user's `prefers-reduced-motion` setting.
+ *
+ * Returns `true` if the OS / browser is reporting a reduce preference. Used
+ * by the player per docs/ux/05-player.md §10: disable the control-bar fade,
+ * the spinner rotation, and popover slide-ins when set.
+ */
+import { useEffect, useState } from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState<boolean>(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return false;
+    return window.matchMedia(QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia(QUERY);
+    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches);
+    // Some older engines only expose addListener/removeListener.
+    if (mql.addEventListener) {
+      mql.addEventListener("change", onChange);
+      return () => mql.removeEventListener("change", onChange);
+    }
+    mql.addListener(onChange);
+    return () => mql.removeListener(onChange);
+  }, []);
+
+  return reduced;
+}

--- a/src/routes/SeriesDetailRoute.tsx
+++ b/src/routes/SeriesDetailRoute.tsx
@@ -960,18 +960,41 @@ export function SeriesDetailRoute() {
     }
   }, [loading, error]);
 
-  const playEpisode = useCallback(
-    (ep: EpisodeInfo, seasonNum: number) => {
-      const title = info
-        ? buildEpisodeTitle(info.name, seasonNum, ep)
-        : `S${seasonNum}E${ep.episodeNumber} · ${ep.title}`;
+  // ─── Play handler ────────────────────────────────────────────────────────
+  // playEpisodeAt wires onPrev/onNext so the player's ⏮/⏭ walk within the
+  // same season's episode list in the user's current sort order (Phase 6c).
+  // Each call passes a new index into the same array, forming a cheap
+  // closure chain rather than storing list state in PlayerProvider.
+  const playEpisodeAt = useCallback(
+    (episodes: EpisodeInfo[], idx: number, seasonNum: number) => {
+      const ep = episodes[idx];
+      if (!ep || !info) return;
+      const title = buildEpisodeTitle(info.name, seasonNum, ep);
       void openPlayer({
         kind: "series-episode",
         id: ep.id,
         title,
+        ...(idx > 0 && {
+          onPrev: () => playEpisodeAt(episodes, idx - 1, seasonNum),
+        }),
+        ...(idx < episodes.length - 1 && {
+          onNext: () => playEpisodeAt(episodes, idx + 1, seasonNum),
+        }),
       });
     },
     [info, openPlayer],
+  );
+
+  const playEpisode = useCallback(
+    (ep: EpisodeInfo, seasonNum: number) => {
+      const seasonKey = String(seasonNum);
+      const rawEps = info?.episodes?.[seasonKey] ?? [];
+      // Walk within the user's current sort so ⏮/⏭ matches what's on screen.
+      const sortedEps = sortEpisodes(rawEps, episodeSort);
+      const idx = sortedEps.findIndex((e) => e.id === ep.id);
+      playEpisodeAt(sortedEps, Math.max(0, idx), seasonNum);
+    },
+    [info, episodeSort, playEpisodeAt],
   );
 
   const handleCtaPress = useCallback(() => {


### PR DESCRIPTION
## Summary

Rebased replacement for #88 (base branch was deleted after the prior merges).

Closes Phase 6 — the remaining spec items plus the \"everything by D-pad\" ask.

### Scope

Per your direction: prev/next is **series-episode only**. Movies don't render them; Live doesn't either (channel switching belongs on LiveRoute). The component adapts automatically — it only renders ⏮/⏭ when props are passed.

Rebased on top of main which now includes PR #87 (Series Phase 4 rebuild). Resolved conflict in \`SeriesDetailRoute.tsx\` by keeping the main's \`EpisodeRow(onPlay: (ep, season))\` API and layering \`playEpisodeAt\` underneath so prev/next walks the **sorted** active season list in the user's current sort order.

### Ships

- **Series prev/next** (spec §3 / §8): \`PlayerProvider\` + \`usePlayerOpener\` thread optional \`onPrev\`/\`onNext\` to \`PlayerShell\` → \`PlayerControls\`. \`SeriesDetailRoute\` lifts the play path to \`playEpisodeAt(episodes, idx, seasonNum)\` which closes over the sorted episode list and recurses with an updated idx.
- **Amber failure overlay** (spec §9): \`FailureOverlay\` is a full glass \`role=\"alertdialog\"\`, never red, never auto-retries. Classifier flags VOD/series-episode errors with \`duration===0 && currentTime===0\` as tier-lock (no Try again button); everything else gets Try again + Back to browse.
- **Tier-lock memo** (spec §9.3): on tier-lock classification, \`PlayerShell\` calls \`markTierLocked(contentId.id)\` so MovieCard / EpisodeRow can badge the card on return.
- **Retry without closing**: \`useHlsPlayer.retry()\` bumps a retry-count dep, re-running the attach effect so hls.js / mpegts / native src re-initialises in place.
- **Reduced-motion** (spec §10): new \`useReducedMotion\` hook. Control-bar fade disabled when reduced; spinner swaps the rotating ring for an opacity pulse.

### D-pad coverage audit (final)

Play/Pause · ±10s · Hold-to-scrub · Volume · Audio · Subs · Quality · Back · **Prev/Next episode (series only)** · Try again · Back to browse — all reachable by D-pad / arrows + Enter + Back.

## Test plan

- [x] \`npm test\` — 288/288 (full suite post-Phase 4 rebuild merge)
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [ ] After merge: prod deploy + user validation round
- [ ] Verify Fire TV: Series player shows ⏮/⏭; Enter jumps episodes within season's sort
- [ ] Verify force-broken VOD → amber tier-lock copy; next visit to Movies grid shows lock badge
- [ ] Verify reduced-motion: fade is instant, spinner pulses

🤖 Generated with [Claude Code](https://claude.com/claude-code)