### PR TITLE
fix(nav): focus boundary on CONTENT_AREA_SERIES + CONTENT_AREA_SERIES_DETAIL

### DIFF
--- a/src/routes/SeriesDetailRoute.tsx
+++ b/src/routes/SeriesDetailRoute.tsx
@@ -718,6 +718,13 @@ export function SeriesDetailRoute() {
     focusKey: "CONTENT_AREA_SERIES_DETAIL",
     focusable: false,
     trackChildren: true,
+    // Absorb dead-direction bubble-ups at the detail route's outer edges
+    // (Left on first episode / first season chip, Right on last, Up on
+    // hero). Down stays open so episode rows can still reach BottomDock.
+    // Matches PR #85's treatment of CONTENT_AREA_* — see
+    // streamvault-v3-focus-vanish-bug.md.
+    isFocusBoundary: true,
+    focusBoundaryDirections: ["left", "right", "up"],
   });
 
   const [info, setInfo] = useState<SeriesInfo | null>(null);

--- a/src/routes/SeriesRoute.tsx
+++ b/src/routes/SeriesRoute.tsx
@@ -145,6 +145,13 @@ export function SeriesRoute() {
     focusKey: "CONTENT_AREA_SERIES",
     focusable: false,
     trackChildren: true,
+    // Absorb dead-direction bubble-ups at the route's outer edges (Left on
+    // first card / first chip, Right on last, Up on hero). Down stays open
+    // so the bottom row still reaches BottomDock. Matches PR #85's
+    // treatment of other CONTENT_AREA_* routes — see
+    // streamvault-v3-focus-vanish-bug.md.
+    isFocusBoundary: true,
+    focusBoundaryDirections: ["left", "right", "up"],
   });
 
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary

Inherits PR #85's `isFocusBoundary` treatment on the two Series routes now that Phase 4 (#87) is merged. Closes the focus-vanish bug on `/series` and `/series/:id`.

| Container | `focusBoundaryDirections` |
|---|---|
| `CONTENT_AREA_SERIES` | `['left', 'right', 'up']` |
| `CONTENT_AREA_SERIES_DETAIL` | `['left', 'right', 'up']` |

Down stays open on both so grid / episode rows still reach BottomDock.

## Test plan

- [ ] Series: first card + Left — focus stays
- [ ] Series: first chip + Left / last chip + Right — focus stays
- [ ] Series: hero + Up / Left / Right — focus stays
- [ ] Series: last row + Down — still reaches DOCK_SERIES
- [ ] Series detail: first season chip + Left — focus stays
- [ ] Series detail: first episode + Left — focus stays
- [ ] Series detail: last episode row + Down — still reaches BottomDock
- [ ] Regression: card-to-card and chip-to-chip nav within Series still works

288/288 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)