### PR TITLE
fix(player): 120 s forward buffer + preload=auto

### DIFF
--- a/src/player/PlayerShell.tsx
+++ b/src/player/PlayerShell.tsx
@@ -165,6 +165,11 @@ export function PlayerShell() {
             objectFit: "contain",
           }}
           playsInline
+          // Hint to the browser: prefetch as much VOD as possible. Native
+          // video buffer size is ultimately browser-controlled, but "auto"
+          // tells it not to throttle prefetch. For HLS / mpegts this attr
+          // is ignored — those libraries manage their own buffer.
+          preload="auto"
         />
 
         {(status === "loading" || status === "buffering") && (

--- a/src/player/useHlsPlayer.ts
+++ b/src/player/useHlsPlayer.ts
@@ -13,9 +13,14 @@
  *
  * Design decisions:
  *  - backBufferLength: 20 — reduces memory pressure on Fire TV; do NOT raise.
+ *  - maxBufferLength: 120 — 2 min forward target for smoother playback on
+ *    flaky networks (2026-04-23 prod feedback). maxMaxBufferLength caps at
+ *    180 so hls.js can't grow the buffer indefinitely under adaptive pressure.
  *  - Use nextLevel (NOT currentLevel) for quality changes — avoids mid-segment
  *    cuts (lesson from v2 Sprint 4).
  *  - mpegts.js: enableStashBuffer=false + lowBufferLatencyChasing — live-TV tuned.
+ *    Live is deliberately near-live-edge, so the 120 s VOD buffer doesn't
+ *    apply; chasing would fight against a deep live buffer anyway.
  *  - Clean up hls.destroy() / mpegts.destroy() on unmount.
  */
 import { useEffect, useRef, useState, useCallback } from "react";
@@ -142,10 +147,14 @@ export function useHlsPlayer(
         /* autoplay blocked or jsdom */
       });
     } else if (isM3u8 && Hls.isSupported()) {
+      // Phase 6 follow-up (2026-04-23 user ask): bump forward-buffer target
+      // to 120 s for smoother playback on flaky networks. backBufferLength
+      // stays at 20 s — keeps memory pressure on Fire TV bounded per the
+      // v2 lesson.
       const hls = new Hls({
         backBufferLength: 20,
-        maxBufferLength: 30,
-        maxMaxBufferLength: 60,
+        maxBufferLength: 120,
+        maxMaxBufferLength: 180,
         enableWorker: true,
         lowLatencyMode: false,
       });


### PR DESCRIPTION
## Summary

Prod feedback: VOD stutters during long stretches. Two frontend levers:

- **hls.js** `maxBufferLength 30→120 s`, `maxMaxBufferLength 60→180 s`. `backBufferLength` stays at 20 s (Fire TV memory ceiling, documented at top of file).
- **`<video preload=\"auto\">`** for native VOD (MP4/MKV via /api/stream proxy). \"auto\" removes the browser's prefetch throttle; typical ceiling is 30–60 s, browser-dependent.

## Caveat

The **hard ceiling** on native VOD smoothness is the backend proxy's throughput. If the Xtream origin is slow, the browser can't prefetch what the proxy won't deliver — that's a backend investigation (check `/api/stream/vod/:id` logs, keep-alive, Range support), not a frontend tweak. Worth a Paperclip ticket if stutter persists after this deploy.

Live (mpegts.js) is deliberately near-live-edge and is not changed.

## Test plan

- [x] 37/37 player tests
- [x] build clean
- [ ] Prod: start a long movie, let it play for 10+ minutes, confirm fewer buffering pauses
- [ ] If stutter persists: investigate backend `/api/stream/vod/:id` response times

🤖 Generated with [Claude Code](https://claude.com/claude-code)