### PR TITLE
feat(player): move ⏮/⏭ to top bar (fixes 6d arrow-seek conflict)

### DIFF
--- a/src/player/PlayerControls.test.tsx
+++ b/src/player/PlayerControls.test.tsx
@@ -425,4 +425,51 @@ describe("PlayerControls", () => {
     act(() => pressArrow("PLAYER_SEEK_BACK", "left"));
     expect(onSeek).toHaveBeenCalledWith(190);
   });
+
+  // ─── 6e: Prev/Next moved to top bar (UX option 1) ───────────────────────
+
+  it("Prev/Next render in the top bar, not the control bar", () => {
+    const { container } = render(
+      <PlayerControls
+        {...makeProps({ kind: "series-episode", onPrev: vi.fn(), onNext: vi.fn() })}
+      />,
+    );
+    // Buttons still exist and fire their callbacks (no regression on the
+    // click-through path); their DOM home is the top bar, not alongside the
+    // transport row.
+    expect(screen.getByRole("button", { name: "Previous episode" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Next episode" })).toBeTruthy();
+    // The top bar is the FIRST band in the controls; Back sits in it.
+    // Verify Prev/Next sit in the same band as Back (not with Play/Pause).
+    const backBtn = screen.getByRole("button", { name: "Back" });
+    const prevBtn = screen.getByRole("button", { name: "Previous episode" });
+    const playBtn = screen.getByRole("button", { name: /pause|play/i });
+    expect(backBtn.parentElement).toBe(prevBtn.parentElement);
+    expect(prevBtn.parentElement).not.toBe(playBtn.parentElement);
+    expect(container).toBeTruthy();
+  });
+
+  it("ArrowRight on Back jumps to Prev when onPrev provided", async () => {
+    const mod = await import("@noriginmedia/norigin-spatial-navigation");
+    const setFocusMock = mod.setFocus as unknown as Mock;
+    setFocusMock.mockClear();
+    render(
+      <PlayerControls
+        {...makeProps({ kind: "series-episode", onPrev: vi.fn(), onNext: vi.fn() })}
+      />,
+    );
+    act(() => pressArrow("PLAYER_BACK", "right"));
+    expect(setFocusMock).toHaveBeenCalledWith("PLAYER_PREV");
+  });
+
+  it("ArrowDown on Prev jumps to Play/Pause", async () => {
+    const mod = await import("@noriginmedia/norigin-spatial-navigation");
+    const setFocusMock = mod.setFocus as unknown as Mock;
+    setFocusMock.mockClear();
+    render(
+      <PlayerControls {...makeProps({ kind: "series-episode", onPrev: vi.fn() })} />,
+    );
+    act(() => pressArrow("PLAYER_PREV", "down"));
+    expect(setFocusMock).toHaveBeenCalledWith("PLAYER_PLAY_PAUSE");
+  });
 });

--- a/src/player/PlayerControls.tsx
+++ b/src/player/PlayerControls.tsx
@@ -563,12 +563,61 @@ export function PlayerControls({
 
   // ── Focusables for top bar ────────────────────────────────────────────────
 
+  const hasPrev = Boolean(onPrev);
+  const hasNext = Boolean(onNext);
+
+  // Top-bar layout (6e — UX option 1): Back | Prev | Next on series-episode.
+  // Back is the left edge; walking right in the top bar goes Back → Prev →
+  // Next. Down from any of them lands on Play/Pause (predictable re-entry
+  // to the transport row per spec §4.2).
   const { ref: backRef, focused: backFocused } = useFocusable({
     focusKey: FK.BACK,
     onEnterPress: onClose,
     onArrowPress: (direction) => {
       if (direction === "down") {
         setFocus(FK.PLAY_PAUSE);
+        return false;
+      }
+      if (direction === "right" && hasPrev) {
+        setFocus(FK.PREV);
+        return false;
+      }
+      return false;
+    },
+  });
+
+  const { ref: prevRef, focused: prevFocused } = useFocusable({
+    focusKey: FK.PREV,
+    focusable: hasPrev,
+    onEnterPress: () => onPrev?.(),
+    onArrowPress: (direction) => {
+      if (direction === "down") {
+        setFocus(FK.PLAY_PAUSE);
+        return false;
+      }
+      if (direction === "left") {
+        setFocus(FK.BACK);
+        return false;
+      }
+      if (direction === "right" && hasNext) {
+        setFocus(FK.NEXT);
+        return false;
+      }
+      return false;
+    },
+  });
+
+  const { ref: nextRef, focused: nextFocused } = useFocusable({
+    focusKey: FK.NEXT,
+    focusable: hasNext,
+    onEnterPress: () => onNext?.(),
+    onArrowPress: (direction) => {
+      if (direction === "down") {
+        setFocus(FK.PLAY_PAUSE);
+        return false;
+      }
+      if (direction === "left") {
+        setFocus(hasPrev ? FK.PREV : FK.BACK);
         return false;
       }
       return false;
@@ -618,13 +667,11 @@ export function PlayerControls({
   const audioHasOptions = audioTracks.length > 1;
   const subsAvailable = subtitleTracks.length > 0;
   const qualityAvailable = levels.length > 0;
-  const hasPrev = Boolean(onPrev);
-  const hasNext = Boolean(onNext);
 
+  // 6e — Prev/Next moved to the top bar so arrow-seek on the transport row
+  // stays clean. Only the transport + settings rows live in orderedKeys now.
   const orderedKeys: string[] = [
-    hasPrev ? FK.PREV : null,
     FK.PLAY_PAUSE,
-    hasNext ? FK.NEXT : null,
     seekable ? FK.SEEK_BACK : null,
     seekable ? FK.SEEK_FORWARD : null,
     FK.VOLUME,
@@ -791,6 +838,36 @@ export function PlayerControls({
           >
             {title}
           </span>
+          {hasPrev && (
+            <button
+              ref={prevRef as RefObject<HTMLButtonElement>}
+              type="button"
+              className="focus-ring"
+              aria-label="Previous episode"
+              onClick={() => onPrev?.()}
+              style={{
+                ...controlButtonStyle,
+                outline: prevFocused ? "2px solid var(--accent-copper)" : undefined,
+              }}
+            >
+              ⏮
+            </button>
+          )}
+          {hasNext && (
+            <button
+              ref={nextRef as RefObject<HTMLButtonElement>}
+              type="button"
+              className="focus-ring"
+              aria-label="Next episode"
+              onClick={() => onNext?.()}
+              style={{
+                ...controlButtonStyle,
+                outline: nextFocused ? "2px solid var(--accent-copper)" : undefined,
+              }}
+            >
+              ⏭
+            </button>
+          )}
           {isLive ? (
             <span
               aria-label="Live"
@@ -893,17 +970,6 @@ export function PlayerControls({
               gap: "var(--space-3)",
             }}
           >
-            {hasPrev && onPrev && (
-              <ControlButton
-                focusKey={FK.PREV}
-                label={isLive ? "Previous channel" : "Previous episode"}
-                icon="⏮"
-                onPress={onPrev}
-                isEdgeLeft={leftEdgeKey === FK.PREV}
-                isEdgeRight={rightEdgeKey === FK.PREV}
-              />
-            )}
-
             <ControlButton
               focusKey={FK.PLAY_PAUSE}
               label={isPlaying ? "Pause" : "Play"}
@@ -913,17 +979,6 @@ export function PlayerControls({
               isEdgeRight={rightEdgeKey === FK.PLAY_PAUSE}
               arrowOverrides={transportArrowOverrides}
             />
-
-            {hasNext && onNext && (
-              <ControlButton
-                focusKey={FK.NEXT}
-                label={isLive ? "Next channel" : "Next episode"}
-                icon="⏭"
-                onPress={onNext}
-                isEdgeLeft={leftEdgeKey === FK.NEXT}
-                isEdgeRight={rightEdgeKey === FK.NEXT}
-              />
-            )}
 
             <ControlButton
               focusKey={FK.SEEK_BACK}


### PR DESCRIPTION
## Summary

Fixes the Prev/Next discoverability problem created by PR #92 (arrow-seek on the transport row). UX agent reviewed 4 options, recommended option 1: **move ⏮/⏭ to the top bar, next to Back.**

### New layout (series-episode only)

\`\`\`
┌─────────────────────────────────────────────────────┐
│ ← Back    Title · S2E5 \"Episode\"    [⏮] [⏭]  18:42/44:12 │  ← TOP BAR
│                                                          │
│ ▰▰▰▰▱▱▱▱▱▱  18:42 / 44:12                                │
│ ⏯ · ◀◀ ▶▶ · 🔉 · Audio · Subs · Quality                  │  ← TRANSPORT
└─────────────────────────────────────────────────────┘
\`\`\`

### D-pad flow

- **ArrowRight** on Back → Prev (when present)
- **ArrowRight** on Prev → Next (when present)
- **ArrowLeft** on Next → Prev (or Back if no Prev)
- **ArrowDown** from Back / Prev / Next → Play/Pause (predictable re-entry)
- Transport L/R still seeks ±10s on VOD/series (#92 unchanged)
- Transport Up → Back (unchanged)

### Why this

Prev/Next are *navigation* actions (like Back), not *transport* (like Play). Grouping them with Back:
1. Honors the #92 seek behavior on the transport row — no regression
2. Is more discoverable than a hidden overlay or long-press gesture
3. Matches Netflix/Prime TV convention (Next Episode is a top-right affordance)

Rejected alternatives (UX agent's full memo available on request):
- ArrowUp-on-⏯ opens hidden overlay → discoverability-hostile
- Single \"Episodes ▾\" popover → 3-press cost for the common case
- Long-press L/R for Prev/Next → invisible affordance, mode collision

### Kind behavior

- **Series-episode**: renders both ⏮/⏭ in the top bar (when onPrev/onNext set)
- **Movies**: renders neither (no onPrev/onNext passed)
- **Live**: renders neither (channel-switching stays on LiveRoute)

## Test plan

- [x] 40/40 player tests (was 37; +3: Prev/Next DOM band, Back→Prev on ArrowRight, Prev→Play/Pause on ArrowDown)
- [x] Build + typecheck clean
- [ ] Prod: open a series episode → press Up from ⏯ → Back focused → ArrowRight → Prev highlights → ArrowRight → Next highlights
- [ ] Prod: ArrowDown from Prev/Next lands back on ⏯
- [ ] Prod: VOD (movie) shows no ⏮/⏭ in top bar

## Spec note

Spec §3.1 control table should be updated — Prev/Next move out of the \"control bar\" row and into a new \"top bar secondary actions\" entry. Click-budget table §11 gains \"Next episode: 4 presses (Up, Right, Right, Enter)\" — acceptable for an end-of-episode action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)