### PR TITLE
fix: prod-testing feedback round (Fire TV back, OTT bucket, player focus/audio)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,23 +107,66 @@ function AppShell() {
   // Escape both land here. The player overlay's own back handler takes
   // precedence when open (see PlayerProvider popstate listener) — this one
   // only fires when a route content area owns focus.
+  //
+  // Fire TV Silk browser variants: the remote Back button arrives as
+  // `Backspace`, `Back`, `GoBack`, or keyCode 4 depending on firmware. Catch
+  // all of them.
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
-      // Escape anywhere OR Backspace on elements that aren't text inputs.
       const t = e.target as HTMLElement | null;
       const isTextInput =
         t?.tagName === "INPUT" || t?.tagName === "TEXTAREA";
-      if (e.key === "Escape" || (e.key === "Backspace" && !isTextInput)) {
-        const active = document.activeElement?.getAttribute("aria-label");
-        // Already on the dock? nothing to do.
-        const dockLabels = Object.values(DOCK_LABELS);
-        if (active && dockLabels.includes(active)) return;
-        setFocus(`DOCK_${activeTab.toUpperCase()}`);
+      const isBackKey =
+        e.key === "Escape" ||
+        e.key === "Back" ||
+        e.key === "GoBack" ||
+        (e.key === "Backspace" && !isTextInput) ||
+        e.keyCode === 4;
+      if (!isBackKey) return;
+
+      const active = document.activeElement?.getAttribute("aria-label");
+      const dockLabels = Object.values(DOCK_LABELS);
+      if (active && dockLabels.includes(active)) {
+        // Already on the dock — swallow so the browser doesn't navigate
+        // history.back() from an already-cornered state and exit the app.
         e.preventDefault();
+        return;
       }
+      setFocus(`DOCK_${activeTab.toUpperCase()}`);
+      e.preventDefault();
     };
     window.addEventListener("keydown", handleEscape);
     return () => window.removeEventListener("keydown", handleEscape);
+  }, [activeTab]);
+
+  // Exit-guard: keep a sentinel history entry so Fire TV's hardware Back (which
+  // can fire popstate directly without a keydown) doesn't pop us out of the
+  // PWA. The PlayerProvider's own popstate listener takes precedence while the
+  // player is open; this one runs for the rest of the app.
+  //
+  // Strategy: on mount, push one sentinel. Each time popstate fires, push
+  // another sentinel back — unless we're on a sub-route like /series/:id,
+  // where natural back-navigation is what the user wants. Detail routes are
+  // anything deeper than a single path segment ("/series/123" has two).
+  useEffect(() => {
+    if (!window.history.state?.svExitGuard) {
+      window.history.pushState({ svExitGuard: true }, "");
+    }
+    const onPop = () => {
+      const segments = window.location.pathname
+        .split("/")
+        .filter(Boolean);
+      const isDetailRoute = segments.length > 1;
+      if (isDetailRoute) {
+        // React-router will handle the navigation; don't interfere.
+        return;
+      }
+      // Root dock route — re-push the sentinel and anchor focus to the dock.
+      window.history.pushState({ svExitGuard: true }, "");
+      setFocus(`DOCK_${activeTab.toUpperCase()}`);
+    };
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
   }, [activeTab]);
 
   // Global D-pad focus-recovery watcher. Any dead-direction arrow press

--- a/src/features/movies/MovieGrid.tsx
+++ b/src/features/movies/MovieGrid.tsx
@@ -32,11 +32,15 @@ export interface MovieGridProps {
 }
 
 function columnsForWidth(width: number): number {
-  if (width >= 1600) return 6;
-  if (width >= 1280) return 5;
-  if (width >= 960) return 4;
-  if (width >= 640) return 3;
-  return 2;
+  // Sized for TV viewports: Fire TV Silk reports ~1280 CSS px at 1080p (DPR=2)
+  // and ~1600-1920 at 4K; posters were too large on TV at prior column counts
+  // (reported 2026-04-23 from a real Fire TV). Bump each tier by one so cards
+  // settle at ~200-220 px wide on TV, matching Netflix/Prime density.
+  if (width >= 1600) return 7;
+  if (width >= 1280) return 6;
+  if (width >= 960) return 5;
+  if (width >= 640) return 4;
+  return 3;
 }
 
 function useResponsiveColumns(): number {

--- a/src/features/movies/languageUnion.ts
+++ b/src/features/movies/languageUnion.ts
@@ -16,6 +16,7 @@
 import { fetchVodCategories, fetchVodStreams } from "../../api/vod";
 import type { VodCategory, VodStream } from "../../api/schemas";
 import type { LangId } from "../../lib/langPref";
+import { isOttPlatform, seriesNameMatchesLang } from "../../lib/inferLanguage";
 
 const TTL_MS = 5 * 60 * 1000;
 const MAX_CONCURRENCY = 8;
@@ -123,6 +124,35 @@ export function categoryMatchesLang(cat: VodCategory, lang: LangId): boolean {
   return true;
 }
 
+/**
+ * Categories are classified the same way as series (see
+ * `features/series/seriesLanguageUnion.ts`):
+ *
+ *   pure-lang    — category name uniquely identifies the language
+ *   ott-platform — multi-language catalogue; each item is filtered by name
+ *
+ * Pure-lang uses the strict word-boundary `categoryMatchesLang` to avoid
+ * Hindi titles leaking under Telugu (see top-of-file comment on
+ * `LANG_WORDS`). OTT platforms are identified via the shared pattern set so
+ * Movies and Series stay consistent.
+ */
+export type MovieCategoryBucket = "pure-lang" | "ott-platform";
+
+export function classifyMovieCategory(
+  cat: VodCategory,
+  lang: LangId,
+): MovieCategoryBucket | null {
+  if (lang === "all") {
+    return categoryMatchesLang(cat, lang) || isOttPlatform(cat.name)
+      ? "pure-lang"
+      : null;
+  }
+  if (lang === "sports") return null;
+  if (categoryMatchesLang(cat, lang)) return "pure-lang";
+  if (isOttPlatform(cat.name)) return "ott-platform";
+  return null;
+}
+
 async function poolMap<T, R>(
   items: readonly T[],
   concurrency: number,
@@ -161,15 +191,27 @@ export async function fetchLanguageUnion(
   lang: LangId,
 ): Promise<LanguageUnionResult> {
   const cats = await getCategoriesCached();
-  const matching = cats.filter((c) => categoryMatchesLang(c, lang));
+  const classified: { cat: VodCategory; bucket: MovieCategoryBucket }[] = [];
+  for (const c of cats) {
+    const bucket = classifyMovieCategory(c, lang);
+    if (bucket) classified.push({ cat: c, bucket });
+  }
 
-  const perCategory = await poolMap(matching, MAX_CONCURRENCY, async (c) => {
-    try {
-      return await getStreamsCached(c.id);
-    } catch {
-      return [] as VodStream[];
-    }
-  });
+  const perCategory = await poolMap(
+    classified,
+    MAX_CONCURRENCY,
+    async ({ cat, bucket }) => {
+      try {
+        const items = await getStreamsCached(cat.id);
+        // OTT platforms are multi-language — filter by item name.
+        return bucket === "ott-platform"
+          ? items.filter((s) => seriesNameMatchesLang(s.name, lang))
+          : items;
+      } catch {
+        return [] as VodStream[];
+      }
+    },
+  );
 
   const seen = new Set<string>();
   const merged: VodStream[] = [];
@@ -182,7 +224,7 @@ export async function fetchLanguageUnion(
     }
   }
 
-  return { streams: merged, matchedCategories: matching.length };
+  return { streams: merged, matchedCategories: classified.length };
 }
 
 export interface LanguageUnionBatch {
@@ -208,9 +250,13 @@ export async function streamLanguageUnion(
   onBatch: (batch: LanguageUnionBatch) => void,
 ): Promise<void> {
   const cats = await getCategoriesCached();
-  const matching = cats.filter((c) => categoryMatchesLang(c, lang));
+  const classified: { cat: VodCategory; bucket: MovieCategoryBucket }[] = [];
+  for (const c of cats) {
+    const bucket = classifyMovieCategory(c, lang);
+    if (bucket) classified.push({ cat: c, bucket });
+  }
 
-  if (matching.length === 0) {
+  if (classified.length === 0) {
     onBatch({
       streams: [],
       isFinal: true,
@@ -224,25 +270,27 @@ export async function streamLanguageUnion(
   const merged: VodStream[] = [];
   let completed = 0;
 
-  await poolMap(matching, MAX_CONCURRENCY, async (c) => {
+  await poolMap(classified, MAX_CONCURRENCY, async ({ cat, bucket }) => {
     try {
-      const items = await getStreamsCached(c.id);
+      const items = await getStreamsCached(cat.id);
       for (const s of items) {
-        if (!seen.has(s.id)) {
-          seen.add(s.id);
-          merged.push(s);
+        if (seen.has(s.id)) continue;
+        if (bucket === "ott-platform" && !seriesNameMatchesLang(s.name, lang)) {
+          continue;
         }
+        seen.add(s.id);
+        merged.push(s);
       }
     } catch {
-      // per-category failures contribute zero streams, same as fetchLanguageUnion
+      // per-category failures contribute zero streams
     }
     completed += 1;
-    const isFinal = completed === matching.length;
+    const isFinal = completed === classified.length;
     // Shallow copy so React's setState sees a new reference.
     onBatch({
       streams: merged.slice(),
       isFinal,
-      matchedCategories: matching.length,
+      matchedCategories: classified.length,
       completedCategories: completed,
     });
   });

--- a/src/features/series/seriesLanguageUnion.test.ts
+++ b/src/features/series/seriesLanguageUnion.test.ts
@@ -27,11 +27,20 @@ describe("seriesLanguageUnion.categoryMatchesLang", () => {
     expect(categoryMatchesLang(cat("4", "Hindi Serials"), "hindi")).toBe(true);
   });
 
-  it("matches English via broader patterns — Netflix, HBO, Amazon", () => {
-    expect(categoryMatchesLang(cat("1", "Netflix Originals"), "english")).toBe(
+  it("matches English by the literal word", () => {
+    expect(categoryMatchesLang(cat("1", "English Drama"), "english")).toBe(true);
+    expect(categoryMatchesLang(cat("2", "HBO Series"), "english")).toBe(true);
+  });
+
+  it("OTT platforms contribute under every language (items are filtered by name downstream)", () => {
+    // 2026-04-23: Netflix / Hotstar / Zee5 / Sony LIV carry multi-language
+    // content. They're matched as OTT categories so their items flow into
+    // the union — the union then filters by series NAME per selected
+    // language (see `streamSeriesLanguageUnion`).
+    expect(categoryMatchesLang(cat("1", "Netflix Originals"), "telugu")).toBe(
       true,
     );
-    expect(categoryMatchesLang(cat("2", "HBO Series"), "english")).toBe(true);
+    expect(categoryMatchesLang(cat("2", "Disney+ Hotstar"), "hindi")).toBe(true);
     expect(categoryMatchesLang(cat("3", "Amazon Prime"), "english")).toBe(true);
   });
 
@@ -43,12 +52,12 @@ describe("seriesLanguageUnion.categoryMatchesLang", () => {
     expect(categoryMatchesLang(cat("1", "Sports Live"), "sports")).toBe(false);
   });
 
-  it("first-matching-language wins when patterns overlap", () => {
-    expect(categoryMatchesLang(cat("1", "English Hindi Mix"), "hindi")).toBe(
-      true,
-    );
-    expect(categoryMatchesLang(cat("2", "English Hindi Mix"), "english")).toBe(
-      false,
-    );
+  it("Telugu-exclusive categories beat ambiguous OTT matches", () => {
+    // "Zee Telugu" contains the word "telugu" → pure-lang telugu match.
+    expect(categoryMatchesLang(cat("1", "Zee Telugu"), "telugu")).toBe(true);
+    expect(categoryMatchesLang(cat("2", "Zee Telugu"), "hindi")).toBe(false);
+    // "Colors Hindi" has no telugu cue → does not leak into Telugu.
+    expect(categoryMatchesLang(cat("3", "Colors Hindi"), "telugu")).toBe(false);
+    expect(categoryMatchesLang(cat("4", "Colors Hindi"), "hindi")).toBe(true);
   });
 });

--- a/src/features/series/seriesLanguageUnion.ts
+++ b/src/features/series/seriesLanguageUnion.ts
@@ -17,7 +17,11 @@
 import { fetchSeriesCategories, fetchSeriesList } from "../../api/series";
 import type { SeriesCategory, SeriesItem } from "../../api/schemas";
 import type { LangId } from "../../lib/langPref";
-import { inferLanguage } from "../../lib/inferLanguage";
+import {
+  inferLanguage,
+  isOttPlatform,
+  seriesNameMatchesLang,
+} from "../../lib/inferLanguage";
 
 const TTL_MS = 5 * 60 * 1000;
 const MAX_CONCURRENCY = 8;
@@ -75,20 +79,43 @@ export function getSeriesListCached(categoryId: string): Promise<SeriesItem[]> {
   return promise;
 }
 
-// Uses the shared `inferLanguage` pattern set (mirrors the backend service) so
-// a Hindi filter picks up "Bollywood Classics" / "Indian Series", English
-// picks up "Netflix Originals" / "HBO Series", etc. The narrower word-boundary
-// match used in the Movies union (features/movies/languageUnion.ts) drops
-// those categories — we intentionally diverge here per user ask "get
-// everything of telugu". `inferLanguage` is the authoritative source because
-// it matches what the backend attaches as `inferredLang` to each item.
+/**
+ * Categories split into two buckets for the series union:
+ *
+ *   PURE-LANGUAGE — the category name uniquely determines the language
+ *   (Telugu Movies, Zee Telugu, Colors Hindi, Bollywood, etc.). Every item
+ *   inside is included under that language.
+ *
+ *   OTT-PLATFORM — the category spans multiple languages (Hotstar, Netflix,
+ *   Zee5, Sony LIV, etc.). Items are included ONLY if the series NAME itself
+ *   carries the target language tag ("… (Telugu)", "… - Hindi", etc.).
+ *
+ * `classifyCategory` returns which bucket a category falls into for a given
+ * language selection. `null` means the category contributes nothing.
+ */
+export type CategoryBucket = "pure-lang" | "ott-platform";
+
+export function classifyCategory(
+  cat: SeriesCategory,
+  lang: LangId,
+): CategoryBucket | null {
+  // "All" includes every category, OTT or pure. No per-item name filter.
+  if (lang === "all") return "pure-lang";
+  if (lang === "sports") return null;
+  if (inferLanguage(cat.name) === lang) return "pure-lang";
+  if (isOttPlatform(cat.name)) return "ott-platform";
+  return null;
+}
+
+/**
+ * Legacy name kept for the test suite — synonymous with "this category
+ * contributes at least one item". Prefer `classifyCategory` in new code.
+ */
 export function categoryMatchesLang(
   cat: SeriesCategory,
   lang: LangId,
 ): boolean {
-  if (lang === "all") return true;
-  if (lang === "sports") return false;
-  return inferLanguage(cat.name) === lang;
+  return classifyCategory(cat, lang) !== null;
 }
 
 async function poolMap<T, R>(
@@ -130,9 +157,13 @@ export async function streamSeriesLanguageUnion(
   onBatch: (batch: SeriesLanguageUnionBatch) => void,
 ): Promise<void> {
   const cats = await getSeriesCategoriesCached();
-  const matching = cats.filter((c) => categoryMatchesLang(c, lang));
+  const classified: { cat: SeriesCategory; bucket: CategoryBucket }[] = [];
+  for (const c of cats) {
+    const bucket = classifyCategory(c, lang);
+    if (bucket) classified.push({ cat: c, bucket });
+  }
 
-  if (matching.length === 0) {
+  if (classified.length === 0) {
     onBatch({
       items: [],
       isFinal: true,
@@ -146,24 +177,28 @@ export async function streamSeriesLanguageUnion(
   const merged: SeriesItem[] = [];
   let completed = 0;
 
-  await poolMap(matching, MAX_CONCURRENCY, async (c) => {
+  await poolMap(classified, MAX_CONCURRENCY, async ({ cat, bucket }) => {
     try {
-      const items = await getSeriesListCached(c.id);
+      const items = await getSeriesListCached(cat.id);
       for (const s of items) {
-        if (!seen.has(s.id)) {
-          seen.add(s.id);
-          merged.push(s);
+        if (seen.has(s.id)) continue;
+        // OTT platforms (Hotstar / Netflix / Zee5 …) carry all languages.
+        // Only include items whose NAME tags them for the selected language.
+        if (bucket === "ott-platform" && !seriesNameMatchesLang(s.name, lang)) {
+          continue;
         }
+        seen.add(s.id);
+        merged.push(s);
       }
     } catch {
       // per-category failures contribute zero items
     }
     completed += 1;
-    const isFinal = completed === matching.length;
+    const isFinal = completed === classified.length;
     onBatch({
       items: merged.slice(),
       isFinal,
-      matchedCategories: matching.length,
+      matchedCategories: classified.length,
       completedCategories: completed,
     });
   });

--- a/src/index.css
+++ b/src/index.css
@@ -85,6 +85,15 @@ body {
 #root {
   min-height: 100svh;
   width: 100%;
+  /* Guard against horizontal overflow on TV browsers (reported 2026-04-23
+     from Fire TV Silk — the rightmost poster was bleeding past the viewport
+     because Virtuoso's absolute-positioned sizer briefly exceeded parent
+     width during row recalc). */
+  overflow-x: hidden;
+  /* Respect hardware safe areas on the rare TV/webview that reports them.
+     Fire TV Silk ignores env() so this is free there; iPad / Chromecast with
+     Google TV honour it and get a non-clipped top edge. */
+  padding-top: env(safe-area-inset-top, 0);
 }
 
 p {

--- a/src/lib/inferLanguage.test.ts
+++ b/src/lib/inferLanguage.test.ts
@@ -6,7 +6,14 @@
  * way this suite will pass.
  */
 import { describe, expect, it } from "vitest";
-import { inferLanguage, LANGUAGE_PATTERNS } from "./inferLanguage";
+import {
+  inferLanguage,
+  LANGUAGE_PATTERNS,
+  isOttPlatform,
+  seriesNameMatchesLang,
+  scoreAudioTrackForLang,
+  pickAudioTrackForLang,
+} from "./inferLanguage";
 
 describe("inferLanguage", () => {
   it("returns 'telugu' for Telugu categories", () => {
@@ -23,9 +30,39 @@ describe("inferLanguage", () => {
 
   it("returns 'english' for English / streamer-branded categories", () => {
     expect(inferLanguage("English Movies")).toBe("english");
-    expect(inferLanguage("Netflix Originals")).toBe("english");
     expect(inferLanguage("HBO Max")).toBe("english");
     expect(inferLanguage("USA Sitcoms")).toBe("english");
+  });
+
+  it("returns null for multi-language OTT platforms", () => {
+    // 2026-04-23: OTT platforms (Netflix, Hotstar, Zee5, …) carry content in
+    // multiple languages. Routing them wholesale to a single language was
+    // wrong — they are handled separately via `isOttPlatform` + per-item
+    // name filtering in the language-union fetchers.
+    expect(inferLanguage("Netflix Originals")).toBe(null);
+    expect(inferLanguage("Amazon Prime")).toBe(null);
+    expect(inferLanguage("Disney+ Hotstar")).toBe(null);
+    expect(inferLanguage("Zee5 Originals")).toBe(null);
+  });
+
+  it("isOttPlatform recognises multi-language streaming categories", () => {
+    expect(isOttPlatform("Netflix Originals")).toBe(true);
+    expect(isOttPlatform("Disney+ Hotstar")).toBe(true);
+    expect(isOttPlatform("Zee5")).toBe(true);
+    expect(isOttPlatform("Sony LIV")).toBe(true);
+    expect(isOttPlatform("JioCinema")).toBe(true);
+    // Pure-language categories are NOT OTT platforms.
+    expect(isOttPlatform("Zee Telugu")).toBe(false);
+    expect(isOttPlatform("Star Maa")).toBe(false);
+    expect(isOttPlatform("Hindi Serials")).toBe(false);
+  });
+
+  it("seriesNameMatchesLang filters OTT items by the language tag in the name", () => {
+    expect(seriesNameMatchesLang("Panchayat (Telugu)", "telugu")).toBe(true);
+    expect(seriesNameMatchesLang("Panchayat (Hindi)", "telugu")).toBe(false);
+    expect(seriesNameMatchesLang("Succession - English", "english")).toBe(true);
+    expect(seriesNameMatchesLang("Any Title", "all")).toBe(true);
+    expect(seriesNameMatchesLang("Any Title", "sports")).toBe(false);
   });
 
   it("returns 'sports' for sports-themed categories", () => {
@@ -54,5 +91,59 @@ describe("inferLanguage", () => {
     for (const [lang, patterns] of Object.entries(LANGUAGE_PATTERNS)) {
       expect(patterns.length, `${lang} has no patterns`).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("audio-track lang matching", () => {
+  it("scoreAudioTrackForLang recognises ISO 639-1 + 639-2 + full-name lang codes", () => {
+    // 639-2 (tel/hin/eng)
+    expect(scoreAudioTrackForLang({ lang: "tel", name: "" }, "telugu")).toBe(3);
+    expect(scoreAudioTrackForLang({ lang: "hin", name: "" }, "hindi")).toBe(3);
+    expect(scoreAudioTrackForLang({ lang: "eng", name: "" }, "english")).toBe(3);
+    // 639-1 (te/hi/en)
+    expect(scoreAudioTrackForLang({ lang: "te", name: "" }, "telugu")).toBe(3);
+    expect(scoreAudioTrackForLang({ lang: "hi", name: "" }, "hindi")).toBe(3);
+    // Full-name in `name` field when `lang` is missing (common in MKV).
+    expect(scoreAudioTrackForLang({ lang: "", name: "Telugu" }, "telugu")).toBe(2);
+    expect(scoreAudioTrackForLang({ lang: "", name: "Hindi Dub" }, "hindi")).toBe(1);
+  });
+
+  it("scoreAudioTrackForLang rejects non-matches", () => {
+    expect(scoreAudioTrackForLang({ lang: "hin", name: "Hindi" }, "telugu")).toBe(0);
+    expect(scoreAudioTrackForLang({ lang: "", name: "Commentary" }, "telugu")).toBe(0);
+  });
+
+  it("scoreAudioTrackForLang never auto-picks for 'all' or 'sports'", () => {
+    expect(scoreAudioTrackForLang({ lang: "tel", name: "Telugu" }, "all")).toBe(0);
+    expect(scoreAudioTrackForLang({ lang: "hin", name: "Hindi" }, "sports")).toBe(0);
+  });
+
+  it("pickAudioTrackForLang picks the highest-scoring track", () => {
+    const tracks = [
+      { index: 0, lang: "eng", name: "English" },
+      { index: 1, lang: "hin", name: "Hindi" },
+      { index: 2, lang: "tel", name: "Telugu" },
+    ];
+    expect(pickAudioTrackForLang(tracks, "telugu")).toBe(2);
+    expect(pickAudioTrackForLang(tracks, "hindi")).toBe(1);
+    expect(pickAudioTrackForLang(tracks, "english")).toBe(0);
+  });
+
+  it("pickAudioTrackForLang returns -1 when no track matches — caller leaves default alone", () => {
+    const tracks = [
+      { index: 0, lang: "eng", name: "English" },
+      { index: 1, lang: "hin", name: "Hindi" },
+    ];
+    expect(pickAudioTrackForLang(tracks, "telugu")).toBe(-1);
+    expect(pickAudioTrackForLang([], "telugu")).toBe(-1);
+  });
+
+  it("prefers exact lang-code over loose name substring", () => {
+    // A track tagged `tel` beats one whose name merely mentions "telugu".
+    const tracks = [
+      { index: 0, lang: "", name: "Telugu Commentary" }, // score 1
+      { index: 1, lang: "tel", name: "Main" }, // score 3
+    ];
+    expect(pickAudioTrackForLang(tracks, "telugu")).toBe(1);
   });
 });

--- a/src/lib/inferLanguage.ts
+++ b/src/lib/inferLanguage.ts
@@ -22,12 +22,45 @@ export type InferredLang = Exclude<LangId, "all">;
  * Language → category-name substring patterns. Order matters: first match
  * wins (telugu before hindi before english before sports). Case-insensitive.
  *
- * SOURCE-OF-TRUTH: `streamvault-backend/src/services/language-inference.service.ts`.
+ * SOURCE-OF-TRUTH for the shared base patterns:
+ * `streamvault-backend/src/services/language-inference.service.ts`.
+ *
+ * The frontend extends that base with language-EXCLUSIVE TV channels only
+ * (2026-04-23: user asked to "combine all zee telugu, aha, etc."). These
+ * patterns must never be ambiguous between languages — a category that
+ * could contain Telugu AND Hindi content (e.g. "Netflix", "Hotstar") must
+ * NOT appear here. Multi-language platforms are handled separately via
+ * `OTT_PLATFORM_PATTERNS` + `seriesNameMatchesLang`, which fetches their
+ * items and filters by the series NAME instead of the category name.
  */
 export const LANGUAGE_PATTERNS: Record<InferredLang, readonly string[]> = {
-  telugu: ["telugu"],
-  hindi: ["hindi", "india entertainment", "indian", "bollywood"],
-  english: ["english", "netflix", "amazon", "hbo", "usa ", "uk "],
+  telugu: [
+    "telugu",
+    "aha",
+    "star maa",
+    "etv",
+    "gemini",
+    "maa tv",
+    "mahaa",
+  ],
+  hindi: [
+    "hindi",
+    "india entertainment",
+    "indian",
+    "bollywood",
+    "colors tv",
+    "colors hindi",
+    "star plus",
+    "star bharat",
+    "zee tv",
+    "sab tv",
+    "and tv",
+    "mtv hindi",
+    "sun neo",
+    "sony set",
+    "bigg boss",
+  ],
+  english: ["english", "hbo", "apple tv", "usa ", "uk "],
   sports: [
     "sport",
     "sports",
@@ -44,6 +77,120 @@ export const LANGUAGE_PATTERNS: Record<InferredLang, readonly string[]> = {
     "racing",
   ],
 } as const;
+
+/**
+ * Multi-language OTT / streaming-service categories.
+ *
+ * These categories carry Telugu, Hindi, and English content side-by-side.
+ * Routing the whole category to one language would mis-bucket the rest.
+ * Callers fetch these categories unconditionally and filter by series NAME
+ * via `seriesNameMatchesLang`.
+ */
+export const OTT_PLATFORM_PATTERNS: readonly string[] = [
+  "hotstar",
+  "disney+",
+  "zee5",
+  "sonyliv",
+  "sony liv",
+  "jiocinema",
+  "jio cinema",
+  "voot",
+  "netflix",
+  "amazon",
+  "prime video",
+  "alt balaji",
+  "altbalaji",
+];
+
+export function isOttPlatform(categoryName: string): boolean {
+  const lower = categoryName.toLowerCase();
+  return OTT_PLATFORM_PATTERNS.some((pat) => lower.includes(pat));
+}
+
+/**
+ * Per-item language inference for OTT catalogues.
+ *
+ * When a Hotstar / Netflix / Zee5 category is fetched under the Telugu
+ * filter, we include only items whose NAME hints at Telugu. Providers
+ * conventionally tag these as "Title (Telugu)", "Title - Telugu", etc.
+ *
+ * Word-boundary matching is deliberate: a Hindi title with the English
+ * word "telugu" accidentally embedded (rare but possible) is not a real
+ * match. "All" accepts every item. Sports is never inferred from a
+ * series/movie name — OTT catalogues are never sports.
+ */
+const NAME_LANG_WORDS: Record<Exclude<LangId, "all" | "sports">, RegExp> = {
+  telugu: /\btelugu\b/i,
+  hindi: /\bhindi\b/i,
+  english: /\benglish\b/i,
+};
+
+export function seriesNameMatchesLang(name: string, lang: LangId): boolean {
+  if (lang === "all") return true;
+  if (lang === "sports") return false;
+  return NAME_LANG_WORDS[lang].test(name);
+}
+
+/**
+ * Aliases for matching HLS / native audio-track labels against a LangId.
+ *
+ * HLS manifests and MP4 `<audio>` tracks tag languages using inconsistent
+ * codes: ISO 639-1 (`te`, `hi`, `en`), ISO 639-2 (`tel`, `hin`, `eng`), or
+ * the full English name spelled out. We check all three. The UI never
+ * auto-selects for `all` or `sports` — those aren't real audio languages.
+ */
+const AUDIO_LANG_ALIASES: Record<Exclude<LangId, "all" | "sports">, readonly string[]> = {
+  telugu: ["telugu", "tel", "te"],
+  hindi: ["hindi", "hin", "hi"],
+  english: ["english", "eng", "en"],
+};
+
+/**
+ * Score a track against a language pref. Higher is better. 0 = no match.
+ *
+ * Exact language-code match scores higher than a loose name-substring hit
+ * so "te" beats an accidental "te" inside "Director Commentary". We check:
+ *   3 — language code is an exact alias      (e.g. lang === "tel")
+ *   2 — track name is exactly the full word  (e.g. name === "Telugu")
+ *   1 — full-word appears inside the name    (word-boundary regex)
+ */
+export function scoreAudioTrackForLang(
+  track: { lang: string; name: string },
+  lang: LangId,
+): number {
+  if (lang === "all" || lang === "sports") return 0;
+  const aliases = AUDIO_LANG_ALIASES[lang];
+  const tLang = track.lang.trim().toLowerCase();
+  const tName = track.name.trim().toLowerCase();
+  if (tLang && aliases.includes(tLang)) return 3;
+  if (tName && aliases.includes(tName)) return 2;
+  const fullWord = aliases[0]!; // "telugu" | "hindi" | "english"
+  const re = new RegExp(`\\b${fullWord}\\b`, "i");
+  if (re.test(track.name)) return 1;
+  return 0;
+}
+
+/**
+ * Pick the best-matching audio track index for a language pref.
+ * Returns -1 when no track is a meaningful match — callers should leave
+ * the browser default selection alone in that case.
+ */
+export function pickAudioTrackForLang(
+  tracks: readonly { index: number; lang: string; name: string }[],
+  lang: LangId,
+): number {
+  if (tracks.length === 0) return -1;
+  let bestIdx = -1;
+  let bestScore = 0;
+  for (const t of tracks) {
+    const s = scoreAudioTrackForLang(t, lang);
+    if (s > bestScore) {
+      bestScore = s;
+      bestIdx = t.index;
+    }
+  }
+  return bestIdx;
+}
 
 /**
  * Infer the language of a catalog item from its category name.

--- a/src/player/PlayerControls.tsx
+++ b/src/player/PlayerControls.tsx
@@ -480,10 +480,17 @@ export function PlayerControls({
   }, [isPlaying, onPlay, onPause]);
 
   // Initial focus on Play/Pause when the player opens (spec §4.1).
+  // Fire twice: once synchronously for the fast path, then again after a
+  // tick. When setFocus runs before norigin has finished registering the
+  // PLAY_PAUSE focusable (observed in prod — focus landed on Back instead),
+  // the first call silently falls back to the first registered focusable;
+  // the delayed call corrects it once everything is registered.
   useEffect(() => {
     setFocus(FK.PLAY_PAUSE);
+    const t = setTimeout(() => setFocus(FK.PLAY_PAUSE), 80);
     scheduleHide();
     return () => {
+      clearTimeout(t);
       if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -492,9 +499,25 @@ export function PlayerControls({
   // Capture-phase key interceptor: wake-only on first arrow when hidden,
   // Enter short-circuits pause/play (spec §4.3). Also handles media keys
   // (TV remote) and Escape.
+  //
+  // Fire TV / Android TV media keys are identified either by `event.key`
+  // (Silk recent firmware) or by `event.keyCode` (older WebViews). The
+  // Android KeyEvent codes:
+  //   85 MEDIA_PLAY_PAUSE, 126 MEDIA_PLAY, 127 MEDIA_PAUSE
+  //   89 MEDIA_REWIND,     90 MEDIA_FAST_FORWARD
+  //   87 MEDIA_NEXT,       88 MEDIA_PREVIOUS
+  //    4 BACK
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape" || e.key === "Back" || e.key === "GoBack") {
+      const k = e.key;
+      const kc = e.keyCode;
+
+      const isBack =
+        k === "Escape" ||
+        k === "Back" ||
+        k === "GoBack" ||
+        kc === 4;
+      if (isBack) {
         e.preventDefault();
         if (openMenu) {
           setOpenMenu(null);
@@ -504,31 +527,61 @@ export function PlayerControls({
         return;
       }
 
-      if (e.key === "MediaPlayPause" || e.key === " " || e.key === "k") {
+      const isPlayPauseKey =
+        k === "MediaPlayPause" ||
+        k === "MediaPlay" ||
+        k === "MediaPause" ||
+        k === " " ||
+        k === "k" ||
+        kc === 85 ||
+        kc === 126 ||
+        kc === 127;
+      if (isPlayPauseKey) {
         e.preventDefault();
         togglePlayPause();
         wake();
         return;
       }
-      if ((e.key === "MediaRewind" || e.key === "j") && !isLive) {
+
+      const isRewindKey = k === "MediaRewind" || k === "j" || kc === 89;
+      if (isRewindKey && !isLive) {
         e.preventDefault();
         onSeek(currentTimeRef.current - 10);
         wake();
         return;
       }
-      if ((e.key === "MediaFastForward" || e.key === "l") && !isLive) {
+
+      const isFfKey =
+        k === "MediaFastForward" || k === "l" || kc === 90;
+      if (isFfKey && !isLive) {
         e.preventDefault();
         onSeek(currentTimeRef.current + 10);
         wake();
         return;
       }
 
+      // Fire TV's ⏭ / ⏮ media keys map to prev/next episode if provided.
+      const isMediaNext = k === "MediaTrackNext" || kc === 87;
+      if (isMediaNext && onNext) {
+        e.preventDefault();
+        onNext();
+        wake();
+        return;
+      }
+      const isMediaPrev = k === "MediaTrackPrevious" || kc === 88;
+      if (isMediaPrev && onPrev) {
+        e.preventDefault();
+        onPrev();
+        wake();
+        return;
+      }
+
       const isArrow =
-        e.key === "ArrowUp" ||
-        e.key === "ArrowDown" ||
-        e.key === "ArrowLeft" ||
-        e.key === "ArrowRight";
-      const isEnter = e.key === "Enter" || e.key === "OK";
+        k === "ArrowUp" ||
+        k === "ArrowDown" ||
+        k === "ArrowLeft" ||
+        k === "ArrowRight";
+      const isEnter = k === "Enter" || k === "OK";
 
       if (!visibleRef.current) {
         if (isArrow) {
@@ -557,7 +610,7 @@ export function PlayerControls({
       window.removeEventListener("keydown", onKeyDown, true);
       window.removeEventListener("mousemove", onMouseMove);
     };
-  }, [onClose, onSeek, isLive, openMenu, togglePlayPause, wake]);
+  }, [onClose, onSeek, isLive, openMenu, togglePlayPause, wake, onNext, onPrev]);
 
   const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
 

--- a/src/player/PlayerProvider.tsx
+++ b/src/player/PlayerProvider.tsx
@@ -15,8 +15,14 @@ import {
   useReducer,
   useEffect,
   useCallback,
+  useRef,
   type ReactNode,
 } from "react";
+import {
+  getCurrentFocusKey,
+  doesFocusableExist,
+  setFocus,
+} from "@noriginmedia/norigin-spatial-navigation";
 
 export type PlayerKind = "live" | "vod" | "series-episode";
 
@@ -96,12 +102,35 @@ const PlayerContext = createContext<PlayerContextValue | null>(null);
 export function PlayerProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(playerReducer, { status: "idle" });
 
+  // Remember the focus key the user came from so we can restore it when the
+  // player closes. Without this, closing the player lands focus nowhere
+  // (reported 2026-04-23: "I can go back but there is no focus on any
+  // element on back"). norigin's autoRestoreFocus only walks up to the
+  // nearest parent; the player's FocusBoundary orphans that chain.
+  const previousFocusKeyRef = useRef<string | null>(null);
+
   const open = useCallback((payload: PlayerOpenPayload) => {
+    const current = getCurrentFocusKey();
+    previousFocusKeyRef.current = current || null;
     dispatch({ type: "OPEN", payload });
   }, []);
 
   const close = useCallback(() => {
+    const target = previousFocusKeyRef.current;
+    previousFocusKeyRef.current = null;
     dispatch({ type: "CLOSE" });
+    // Wait a tick so PlayerShell has unmounted and norigin has removed its
+    // focusables before re-seeding. Without the delay, setFocus races the
+    // unmount and the target can bounce back to the player.
+    if (target) {
+      const restore = () => {
+        if (doesFocusableExist(target)) {
+          setFocus(target);
+        }
+      };
+      setTimeout(restore, 0);
+      setTimeout(restore, 80);
+    }
   }, []);
 
   // Back-button handling: when player is open, intercept popstate (Fire TV

--- a/src/player/PlayerShell.test.tsx
+++ b/src/player/PlayerShell.test.tsx
@@ -50,6 +50,8 @@ vi.mock("@noriginmedia/norigin-spatial-navigation", () => ({
     Provider: ({ children }: { children: ReactNode }) => children,
   },
   setFocus: vi.fn(),
+  getCurrentFocusKey: vi.fn(() => ""),
+  doesFocusableExist: vi.fn(() => false),
 }));
 
 // ─── Test wrapper ─────────────────────────────────────────────────────────────

--- a/src/player/PlayerShell.tsx
+++ b/src/player/PlayerShell.tsx
@@ -23,6 +23,9 @@ import { useHlsPlayer } from "./useHlsPlayer";
 import { PlayerControls } from "./PlayerControls";
 import { useReducedMotion } from "./useReducedMotion";
 import { markTierLocked } from "../features/movies/tierLockCache";
+import { recordHistory } from "../api/history";
+import { getLangPref } from "../lib/langPref";
+import { pickAudioTrackForLang } from "../lib/inferLanguage";
 
 // Failure-overlay focus keys — kept local, only the overlay reads them.
 const FK_RETRY = "PLAYER_FAIL_RETRY";
@@ -93,6 +96,35 @@ export function PlayerShell() {
     setCurrentSubtitleTrack(-1);
   }, [src]);
 
+  // Auto-select audio to match the user's language pref (sv_lang_pref) on
+  // the first track list that arrives for a given stream. Fires once per
+  // open; manual selections in the 🎧 menu take over after that.
+  //
+  // Rationale: OTT titles (Hotstar / Netflix / Zee5) often ship multi-audio
+  // HLS. Before this, a Telugu user landing in "Panchayat" heard the default
+  // Hindi track and had to dig through the menu on every episode. The
+  // language rail already tells us which track they want — honour it.
+  const autoSelectedForSrcRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!src) {
+      autoSelectedForSrcRef.current = null;
+      return;
+    }
+    if (autoSelectedForSrcRef.current === src) return;
+    if (audioTracks.length < 2) return; // single-track: nothing to pick
+    const pref = getLangPref();
+    const idx = pickAudioTrackForLang(audioTracks, pref);
+    if (idx < 0) {
+      // No meaningful match. Mark as done so we don't retry on every
+      // track-list update; user can pick manually.
+      autoSelectedForSrcRef.current = src;
+      return;
+    }
+    autoSelectedForSrcRef.current = src;
+    selectAudioTrack(idx);
+    setCurrentAudioTrack(idx);
+  }, [src, audioTracks, selectAudioTrack]);
+
   const handleSelectLevel = useCallback(
     (idx: number) => {
       selectLevel(idx);
@@ -134,6 +166,39 @@ export function PlayerShell() {
       markTierLocked(contentId.id);
     }
   }, [failureClass, contentId]);
+
+  // Live progress tracking → watch history.
+  //
+  // Writes (currentTime, duration, title) every ~15 s of playback so the
+  // ResumeHero can pick the correct in-progress item and show the full
+  // episode/movie title. Without this, history was only ever written on
+  // "mark as watched" — legacy rows had content_name = null, producing
+  // "Resume your episode" (reported 2026-04-23).
+  //
+  // Live streams are excluded: the Xtream TS feed has no stable "duration"
+  // and there is no resume semantic for live TV.
+  const lastWrittenRef = useRef<{ id: string; at: number } | null>(null);
+  useEffect(() => {
+    if (state.status !== "open") return;
+    if (kind === "live") return;
+    if (!contentId) return;
+    if (!(duration > 0)) return;
+    if (!(currentTime > 0)) return;
+
+    const now = Date.now();
+    const prev = lastWrittenRef.current;
+    const sameItem = prev?.id === contentId.id;
+    // Throttle: 15 s between writes per item.
+    if (sameItem && now - (prev?.at ?? 0) < 15_000) return;
+    lastWrittenRef.current = { id: contentId.id, at: now };
+
+    void recordHistory(Number(contentId.id), {
+      content_type: kind === "series-episode" ? "series" : "vod",
+      content_name: title,
+      progress_seconds: Math.floor(currentTime),
+      duration_seconds: Math.floor(duration),
+    });
+  }, [state.status, kind, contentId, currentTime, duration, title]);
 
   if (state.status === "idle") {
     return null;

--- a/src/player/useHlsPlayer.ts
+++ b/src/player/useHlsPlayer.ts
@@ -115,6 +115,15 @@ export function useHlsPlayer(
     // proxies a direct MP4/MKV. Browser handles natively.
     const useNative = !isM3u8 && !isLiveTs;
 
+    // When the browser blocks autoplay, `video.play()` rejects silently and
+    // the `playing` event never fires — the spinner would otherwise spin
+    // forever on a paused video (reported 2026-04-23: "video not playing at
+    // all" even though duration loaded). Flip status to "paused" so the
+    // Play icon renders and the user can hit Enter.
+    const markAutoplayBlocked = () => {
+      setStatus((s) => (s === "playing" ? s : "paused"));
+    };
+
     if (isLiveTs && mpegts.getFeatureList().mseLivePlayback) {
       // Live: backend transcodes Xtream TS → video-copy + AAC TS on the wire,
       // mpegts.js wraps MSE for the browser.
@@ -132,9 +141,7 @@ export function useHlsPlayer(
       mpegtsRef.current = player;
       player.attachMediaElement(video);
       player.load();
-      player.play()?.catch(() => {
-        /* autoplay blocked — user must press play */
-      });
+      player.play()?.catch(markAutoplayBlocked);
 
       player.on(mpegts.Events.ERROR, (errType, errDetail) => {
         setError(new Error(`${errType}: ${errDetail}`));
@@ -143,9 +150,38 @@ export function useHlsPlayer(
     } else if (useNative) {
       video.src = src;
       video.load();
-      void Promise.resolve(video.play()).catch(() => {
-        /* autoplay blocked or jsdom */
-      });
+      // Native MP4/MKV containers can carry multi-audio (dubbed OTT titles
+      // are the common case). `video.audioTracks` is a live AudioTrackList;
+      // surface it into our state the same way the HLS path does so the
+      // 🎧 picker and auto-select logic work identically.
+      // Chromium exposes this; Firefox doesn't — guarded to avoid throwing.
+      const nativeAudio = (
+        video as HTMLVideoElement & {
+          audioTracks?: {
+            length: number;
+            [i: number]: { id?: string; label?: string; language?: string; enabled?: boolean };
+            onaddtrack?: (() => void) | null;
+            onchange?: (() => void) | null;
+          };
+        }
+      ).audioTracks;
+      if (nativeAudio) {
+        const syncNativeAudio = () => {
+          const arr: HlsAudioTrack[] = [];
+          for (let i = 0; i < nativeAudio.length; i += 1) {
+            const t = nativeAudio[i]!;
+            arr.push({
+              index: i,
+              name: t.label || t.language || `Audio ${i}`,
+              lang: t.language ?? "",
+            });
+          }
+          setAudioTracks(arr);
+        };
+        syncNativeAudio();
+        nativeAudio.onaddtrack = syncNativeAudio;
+      }
+      void Promise.resolve(video.play()).catch(markAutoplayBlocked);
     } else if (isM3u8 && Hls.isSupported()) {
       // Phase 6 follow-up (2026-04-23 user ask): bump forward-buffer target
       // to 120 s for smoother playback on flaky networks. backBufferLength
@@ -172,9 +208,7 @@ export function useHlsPlayer(
             name: l.name ?? (l.height ? `${l.height}p` : `Level ${i}`),
           })),
         );
-        video.play().catch(() => {
-          // autoplay blocked — user must press play manually
-        });
+        video.play().catch(markAutoplayBlocked);
       });
 
       hls.on(Hls.Events.AUDIO_TRACKS_UPDATED, (_event, data) => {
@@ -215,9 +249,7 @@ export function useHlsPlayer(
       // mpegts.js says MSE live playback isn't supported.
       video.src = src;
       video.load();
-      void Promise.resolve(video.play()).catch(() => {
-        /* autoplay blocked or jsdom */
-      });
+      void Promise.resolve(video.play()).catch(markAutoplayBlocked);
     }
 
     const onPlay = () => setStatus("playing");
@@ -308,11 +340,31 @@ export function useHlsPlayer(
     }
   }, []);
 
-  const selectAudioTrack = useCallback((idx: number) => {
-    if (hlsRef.current) {
-      hlsRef.current.audioTrack = idx;
-    }
-  }, []);
+  const selectAudioTrack = useCallback(
+    (idx: number) => {
+      if (hlsRef.current) {
+        hlsRef.current.audioTrack = idx;
+        return;
+      }
+      // Native MP4/MKV: flip `enabled` on the AudioTrackList entries. This
+      // API is Chromium-only; on browsers without support the call is a
+      // no-op (`audioTracks` is undefined and the guard bails cleanly).
+      const v = videoRef.current as
+        | (HTMLVideoElement & {
+            audioTracks?: {
+              length: number;
+              [i: number]: { enabled?: boolean };
+            };
+          })
+        | null;
+      const list = v?.audioTracks;
+      if (!list) return;
+      for (let i = 0; i < list.length; i += 1) {
+        list[i]!.enabled = i === idx;
+      }
+    },
+    [videoRef],
+  );
 
   const selectSubtitleTrack = useCallback((idx: number) => {
     if (hlsRef.current) {

--- a/src/routes/SeriesRoute.tsx
+++ b/src/routes/SeriesRoute.tsx
@@ -230,11 +230,18 @@ export function SeriesRoute() {
   }, [history]);
 
   const resumeLabel = useMemo<string>(() => {
-    if (!resumeCandidate) return "your episode";
+    if (!resumeCandidate) return "your last episode";
     const parsed = parseEpisodeName(resumeCandidate.content_name);
     if (parsed.sEp && parsed.series) return `${parsed.sEp} of ${parsed.series}`;
     if (parsed.sEp) return parsed.sEp;
-    return resumeCandidate.content_name ?? "your episode";
+    // content_name populated but not in the series/episode format — fall
+    // through to the raw name (likely an older row from a different writer).
+    if (resumeCandidate.content_name) return resumeCandidate.content_name;
+    // Legacy null content_name. The player now writes the full
+    // "Series · S_E_ · Title" format on every timeupdate (PlayerShell), so
+    // this branch self-heals the next time the user presses play. Until
+    // then, show something less generic than "your episode".
+    return "your last episode";
   }, [resumeCandidate]);
 
   const handleResume = useCallback(() => {


### PR DESCRIPTION
## Summary

Three commits addressing the 2026-04-23 → 2026-04-24 prod testing pass:

1. **`fix(player)`** — initial focus on Play/Pause; autoplay-block → paused (not loading); Fire TV media keyCodes (85/89/90/126/127/87/88/4); focus restored on player close; live watch-history writes during VOD/series playback; audio auto-selects from `sv_lang_pref` on first manifest parse; native MP4/MKV audio tracks wired.
2. **`feat(catalog)`** — Movies + Series categories split into **pure-lang** (every item in) and **ott-platform** (items filtered by `\bTelugu\b` / `\bHindi\b` / `\bEnglish\b` regex on the item name). Hotstar / Netflix / Zee5 / Sony LIV / JioCinema / Voot / Amazon Prime / Disney+ / ALT Balaji are the multi-language bucket; Zee Telugu / Star Maa / Aha / ETV / Gemini / Colors / Star Plus / Zee TV / SAB / And TV / Bigg Boss are the pure-lang bucket.
3. **`fix(nav,layout)`** — Fire TV back-key no longer exits (popstate exit-guard + keyCode 4 + key-name variants); poster grid density +1 col per breakpoint so 1080p Fire TV renders 6 cols; `overflow-x: hidden` on `#root`; `env(safe-area-inset-top)` padding.

## Test plan

- [ ] Fire TV remote: Back on /movies, /series, /live → focus returns to dock, app does NOT exit
- [ ] Fire TV remote: Back from /series/:id → returns to /series
- [ ] Fire TV remote: FF/RW hardware buttons on remote seek ±10s on VOD/series; D-pad Left/Right on Play/Pause also seek
- [ ] Player opens → focus is on Play/Pause (center), not Back (left)
- [ ] Pause/Play on autoplay-blocked: Play icon shown, pressing it starts playback
- [ ] Close player → focus returns to the card/row it was launched from
- [ ] Telugu rail shows content from Aha, Star Maa, ETV, Gemini (not just "Zee Telugu")
- [ ] Hotstar/Netflix Telugu-tagged items appear under Telugu rail; untagged ones stay in All only
- [ ] Multi-audio OTT title (e.g. Panchayat with tel/hin/eng tracks): auto-plays in the rail-selected language; 🎧 menu still lets user switch
- [ ] Resume hero on /series shows "S1E886 of Padamati Sandhyaragam" after first play-with-progress (was "your episode")
- [ ] Poster grid fits comfortably on TV without overflow; ~6 cols at 1080p

## Known CI state

- Pre-existing `Empty prompt produces no output` hook test fails on main too; admin bypass expected.
- Manual deploy required per user — CI currently red.

## Tests + build

- 305/305 unit tests pass
- `tsc --noEmit` clean
- `vite build` clean (bundle 1.32 MB / 375 KB gzipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)