### PR TITLE
feat: Search + Favorites + Fire TV readability + back-to-dock exit

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,23 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>streamvault-v3-frontend</title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+
+    <!-- PWA / Silk fullscreen. On Fire TV Silk, "Add to Home Screen" will
+         launch the app without browser chrome (URL bar hidden) because
+         display:fullscreen is declared in the manifest. The apple-*
+         metas cover iOS / Safari home-screen installs. -->
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#12100e" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="StreamVault" />
+
+    <title>StreamVault</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "StreamVault",
+  "short_name": "StreamVault",
+  "description": "Your live TV, movies, and series in one place.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "fullscreen",
+  "display_override": ["fullscreen", "standalone"],
+  "orientation": "landscape",
+  "background_color": "#12100e",
+  "theme_color": "#12100e",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@
  * Preserved dev-time routes: /test-primitives and /silk-probe (permanent
  * Playwright probe targets — Task 1.7 + Task 2.1).
  */
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   BrowserRouter,
   Routes,
@@ -62,6 +62,12 @@ function AppShell() {
   const { pathname } = useLocation();
   const first = pathname.split("/")[1];
   const activeTab: DockItem = isDockItem(first) ? first : "movies";
+
+  // Back-to-dock-then-exit: when the user presses Back while already on a
+  // dock tab, we let the event through AND mark a timestamp here so the
+  // popstate sentinel stops re-pushing. Without this, Fire TV's hardware
+  // Back was absorbed even from the dock — there was no path out.
+  const lastDockBackAtRef = useRef<number>(0);
 
   // Hide the dock on dev-time probe routes so it doesn't overlap the fixture.
   const hideDock =
@@ -127,9 +133,13 @@ function AppShell() {
       const active = document.activeElement?.getAttribute("aria-label");
       const dockLabels = Object.values(DOCK_LABELS);
       if (active && dockLabels.includes(active)) {
-        // Already on the dock — swallow so the browser doesn't navigate
-        // history.back() from an already-cornered state and exit the app.
-        e.preventDefault();
+        // Back pressed while the dock is focused. Let the event through so
+        // the browser / Fire TV host can close the tab or PWA (a user on
+        // the dock signalling Back means "leave the app"). We also record
+        // the timestamp so the popstate sentinel below stops re-pushing
+        // the exit guard — otherwise Fire TV's hardware Back would be
+        // absorbed by the sentinel re-push and never reach the OS.
+        lastDockBackAtRef.current = Date.now();
         return;
       }
       setFocus(`DOCK_${activeTab.toUpperCase()}`);
@@ -153,6 +163,13 @@ function AppShell() {
       window.history.pushState({ svExitGuard: true }, "");
     }
     const onPop = () => {
+      // If Back was just pressed from the dock, the user is asking to leave.
+      // Don't re-push the sentinel — let the pop resolve so the browser /
+      // Fire TV host can close the tab / PWA. 600ms window matches the
+      // Prime Video exit timing.
+      if (Date.now() - lastDockBackAtRef.current < 600) {
+        return;
+      }
       const segments = window.location.pathname
         .split("/")
         .filter(Boolean);

--- a/src/brand/tokens.css
+++ b/src/brand/tokens.css
@@ -245,4 +245,17 @@
   body {
     font-family: var(--font-ui);
   }
+
+  /* TV-class readability override. Fire TV Silk / 10-foot viewing needs ~24px
+     floor on primary label type. Gated on [data-tv="true"] which is set in
+     main.tsx by sniffing the UA (Silk/AFT). Desktop browsers on big monitors
+     stay on the ordinary desktop scale. */
+  :root[data-tv="true"] {
+    --text-label-size: 22px;
+    --text-label-tracking: 0.6px;
+    --text-caption-size: 20px;
+    --text-body-size: 24px;
+    --text-body-lg-size: 28px;
+    --text-title-size: 36px;
+  }
 }

--- a/src/components/FindInput.tsx
+++ b/src/components/FindInput.tsx
@@ -1,0 +1,201 @@
+/**
+ * FindInput — in-route filter input for /movies and /series.
+ *
+ * Always rendered in the DOM (keeps the layout stable + tests predictable),
+ * but D-pad only lands on it when the caller explicitly invokes it via a
+ * "🔍 Find" trigger chip (see FindTrigger). This keeps browsing users from
+ * having the input steal focus every time they traverse the page.
+ *
+ * Escape or Backspace on an empty input clears the filter and returns focus
+ * to the find-trigger chip.
+ */
+import type { RefObject } from "react";
+import {
+  useFocusable,
+  setFocus,
+} from "@noriginmedia/norigin-spatial-navigation";
+
+interface FindInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  /** Unique suffix used by the route to namespace the focusKey. e.g. "MOVIES". */
+  surface: "MOVIES" | "SERIES";
+  placeholder: string;
+}
+
+export function FindInput({
+  value,
+  onChange,
+  surface,
+  placeholder,
+}: FindInputProps) {
+  const focusKey = `${surface}_FIND_INPUT`;
+  const triggerKey = `${surface}_FIND_TRIGGER`;
+
+  const { ref, focused } = useFocusable<HTMLInputElement>({
+    focusKey,
+  });
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Escape" || (e.key === "Backspace" && value.length === 0)) {
+      e.preventDefault();
+      e.stopPropagation();
+      onChange("");
+      setFocus(triggerKey);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "var(--space-2)",
+        padding: "var(--space-2) var(--space-6)",
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          color: "var(--text-secondary)",
+          fontSize: "var(--text-body-size)",
+        }}
+      >
+        🔍
+      </span>
+      <input
+        ref={ref as RefObject<HTMLInputElement>}
+        type="search"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        autoComplete="off"
+        spellCheck={false}
+        aria-label={placeholder}
+        data-testid={`${surface.toLowerCase()}-find-input`}
+        style={{
+          flex: 1,
+          maxWidth: 420,
+          background: "var(--bg-surface)",
+          border: focused
+            ? "2px solid var(--accent-copper)"
+            : "2px solid var(--bg-elevated)",
+          borderRadius: "var(--radius-sm)",
+          color: "var(--text-primary)",
+          fontSize: "var(--text-body-size)",
+          padding: "var(--space-2) var(--space-3)",
+          outline: "none",
+          boxSizing: "border-box",
+        }}
+      />
+      {value.length > 0 && (
+        <ClearButton
+          onClick={() => {
+            onChange("");
+            setFocus(triggerKey);
+          }}
+          surface={surface}
+        />
+      )}
+    </div>
+  );
+}
+
+function ClearButton({
+  onClick,
+  surface,
+}: {
+  onClick: () => void;
+  surface: "MOVIES" | "SERIES";
+}) {
+  const { ref, focused } = useFocusable<HTMLButtonElement>({
+    focusKey: `${surface}_FIND_CLEAR`,
+    onEnterPress: onClick,
+  });
+  return (
+    <button
+      ref={ref as RefObject<HTMLButtonElement>}
+      type="button"
+      aria-label="Clear filter"
+      onClick={onClick}
+      style={{
+        width: 32,
+        height: 32,
+        borderRadius: "var(--radius-sm)",
+        border: focused
+          ? "2px solid var(--accent-copper)"
+          : "2px solid transparent",
+        background: focused ? "var(--bg-elevated)" : "var(--bg-surface)",
+        color: "var(--text-secondary)",
+        cursor: "pointer",
+        fontSize: 18,
+        lineHeight: 1,
+      }}
+    >
+      ×
+    </button>
+  );
+}
+
+interface FindTriggerProps {
+  surface: "MOVIES" | "SERIES";
+  onSelect: () => void;
+  isActive: boolean;
+}
+
+export function FindTrigger({ surface, onSelect, isActive }: FindTriggerProps) {
+  const { ref, focused } = useFocusable<HTMLButtonElement>({
+    focusKey: `${surface}_FIND_TRIGGER`,
+    onEnterPress: onSelect,
+  });
+  const active = isActive || focused;
+  return (
+    <button
+      ref={ref as RefObject<HTMLButtonElement>}
+      type="button"
+      aria-label={`Find in ${surface.toLowerCase()}`}
+      aria-pressed={isActive}
+      onClick={onSelect}
+      className="focus-ring"
+      style={{
+        padding: "var(--space-2) var(--space-3)",
+        borderRadius: "var(--radius-sm)",
+        border: "none",
+        background: active ? "var(--accent-copper)" : "var(--bg-surface)",
+        color: active ? "var(--bg-base)" : "var(--text-primary)",
+        fontSize: "var(--text-label-size)",
+        letterSpacing: "var(--text-label-tracking)",
+        textTransform: "uppercase",
+        cursor: "pointer",
+        transition:
+          "background var(--motion-focus), color var(--motion-focus)",
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "var(--space-1)",
+      }}
+    >
+      🔍 Find
+    </button>
+  );
+}
+
+/**
+ * Substring filter helper — tokenizes query on whitespace and requires every
+ * token to appear (case-insensitive) in `fields`. Shared between MoviesRoute
+ * and SeriesRoute for identical filter semantics.
+ */
+export function filterByQuery<T>(
+  items: readonly T[],
+  query: string,
+  getFields: (item: T) => string,
+): T[] {
+  const trimmed = query.trim().toLowerCase();
+  if (trimmed.length === 0) return [...items];
+  const tokens = trimmed.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return [...items];
+  return items.filter((it) => {
+    const haystack = getFields(it).toLowerCase();
+    return tokens.every((t) => haystack.includes(t));
+  });
+}

--- a/src/features/favorites/FavoritePosterCard.tsx
+++ b/src/features/favorites/FavoritePosterCard.tsx
@@ -1,0 +1,213 @@
+/**
+ * FavoritePosterCard — 2:3 poster card for /favorites.
+ *
+ * Visually parallel to MovieCard/SeriesCard so /favorites feels like a
+ * sibling destination. Activation matches the card-activation matrix
+ * (IA §2.3): Live → openPlayer, VOD → openPlayer, Series → navigate.
+ *
+ * OverflowMenu (⋯) renders only while the card is focused, same pattern
+ * as MovieCard. Actions vary by content type.
+ */
+import type { RefObject } from "react";
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { useFocusable } from "@noriginmedia/norigin-spatial-navigation";
+import { OverflowMenu } from "../../components/OverflowMenu";
+import { usePlayerOpener } from "../../player";
+import type { FavoriteItem, ContentType } from "../../api/schemas";
+
+interface FavoritePosterCardProps {
+  item: FavoriteItem;
+  onRemove: (contentId: number, contentType: ContentType) => void;
+  onMoreInfo?: (item: FavoriteItem) => void;
+}
+
+const TYPE_GLYPH: Record<ContentType, string> = {
+  channel: "●",
+  vod: "▶",
+  series: "⊞",
+};
+
+function defaultIconGlyph(type: ContentType): string {
+  return TYPE_GLYPH[type];
+}
+
+export function FavoritePosterCard({
+  item,
+  onRemove,
+  onMoreInfo,
+}: FavoritePosterCardProps) {
+  const { openPlayer } = usePlayerOpener();
+  const navigate = useNavigate();
+  const focusKey = `FAV_CARD_${item.content_type.toUpperCase()}_${item.content_id}`;
+
+  const activate = useCallback(() => {
+    const title = item.content_name ?? `Item ${item.content_id}`;
+    const id = String(item.content_id);
+    if (item.content_type === "series") {
+      navigate(`/series/${encodeURIComponent(id)}`);
+      return;
+    }
+    const kind = item.content_type === "channel" ? "live" : "vod";
+    void openPlayer({ kind, id, title });
+  }, [item, navigate, openPlayer]);
+
+  const { ref, focused } = useFocusable<HTMLButtonElement>({
+    focusKey,
+    onEnterPress: activate,
+  });
+
+  const overflowActions = [
+    {
+      label: item.content_type === "series" ? "Open series" : "Play",
+      onSelect: activate,
+    },
+    ...(item.content_type === "vod" && onMoreInfo
+      ? [
+          {
+            label: "More info",
+            onSelect: () => onMoreInfo(item),
+          },
+        ]
+      : []),
+    {
+      label: "Remove from favorites",
+      onSelect: () => onRemove(item.content_id, item.content_type),
+    },
+  ];
+
+  const title = item.content_name ?? `Item ${item.content_id}`;
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: "100%",
+        transform: focused ? "scale(1.03)" : "scale(1)",
+        transition: "transform 150ms ease-out",
+      }}
+    >
+      <button
+        ref={ref as RefObject<HTMLButtonElement>}
+        type="button"
+        aria-label={title}
+        onClick={activate}
+        className="focus-ring"
+        style={{
+          position: "relative",
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+          background: "var(--card-glass-bg, var(--bg-surface))",
+          border: focused
+            ? "1px solid var(--accent-copper)"
+            : "var(--card-glass-border, 1px solid rgba(237,228,211,0.06))",
+          borderRadius: "var(--radius-sm, 6px)",
+          padding: 0,
+          cursor: "pointer",
+          boxShadow: focused
+            ? "var(--focus-glow, 0 0 0 2px var(--accent-copper), 0 8px 32px -8px rgba(200,121,65,0.45))"
+            : "0 2px 8px rgba(0,0,0,0.3)",
+          transition:
+            "box-shadow 150ms ease-out, border-color 150ms ease-out",
+          overflow: "hidden",
+          textAlign: "left",
+        }}
+      >
+        <div
+          style={{
+            width: "100%",
+            paddingBottom: "150%",
+            position: "relative",
+            background: "var(--bg-elevated, #2a2520)",
+          }}
+        >
+          {item.content_icon ? (
+            <img
+              src={item.content_icon}
+              alt=""
+              loading="lazy"
+              style={{
+                position: "absolute",
+                inset: 0,
+                width: "100%",
+                height: "100%",
+                objectFit: "cover",
+              }}
+              onError={(e) => {
+                (e.currentTarget as HTMLImageElement).style.display = "none";
+              }}
+            />
+          ) : (
+            <div
+              aria-hidden="true"
+              style={{
+                position: "absolute",
+                inset: 0,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: 48,
+                color: "var(--text-secondary)",
+                opacity: 0.6,
+              }}
+            >
+              {defaultIconGlyph(item.content_type)}
+            </div>
+          )}
+        </div>
+
+        <div
+          style={{
+            padding: "var(--space-2) var(--space-3)",
+            paddingRight: focused
+              ? "calc(var(--space-3) + 40px)"
+              : "var(--space-3)",
+            color: "var(--text-primary)",
+            fontSize: "var(--text-label-size)",
+            letterSpacing: "var(--text-label-tracking)",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            transition: "padding-right 150ms ease-out",
+          }}
+        >
+          {title}
+        </div>
+
+        {item.category_name && (
+          <div
+            style={{
+              padding: "0 var(--space-3) var(--space-2)",
+              color: "var(--text-secondary)",
+              fontSize: "var(--text-caption-size)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {item.category_name}
+          </div>
+        )}
+      </button>
+
+      {focused && (
+        <div
+          style={{
+            position: "absolute",
+            bottom: "var(--space-2)",
+            right: "var(--space-2)",
+            zIndex: 10,
+          }}
+        >
+          <OverflowMenu
+            focusKey={`FAV_OVERFLOW_${item.content_type.toUpperCase()}_${item.content_id}`}
+            actions={overflowActions}
+            triggerLabel={`More actions for ${title}`}
+            placement="below"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/favorites/sortFavorites.test.ts
+++ b/src/features/favorites/sortFavorites.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  sortFavorites,
+  getFavoriteSortPref,
+  setFavoriteSortPref,
+} from "./sortFavorites";
+import type { FavoriteItem } from "../../api/schemas";
+
+function mk(
+  id: number,
+  name: string,
+  added_at: string,
+): FavoriteItem {
+  return {
+    id,
+    content_type: "vod",
+    content_id: id,
+    content_name: name,
+    content_icon: null,
+    category_name: null,
+    sort_order: id,
+    added_at,
+  };
+}
+
+describe("sortFavorites", () => {
+  const items: FavoriteItem[] = [
+    mk(1, "Charlie", "2026-01-03T00:00:00Z"),
+    mk(2, "alice", "2026-01-01T00:00:00Z"),
+    mk(3, "Bob", "2026-01-02T00:00:00Z"),
+  ];
+
+  it("sorts by recently added (newest first) by default", () => {
+    const sorted = sortFavorites(items, "added");
+    expect(sorted.map((i) => i.content_id)).toEqual([1, 3, 2]);
+  });
+
+  it("sorts alphabetically case-insensitive by name", () => {
+    const sorted = sortFavorites(items, "name");
+    expect(sorted.map((i) => i.content_name)).toEqual(["alice", "Bob", "Charlie"]);
+  });
+
+  it("does not mutate input", () => {
+    const original = [...items];
+    sortFavorites(items, "name");
+    expect(items).toEqual(original);
+  });
+});
+
+describe("favoriteSortPref storage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("default is 'added' when unset", () => {
+    expect(getFavoriteSortPref()).toBe("added");
+  });
+
+  it("round-trips values", () => {
+    setFavoriteSortPref("name");
+    expect(getFavoriteSortPref()).toBe("name");
+    setFavoriteSortPref("added");
+    expect(getFavoriteSortPref()).toBe("added");
+  });
+
+  it("returns default on garbage value", () => {
+    window.localStorage.setItem("sv_sort_favorites", "garbage");
+    expect(getFavoriteSortPref()).toBe("added");
+  });
+});

--- a/src/features/favorites/sortFavorites.ts
+++ b/src/features/favorites/sortFavorites.ts
@@ -1,0 +1,52 @@
+/**
+ * sortFavorites — shared sort helper for /favorites.
+ *
+ * Two sort modes persisted via `sv_sort_favorites` localStorage key.
+ */
+import type { FavoriteItem } from "../../api/schemas";
+
+export type FavoriteSortKey = "added" | "name";
+
+const STORAGE_KEY = "sv_sort_favorites";
+const DEFAULT_SORT: FavoriteSortKey = "added";
+
+export function getFavoriteSortPref(): FavoriteSortKey {
+  if (typeof window === "undefined") return DEFAULT_SORT;
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    return v === "name" || v === "added" ? v : DEFAULT_SORT;
+  } catch {
+    return DEFAULT_SORT;
+  }
+}
+
+export function setFavoriteSortPref(v: FavoriteSortKey): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, v);
+  } catch {
+    // no-op
+  }
+}
+
+export function sortFavorites(
+  items: readonly FavoriteItem[],
+  key: FavoriteSortKey,
+): FavoriteItem[] {
+  const arr = [...items];
+  if (key === "name") {
+    arr.sort((a, b) => {
+      const an = (a.content_name ?? "").toLocaleLowerCase();
+      const bn = (b.content_name ?? "").toLocaleLowerCase();
+      return an < bn ? -1 : an > bn ? 1 : 0;
+    });
+  } else {
+    // Recently added first
+    arr.sort((a, b) => {
+      const at = Date.parse(a.added_at) || 0;
+      const bt = Date.parse(b.added_at) || 0;
+      return bt - at;
+    });
+  }
+  return arr;
+}

--- a/src/features/movies/MovieGrid.tsx
+++ b/src/features/movies/MovieGrid.tsx
@@ -32,15 +32,15 @@ export interface MovieGridProps {
 }
 
 function columnsForWidth(width: number): number {
-  // Sized for TV viewports: Fire TV Silk reports ~1280 CSS px at 1080p (DPR=2)
-  // and ~1600-1920 at 4K; posters were too large on TV at prior column counts
-  // (reported 2026-04-23 from a real Fire TV). Bump each tier by one so cards
-  // settle at ~200-220 px wide on TV, matching Netflix/Prime density.
-  if (width >= 1600) return 7;
-  if (width >= 1280) return 6;
-  if (width >= 960) return 5;
-  if (width >= 640) return 4;
-  return 3;
+  // Card-density tuned for 10-foot readability. On a real Fire TV (reported
+  // 2026-04-24) 6 cols at 1280 CSS px felt oversized relative to the TV
+  // type scale; dropping one column per tier lands cards at ~250-280 px wide,
+  // which matches Netflix / Prime grid density on 1080p TVs.
+  if (width >= 1600) return 6;
+  if (width >= 1280) return 5;
+  if (width >= 960) return 4;
+  if (width >= 640) return 3;
+  return 2;
 }
 
 function useResponsiveColumns(): number {

--- a/src/features/search/SearchKindChips.tsx
+++ b/src/features/search/SearchKindChips.tsx
@@ -1,0 +1,87 @@
+/**
+ * SearchKindChips — All · Live · Movies · Series segmented control.
+ *
+ * Client-side section filter for the Search route. Does NOT re-fetch;
+ * just hides/shows sections. Session-only (no persistence) per the
+ * search-favorites UX spec.
+ */
+import type { RefObject } from "react";
+import { useFocusable } from "@noriginmedia/norigin-spatial-navigation";
+
+export type SearchKind = "all" | "live" | "vod" | "series";
+
+interface ChipProps {
+  kind: SearchKind;
+  label: string;
+  isActive: boolean;
+  onSelect: () => void;
+}
+
+function Chip({ kind, label, isActive, onSelect }: ChipProps) {
+  const { ref, focused } = useFocusable<HTMLButtonElement>({
+    focusKey: `SEARCH_KIND_${kind.toUpperCase()}`,
+    onEnterPress: onSelect,
+  });
+  const active = isActive || focused;
+  return (
+    <button
+      ref={ref as RefObject<HTMLButtonElement>}
+      type="button"
+      role="radio"
+      aria-checked={isActive}
+      onClick={onSelect}
+      className="focus-ring"
+      style={{
+        padding: "var(--space-2) var(--space-4)",
+        borderRadius: "var(--radius-sm)",
+        border: "none",
+        background: active ? "var(--accent-copper)" : "var(--bg-surface)",
+        color: active ? "var(--bg-base)" : "var(--text-primary)",
+        fontSize: "var(--text-label-size)",
+        letterSpacing: "var(--text-label-tracking)",
+        textTransform: "uppercase",
+        cursor: "pointer",
+        transition:
+          "background var(--motion-focus), color var(--motion-focus)",
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+const CHIPS: { kind: SearchKind; label: string }[] = [
+  { kind: "all", label: "All" },
+  { kind: "vod", label: "Movies" },
+  { kind: "series", label: "Series" },
+  { kind: "live", label: "Live" },
+];
+
+interface SearchKindChipsProps {
+  value: SearchKind;
+  onChange: (kind: SearchKind) => void;
+}
+
+export function SearchKindChips({ value, onChange }: SearchKindChipsProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Filter search results by type"
+      style={{
+        display: "flex",
+        gap: "var(--space-2)",
+        padding: "0 var(--space-6) var(--space-4)",
+      }}
+    >
+      {CHIPS.map((c) => (
+        <Chip
+          key={c.kind}
+          kind={c.kind}
+          label={c.label}
+          isActive={value === c.kind}
+          onSelect={() => onChange(c.kind)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/features/search/SearchResultsSection.tsx
+++ b/src/features/search/SearchResultsSection.tsx
@@ -7,13 +7,21 @@
  *   - live    → openPlayer directly
  *   - vod     → openPlayer directly
  *
- * Lazy images with --bg-surface placeholder for missing icons.
+ * ⋯ OverflowMenu (focus-only render) gives the user Play / Add-to-favorites /
+ * More-info reachability so they can favorite a hit without playing it first.
  */
 import type { RefObject } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useFocusable } from "@noriginmedia/norigin-spatial-navigation";
+import { OverflowMenu } from "../../components/OverflowMenu";
 import { usePlayerOpener } from "../../player";
-import type { CatalogItem } from "../../api/schemas";
+import {
+  addFavorite,
+  removeFavorite,
+  isFavorited,
+} from "../../api/favorites";
+import type { CatalogItem, ContentType } from "../../api/schemas";
 import type { PlayerKind } from "../../player/PlayerProvider";
 
 // Map backend content type → player kind. "vod" is the VOD movies shelf.
@@ -22,6 +30,12 @@ import type { PlayerKind } from "../../player/PlayerProvider";
 const KIND_MAP: Record<string, PlayerKind> = {
   live: "live",
   vod: "vod",
+};
+
+const FAVORITE_TYPE: Record<CatalogItem["type"], ContentType> = {
+  live: "channel",
+  vod: "vod",
+  series: "series",
 };
 
 interface SearchCardProps {
@@ -33,9 +47,11 @@ function SearchCard({ item }: SearchCardProps) {
   const navigate = useNavigate();
   const focusKey = `SEARCH_RESULT_${item.type.toUpperCase()}_${item.id}`;
 
+  const favoriteType = FAVORITE_TYPE[item.type];
+  const numericId = Number(item.id);
+
   const activateItem = () => {
     if (item.type === "series") {
-      // Series hits go to the detail page — not the player.
       navigate(`/series/${encodeURIComponent(item.id)}`);
       return;
     }
@@ -48,81 +64,148 @@ function SearchCard({ item }: SearchCardProps) {
     onEnterPress: activateItem,
   });
 
+  const [favorited, setFavorited] = useState(() =>
+    Number.isFinite(numericId) ? isFavorited(numericId, favoriteType) : false,
+  );
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === "sv_favorites" && Number.isFinite(numericId)) {
+        setFavorited(isFavorited(numericId, favoriteType));
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, [numericId, favoriteType]);
+
+  const overflowActions = useMemo(
+    () => [
+      {
+        label: item.type === "series" ? "Open" : "Play",
+        onSelect: activateItem,
+      },
+      favorited
+        ? {
+            label: "Remove from favorites",
+            onSelect: () => {
+              if (Number.isFinite(numericId)) {
+                void removeFavorite(numericId, favoriteType);
+                setFavorited(false);
+              }
+            },
+          }
+        : {
+            label: "Add to favorites",
+            onSelect: () => {
+              if (!Number.isFinite(numericId)) return;
+              void addFavorite(numericId, {
+                content_type: favoriteType,
+                content_name: item.name,
+                ...(item.icon ? { content_icon: item.icon } : {}),
+              });
+              setFavorited(true);
+            },
+          },
+    ],
+    // activateItem closes over navigate/openPlayer which are hook-stable;
+    // favorited toggles re-memo naturally.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [favorited, item, numericId, favoriteType],
+  );
+
   return (
-    <button
-      ref={ref as RefObject<HTMLButtonElement>}
-      type="button"
-      onClick={activateItem}
-      aria-label={item.name}
-      style={{
-        flex: "0 0 auto",
-        width: 160,
-        background: focused ? "var(--bg-elevated)" : "var(--bg-surface)",
-        border: focused
-          ? "2px solid var(--accent-copper)"
-          : "2px solid transparent",
-        borderRadius: "var(--radius-sm)",
-        color: "var(--text-primary)",
-        cursor: "pointer",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        padding: "var(--space-3)",
-        gap: "var(--space-2)",
-        textAlign: "center",
-        // Avoid transition-all — only transition the properties we need
-        transition:
-          "background var(--motion-focus), border-color var(--motion-focus)",
-      }}
-    >
-      <div
+    <div style={{ position: "relative", flex: "0 0 auto" }}>
+      <button
+        ref={ref as RefObject<HTMLButtonElement>}
+        type="button"
+        onClick={activateItem}
+        aria-label={item.name}
         style={{
-          width: 120,
-          height: 90,
-          background: "var(--bg-surface)",
+          width: 160,
+          background: focused ? "var(--bg-elevated)" : "var(--bg-surface)",
+          border: focused
+            ? "2px solid var(--accent-copper)"
+            : "2px solid transparent",
           borderRadius: "var(--radius-sm)",
-          overflow: "hidden",
-          flexShrink: 0,
+          color: "var(--text-primary)",
+          cursor: "pointer",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          padding: "var(--space-3)",
+          gap: "var(--space-2)",
+          textAlign: "center",
+          transition:
+            "background var(--motion-focus), border-color var(--motion-focus)",
         }}
       >
-        {item.icon ? (
-          <img
-            src={item.icon}
-            alt=""
-            loading="lazy"
-            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+        <div
+          style={{
+            width: 120,
+            height: 90,
+            background: "var(--bg-surface)",
+            borderRadius: "var(--radius-sm)",
+            overflow: "hidden",
+            flexShrink: 0,
+          }}
+        >
+          {item.icon ? (
+            <img
+              src={item.icon}
+              alt=""
+              loading="lazy"
+              style={{ width: "100%", height: "100%", objectFit: "cover" }}
+            />
+          ) : (
+            <div
+              aria-hidden="true"
+              style={{
+                width: "100%",
+                height: "100%",
+                background: "var(--bg-elevated)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: 32,
+                color: "var(--text-secondary)",
+              }}
+            >
+              {item.type === "live" ? "●" : item.type === "vod" ? "▶" : "⊞"}
+            </div>
+          )}
+        </div>
+        <span
+          style={{
+            fontSize: "var(--text-label-size)",
+            overflow: "hidden",
+            display: "-webkit-box",
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: "vertical",
+            lineHeight: 1.3,
+          }}
+        >
+          {item.name}
+        </span>
+      </button>
+
+      {focused && Number.isFinite(numericId) && (
+        <div
+          style={{
+            position: "absolute",
+            top: 4,
+            right: 4,
+            zIndex: 10,
+          }}
+        >
+          <OverflowMenu
+            focusKey={`SEARCH_OVERFLOW_${item.type.toUpperCase()}_${item.id}`}
+            actions={overflowActions}
+            triggerLabel={`More actions for ${item.name}`}
+            placement="below"
           />
-        ) : (
-          <div
-            aria-hidden="true"
-            style={{
-              width: "100%",
-              height: "100%",
-              background: "var(--bg-elevated)",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontSize: 32,
-              color: "var(--text-secondary)",
-            }}
-          >
-            {item.type === "live" ? "●" : item.type === "vod" ? "▶" : "⊞"}
-          </div>
-        )}
-      </div>
-      <span
-        style={{
-          fontSize: "var(--text-label-size)",
-          overflow: "hidden",
-          display: "-webkit-box",
-          WebkitLineClamp: 2,
-          WebkitBoxOrient: "vertical",
-          lineHeight: 1.3,
-        }}
-      >
-        {item.name}
-      </span>
-    </button>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/features/series/SeriesGrid.tsx
+++ b/src/features/series/SeriesGrid.tsx
@@ -67,7 +67,7 @@ export function SeriesGrid({
       style={{
         display: "grid",
         gridTemplateColumns:
-          "repeat(auto-fill, minmax(min(160px, 100%), 1fr))",
+          "repeat(auto-fill, minmax(min(220px, 100%), 1fr))",
         gap: "var(--space-4)",
         padding: "var(--space-4) var(--space-6)",
       }}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,17 @@ import { initSpatialNav } from "./nav/spatialNav";
 // Must run before createRoot so norigin is ready when React mounts.
 initSpatialNav();
 
+// TV platform sniff — Fire TV Silk identifies via "Silk" or "AFT…" in UA.
+// Setting data-tv on <html> lets tokens.css apply the 10-foot type scale
+// before first paint. Desktop browsers stay on desktop scale.
+(() => {
+  const ua = navigator.userAgent || "";
+  const isTv = /Silk|AFT/i.test(ua);
+  if (isTv) {
+    document.documentElement.setAttribute("data-tv", "true");
+  }
+})();
+
 // Task 2.4: expose setFocus on window in dev/test builds so Playwright can
 // prime norigin's focus tree (DOM focus alone doesn't update norigin's internal
 // lastFocused pointer). Guarded by import.meta.env.DEV so prod bundles

--- a/src/routes/FavoritesRoute.test.tsx
+++ b/src/routes/FavoritesRoute.test.tsx
@@ -1,13 +1,15 @@
 /**
- * FavoritesRoute tests (Phase 8)
+ * FavoritesRoute tests.
  *
  * Covers:
  *  - Loading state shows skeleton
- *  - Empty state shows empty message
- *  - Populated state shows items grouped by type
+ *  - Empty state (all zero) shows whole-page empty
+ *  - Populated + empty-sections mixed state shows per-section empty + items
  *  - CONTENT_AREA_FAVORITES focusKey registered
+ *  - Sort toolbar renders when not empty
+ *  - Remove-from-favorites path fires toggle
  */
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import React from "react";
 import type { FavoriteItem } from "../api/schemas";
@@ -32,19 +34,24 @@ vi.mock("@noriginmedia/norigin-spatial-navigation", () => ({
   setFocus: vi.fn(),
 }));
 
+const mockToggle = vi.hoisted(() => vi.fn());
 const mockUseFavorites = vi.hoisted(() =>
   vi.fn(() => ({
     favorites: [] as FavoriteItem[],
     loading: false,
     error: null,
     isFav: vi.fn(() => true),
-    toggle: vi.fn(),
+    toggle: mockToggle,
     reload: vi.fn(),
   })),
 );
 
 vi.mock("../features/favorites/useFavorites", () => ({
   useFavorites: mockUseFavorites,
+}));
+
+vi.mock("../player", () => ({
+  usePlayerOpener: () => ({ openPlayer: vi.fn() }),
 }));
 
 // React Router mock
@@ -79,12 +86,13 @@ const mockMovie: FavoriteItem = {
 describe("FavoritesRoute", () => {
   beforeEach(() => {
     useFocusableSpy.mockClear();
+    mockToggle.mockClear();
     mockUseFavorites.mockReturnValue({
       favorites: [],
       loading: false,
       error: null,
       isFav: vi.fn(() => true),
-      toggle: vi.fn(),
+      toggle: mockToggle,
       reload: vi.fn(),
     });
   });
@@ -95,7 +103,7 @@ describe("FavoritesRoute", () => {
       loading: true,
       error: null,
       isFav: vi.fn(() => false),
-      toggle: vi.fn(),
+      toggle: mockToggle,
       reload: vi.fn(),
     });
 
@@ -103,9 +111,32 @@ describe("FavoritesRoute", () => {
     expect(screen.getByLabelText(/loading favorites/i)).toBeInTheDocument();
   });
 
-  it("shows empty state when no favorites", () => {
+  it("shows whole-page empty when all three sections are empty", () => {
     render(<FavoritesRoute />);
     expect(screen.getByLabelText(/no favorites yet/i)).toBeInTheDocument();
+    // Sort toolbar must NOT render when whole-page empty
+    expect(screen.queryByRole("toolbar")).not.toBeInTheDocument();
+  });
+
+  it("renders per-section empty for empty sections when at least one has items", async () => {
+    mockUseFavorites.mockReturnValueOnce({
+      favorites: [mockMovie],
+      loading: false,
+      error: null,
+      isFav: vi.fn(() => true),
+      toggle: mockToggle,
+      reload: vi.fn(),
+    });
+
+    render(<FavoritesRoute />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Inception")).toBeInTheDocument();
+    });
+
+    // Live Channels empty label must render
+    expect(screen.getByText(/no favorite channels yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/no favorite series yet/i)).toBeInTheDocument();
   });
 
   it("renders items grouped by section when populated", async () => {
@@ -114,7 +145,7 @@ describe("FavoritesRoute", () => {
       loading: false,
       error: null,
       isFav: vi.fn(() => true),
-      toggle: vi.fn(),
+      toggle: mockToggle,
       reload: vi.fn(),
     });
 
@@ -125,8 +156,26 @@ describe("FavoritesRoute", () => {
       expect(screen.getByText("Inception")).toBeInTheDocument();
     });
 
-    expect(screen.getByRole("region", { name: /live channels/i })).toBeInTheDocument();
-    expect(screen.getByRole("region", { name: /movies/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: /live channels/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /^movies$/i })).toBeInTheDocument();
+  });
+
+  it("renders sort toolbar with Recently added + A–Z when not empty", () => {
+    mockUseFavorites.mockReturnValueOnce({
+      favorites: [mockMovie],
+      loading: false,
+      error: null,
+      isFav: vi.fn(() => true),
+      toggle: mockToggle,
+      reload: vi.fn(),
+    });
+
+    render(<FavoritesRoute />);
+    expect(screen.getByRole("toolbar", { name: /favorites sort/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /recently added/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /a–z/i })).toBeInTheDocument();
   });
 
   it("renders page heading", () => {
@@ -141,5 +190,23 @@ describe("FavoritesRoute", () => {
     expect(useFocusableSpy).toHaveBeenCalledWith(
       expect.objectContaining({ focusKey: "CONTENT_AREA_FAVORITES" }),
     );
+  });
+
+  it("clicking a sort button persists via toolbar state", () => {
+    // Keep returning items across re-renders — mockReturnValue (not Once)
+    // because the state change on click triggers another useFavorites call.
+    mockUseFavorites.mockReturnValue({
+      favorites: [mockMovie],
+      loading: false,
+      error: null,
+      isFav: vi.fn(() => true),
+      toggle: mockToggle,
+      reload: vi.fn(),
+    });
+
+    render(<FavoritesRoute />);
+    const azBtn = screen.getByRole("button", { name: /a–z/i });
+    fireEvent.click(azBtn);
+    expect(azBtn.getAttribute("aria-pressed")).toBe("true");
   });
 });

--- a/src/routes/FavoritesRoute.tsx
+++ b/src/routes/FavoritesRoute.tsx
@@ -1,133 +1,80 @@
 /**
- * FavoritesRoute — /favorites screen (Phase 8).
+ * FavoritesRoute — /favorites screen.
  *
- * Shows all favorited items grouped by type:
- *   1. Live Channels
- *   2. Movies (VOD)
- *   3. Series
+ * Rebuilt 2026-04-24 per UX-lead spec (search-favorites session):
+ *   - Three horizontal rails: Live Channels · Movies · Series
+ *   - Cards are 2:3 FavoritePosterCard (visual parity with MovieCard/SeriesCard)
+ *   - Per-card activation: Live → player, VOD → player, Series → /series/:id
+ *   - Per-card OverflowMenu (Play / More info for VOD / Remove from favorites)
+ *   - Sort toolbar (Recently added · Alphabetical), persisted
+ *   - Per-section empty states (only a whole-page empty if ALL sections empty)
  *
- * Each section is a horizontal row of focusable cards. D-pad Left/Right
- * navigates within a row; Up/Down moves between rows. Enter on a card
- * navigates to the content (stub: navigate(-1) back to the source route
- * in Phase 8; deep-link in Phase 9).
+ * Layout note: no LanguageRail. Favorites are cross-language by design.
  *
- * Dock: accessed via Settings → Favorites. The BottomDock keeps its
- * 5-item shape unchanged. See PR body for rationale.
+ * MUST PRESERVE: CONTENT_AREA_FAVORITES focus key + FocusContext — load-bearing
+ * for BottomDock's setFocus("CONTENT_AREA_FAVORITES") on Esc routing.
  */
 import type { RefObject } from "react";
-import { useCallback } from "react";
-import { useNavigate } from "react-router-dom";
+import { useCallback, useMemo, useState } from "react";
 import {
   useFocusable,
   FocusContext,
 } from "@noriginmedia/norigin-spatial-navigation";
 import { useFavorites } from "../features/favorites/useFavorites";
-import { FavoriteToggle } from "../features/favorites/FavoriteToggle";
+import { FavoritePosterCard } from "../features/favorites/FavoritePosterCard";
+import { MovieDetailSheet } from "../features/movies/MovieDetailSheet";
+import { usePlayerOpener } from "../player";
+import {
+  getFavoriteSortPref,
+  setFavoriteSortPref,
+  sortFavorites,
+  type FavoriteSortKey,
+} from "../features/favorites/sortFavorites";
 import { Skeleton } from "../primitives/Skeleton";
 import { ErrorShell } from "../primitives/ErrorShell";
-import type { FavoriteItem, ContentType } from "../api/schemas";
+import type { FavoriteItem, ContentType, VodStream } from "../api/schemas";
 
-// ─── Section row ─────────────────────────────────────────────────────────────
+const SORT_OPTIONS: { id: FavoriteSortKey; label: string }[] = [
+  { id: "added", label: "Recently added" },
+  { id: "name", label: "A–Z" },
+];
 
-function FavoriteCard({
-  item,
-  onUnfav,
-}: {
-  item: FavoriteItem;
-  onUnfav: (id: number, type: ContentType) => void;
-}) {
-  const focusKey = `FAV_CARD_${item.content_type.toUpperCase()}_${item.content_id}`;
-  const { ref, focused } = useFocusable({
-    focusKey,
-    onEnterPress: () => {
-      // Phase 8 stub: actual deep-link in Phase 9.
-    },
+interface SortButtonProps {
+  id: FavoriteSortKey;
+  label: string;
+  isActive: boolean;
+  onSelect: () => void;
+}
+
+function SortButton({ id, label, isActive, onSelect }: SortButtonProps) {
+  const { ref, focused } = useFocusable<HTMLButtonElement>({
+    focusKey: `FAV_SORT_${id.toUpperCase()}`,
+    onEnterPress: onSelect,
   });
-
+  const active = isActive || focused;
   return (
-    <li
+    <button
+      ref={ref as RefObject<HTMLButtonElement>}
+      type="button"
+      aria-pressed={isActive}
+      onClick={onSelect}
+      className="focus-ring"
       style={{
-        listStyle: "none",
-        flexShrink: 0,
-        width: 160,
-        display: "flex",
-        flexDirection: "column",
-        gap: "var(--space-2)",
+        padding: "var(--space-2) var(--space-4)",
+        borderRadius: "var(--radius-sm)",
+        border: "none",
+        background: active ? "var(--accent-copper)" : "var(--bg-surface)",
+        color: active ? "var(--bg-base)" : "var(--text-primary)",
+        fontSize: "var(--text-label-size)",
+        letterSpacing: "var(--text-label-tracking)",
+        textTransform: "uppercase",
+        cursor: "pointer",
+        transition:
+          "background var(--motion-focus), color var(--motion-focus)",
       }}
     >
-      <div
-        ref={ref as RefObject<HTMLDivElement>}
-        tabIndex={-1}
-        aria-label={item.content_name ?? "Favorite item"}
-        style={{
-          background: focused ? "var(--accent-copper)" : "var(--bg-surface)",
-          borderRadius: "var(--radius-md)",
-          padding: "var(--space-4)",
-          display: "flex",
-          flexDirection: "column",
-          gap: "var(--space-2)",
-          minHeight: 100,
-          position: "relative",
-          transition:
-            "background var(--motion-focus), color var(--motion-focus)",
-        }}
-      >
-        {/* Star toggle — focusable sibling inside the card */}
-        <div style={{ position: "absolute", top: 6, right: 6 }}>
-          <FavoriteToggle
-            contentId={item.content_id}
-            contentType={item.content_type}
-            isFavorited={true}
-            onToggle={() => onUnfav(item.content_id, item.content_type)}
-            compact
-          />
-        </div>
-
-        {/* Poster / icon placeholder */}
-        <div
-          aria-hidden="true"
-          style={{
-            fontSize: 32,
-            lineHeight: 1,
-            color: focused
-              ? "var(--bg-base)"
-              : "var(--text-secondary)",
-          }}
-        >
-          {item.content_type === "channel"
-            ? "●"
-            : item.content_type === "vod"
-              ? "▶"
-              : "⊞"}
-        </div>
-
-        <p
-          style={{
-            margin: 0,
-            fontSize: "var(--text-label-size)",
-            letterSpacing: "var(--text-label-tracking)",
-            color: focused ? "var(--bg-base)" : "var(--text-primary)",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {item.content_name ?? `Item ${item.content_id}`}
-        </p>
-        {item.category_name && (
-          <p
-            style={{
-              margin: 0,
-              fontSize: "var(--text-label-size)",
-              color: focused ? "var(--bg-base)" : "var(--text-secondary)",
-              opacity: 0.8,
-            }}
-          >
-            {item.category_name}
-          </p>
-        )}
-      </div>
-    </li>
+      {label}
+    </button>
   );
 }
 
@@ -135,84 +82,148 @@ function FavoriteSection({
   title,
   items,
   focusKeyPrefix,
-  onUnfav,
+  emptyLabel,
+  onRemove,
+  onMoreInfo,
 }: {
   title: string;
   items: FavoriteItem[];
   focusKeyPrefix: string;
-  onUnfav: (id: number, type: ContentType) => void;
+  emptyLabel: string;
+  onRemove: (id: number, type: ContentType) => void;
+  onMoreInfo?: (item: FavoriteItem) => void;
 }) {
   const { ref, focusKey } = useFocusable({
     focusKey: `FAV_ROW_${focusKeyPrefix}`,
   });
 
-  if (items.length === 0) return null;
-
   return (
     <FocusContext.Provider value={focusKey}>
-      <section aria-label={title} ref={ref as RefObject<HTMLElement>}>
+      <section
+        aria-label={title}
+        ref={ref as RefObject<HTMLElement>}
+        style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}
+      >
         <h2
           style={{
             fontSize: "var(--text-title-size)",
             color: "var(--text-primary)",
-            margin: "0 0 var(--space-3) 0",
+            margin: 0,
             fontWeight: 600,
           }}
         >
           {title}
+          <span
+            style={{
+              marginLeft: "var(--space-3)",
+              color: "var(--text-secondary)",
+              fontSize: "var(--text-label-size)",
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
+            {items.length}
+          </span>
         </h2>
-        <ul
-          aria-label={`${title} favorites`}
-          style={{
-            display: "flex",
-            gap: "var(--space-4)",
-            overflowX: "auto",
-            padding: "var(--space-2) 0",
-            margin: 0,
-            listStyle: "none",
-            // No scroll-snap or backdrop-filter per constraints.
-          }}
-        >
-          {items.map((item) => (
-            <FavoriteCard
-              key={`${item.content_type}-${item.content_id}`}
-              item={item}
-              onUnfav={onUnfav}
-            />
-          ))}
-        </ul>
+        {items.length === 0 ? (
+          <p
+            role="status"
+            style={{
+              margin: 0,
+              padding: "var(--space-4)",
+              background: "var(--bg-surface)",
+              borderRadius: "var(--radius-sm)",
+              color: "var(--text-secondary)",
+              fontSize: "var(--text-body-size)",
+            }}
+          >
+            {emptyLabel}
+          </p>
+        ) : (
+          <ul
+            aria-label={`${title} favorites`}
+            style={{
+              display: "flex",
+              gap: "var(--space-4)",
+              overflowX: "auto",
+              padding: "var(--space-2) 0",
+              margin: 0,
+              listStyle: "none",
+            }}
+          >
+            {items.map((item) => (
+              <li
+                key={`${item.content_type}-${item.content_id}`}
+                style={{ listStyle: "none", flexShrink: 0, width: 160 }}
+              >
+                <FavoritePosterCard
+                  item={item}
+                  onRemove={onRemove}
+                  {...(onMoreInfo ? { onMoreInfo } : {})}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
       </section>
     </FocusContext.Provider>
   );
 }
-
-// ─── Route ────────────────────────────────────────────────────────────────────
 
 export function FavoritesRoute() {
   const { ref, focusKey } = useFocusable({
     focusKey: "CONTENT_AREA_FAVORITES",
     focusable: false,
     trackChildren: true,
-    // Absorb dead-direction bubble-ups at the route's outer edges; Down
-    // stays open so rows can still reach BottomDock. See
-    // streamvault-v3-focus-vanish-bug.md.
     isFocusBoundary: true,
     focusBoundaryDirections: ["left", "right", "up"],
   });
-  const navigate = useNavigate();
-  const { favorites, loading, error, toggle, reload } = useFavorites();
 
-  const handleUnfav = useCallback(
+  const { favorites, loading, error, toggle, reload } = useFavorites();
+  const { openPlayer } = usePlayerOpener();
+  const [sort, setSort] = useState<FavoriteSortKey>(() => getFavoriteSortPref());
+  const [sheetItem, setSheetItem] = useState<FavoriteItem | null>(null);
+
+  const handleRemove = useCallback(
     async (id: number, type: ContentType) => {
       await toggle(id, type, {});
     },
     [toggle],
   );
 
-  const channels = favorites.filter((f) => f.content_type === "channel");
-  const movies = favorites.filter((f) => f.content_type === "vod");
-  const series = favorites.filter((f) => f.content_type === "series");
-  const isEmpty = channels.length === 0 && movies.length === 0 && series.length === 0;
+  const handleSortChange = useCallback((next: FavoriteSortKey) => {
+    setSort(next);
+    setFavoriteSortPref(next);
+  }, []);
+
+  const handleMoreInfo = useCallback((item: FavoriteItem) => {
+    if (item.content_type !== "vod") return;
+    setSheetItem(item);
+  }, []);
+
+  const { channels, movies, series } = useMemo(() => {
+    const sorted = sortFavorites(favorites, sort);
+    return {
+      channels: sorted.filter((f) => f.content_type === "channel"),
+      movies: sorted.filter((f) => f.content_type === "vod"),
+      series: sorted.filter((f) => f.content_type === "series"),
+    };
+  }, [favorites, sort]);
+
+  const isEmpty =
+    channels.length === 0 && movies.length === 0 && series.length === 0;
+
+  // Adapt a favorite VOD into the VodStream shape MovieDetailSheet expects.
+  // We only need id + name + icon; everything else is optional on VodStream.
+  const sheetStream: VodStream | null = useMemo(() => {
+    if (!sheetItem) return null;
+    return {
+      id: String(sheetItem.content_id),
+      name: sheetItem.content_name ?? `Item ${sheetItem.content_id}`,
+      type: "vod",
+      categoryId: "",
+      ...(sheetItem.content_icon ? { icon: sheetItem.content_icon } : {}),
+    } as VodStream;
+  }, [sheetItem]);
 
   return (
     <FocusContext.Provider value={focusKey}>
@@ -226,19 +237,50 @@ export function FavoritesRoute() {
           padding: "var(--space-6)",
         }}
       >
-        {/* Back button */}
-        <BackButton onBack={() => navigate(-1)} />
-
         <h1
           style={{
             fontSize: "var(--text-title-size)",
             color: "var(--text-primary)",
-            margin: "0 0 var(--space-6) 0",
+            margin: "0 0 var(--space-4) 0",
             fontWeight: 700,
           }}
         >
           My Favorites
         </h1>
+
+        {!loading && !error && !isEmpty && (
+          <div
+            role="toolbar"
+            aria-label="Favorites sort"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "var(--space-2)",
+              padding: "var(--space-2) 0 var(--space-4)",
+            }}
+          >
+            <span
+              style={{
+                fontSize: "var(--text-label-size)",
+                letterSpacing: "var(--text-label-tracking)",
+                textTransform: "uppercase",
+                color: "var(--text-secondary)",
+                marginRight: "var(--space-2)",
+              }}
+            >
+              Sort
+            </span>
+            {SORT_OPTIONS.map((opt) => (
+              <SortButton
+                key={opt.id}
+                id={opt.id}
+                label={opt.label}
+                isActive={sort === opt.id}
+                onSelect={() => handleSortChange(opt.id)}
+              />
+            ))}
+          </div>
+        )}
 
         {loading && (
           <div
@@ -247,7 +289,7 @@ export function FavoritesRoute() {
             style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}
           >
             {[1, 2, 3].map((i) => (
-              <Skeleton key={i} width="100%" height="140px" />
+              <Skeleton key={i} width="100%" height="220px" />
             ))}
           </div>
         )}
@@ -261,71 +303,58 @@ export function FavoritesRoute() {
           />
         )}
 
-        {!loading && !error && isEmpty && (
-          <EmptyState />
-        )}
+        {!loading && !error && isEmpty && <WholePageEmpty />}
 
         {!loading && !error && !isEmpty && (
           <div
-            style={{ display: "flex", flexDirection: "column", gap: "var(--space-8)" }}
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "var(--space-8)",
+            }}
           >
             <FavoriteSection
               title="Live Channels"
               items={channels}
               focusKeyPrefix="CHANNELS"
-              onUnfav={handleUnfav}
+              emptyLabel="No favorite channels yet. Press ⋯ → Add to favorites on any channel."
+              onRemove={handleRemove}
             />
             <FavoriteSection
               title="Movies"
               items={movies}
               focusKeyPrefix="MOVIES"
-              onUnfav={handleUnfav}
+              emptyLabel="No favorite movies yet. Press ⋯ → Add to favorites on any movie."
+              onRemove={handleRemove}
+              onMoreInfo={handleMoreInfo}
             />
             <FavoriteSection
               title="Series"
               items={series}
               focusKeyPrefix="SERIES"
-              onUnfav={handleUnfav}
+              emptyLabel="No favorite series yet. Press ⋯ → Add to favorites on any series."
+              onRemove={handleRemove}
             />
           </div>
         )}
+
+        {sheetStream ? (
+          <MovieDetailSheet
+            key={sheetStream.id}
+            stream={sheetStream}
+            onClose={() => setSheetItem(null)}
+            onPlay={(s) => {
+              void openPlayer({ kind: "vod", id: s.id, title: s.name });
+              setSheetItem(null);
+            }}
+          />
+        ) : null}
       </main>
     </FocusContext.Provider>
   );
 }
 
-// ─── Sub-components ───────────────────────────────────────────────────────────
-
-function BackButton({ onBack }: { onBack: () => void }) {
-  const { ref, focused } = useFocusable({
-    focusKey: "FAV_BACK_BTN",
-    onEnterPress: onBack,
-  });
-  return (
-    <button
-      ref={ref as RefObject<HTMLButtonElement>}
-      type="button"
-      onClick={onBack}
-      className="focus-ring"
-      aria-label="Go back"
-      style={{
-        background: focused ? "var(--accent-copper)" : "var(--bg-surface)",
-        color: focused ? "var(--bg-base)" : "var(--text-secondary)",
-        border: "none",
-        borderRadius: "var(--radius-sm)",
-        padding: "var(--space-2) var(--space-4)",
-        cursor: "pointer",
-        fontSize: "var(--text-label-size)",
-        marginBottom: "var(--space-4)",
-        transition: "background var(--motion-focus), color var(--motion-focus)",
-      }}
-    >
-      ← Back
-    </button>
-  );
-}
-
-function EmptyState() {
+function WholePageEmpty() {
   return (
     <div
       role="status"
@@ -347,7 +376,7 @@ function EmptyState() {
           opacity: 0.7,
         }}
       >
-        Press the ★ on any channel, movie, or series to save it here.
+        Focus any card and press ⋯ → Add to favorites.
       </p>
     </div>
   );

--- a/src/routes/MoviesRoute.test.tsx
+++ b/src/routes/MoviesRoute.test.tsx
@@ -61,6 +61,10 @@ vi.mock("../api/vod", () => ({
 }));
 
 const openPlayerMock = vi.hoisted(() => vi.fn());
+const navigateMock = vi.hoisted(() => vi.fn());
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigateMock,
+}));
 vi.mock("../player/usePlayerOpener", () => ({
   usePlayerOpener: () => ({ openPlayer: openPlayerMock }),
 }));

--- a/src/routes/MoviesRoute.tsx
+++ b/src/routes/MoviesRoute.tsx
@@ -48,9 +48,11 @@ import {
 } from "../features/movies/sortMovies";
 import { isTierLocked } from "../features/movies/tierLockCache";
 import { LanguageRail } from "../components/LanguageRail";
+import { FindInput, FindTrigger, filterByQuery } from "../components/FindInput";
 import { ErrorShell } from "../primitives/ErrorShell";
 import { Skeleton } from "../primitives/Skeleton";
 import { EmptyStateWithLanguageSwitch } from "../primitives/EmptyStateWithLanguageSwitch";
+import { useNavigate } from "react-router-dom";
 import { useLangPref } from "../lib/useLangPref";
 import { fetchHistory } from "../api/history";
 import { fetchVodInfo } from "../api/vod";
@@ -121,8 +123,10 @@ export function MoviesRoute() {
   });
 
   const { openPlayer } = usePlayerOpener();
+  const navigate = useNavigate();
   const [lang, setLang] = useLangPref({ excludeSports: true });
   const [sort, setSort] = useState<MovieSortKey>(() => getSortPref());
+  const [findQuery, setFindQuery] = useState("");
   const [streams, setStreams] = useState<VodStream[]>([]);
   const [history, setHistory] = useState<HistoryItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -183,8 +187,17 @@ export function MoviesRoute() {
     };
   }, []);
 
-  // ─── Derived: sorted streams + history lookup map ────────────────────────
-  const sortedStreams = useMemo(() => sortStreams(streams, sort), [streams, sort]);
+  // ─── Derived: filter → sort → history lookup map ────────────────────────
+  // Filter applies first so the count reflects the visible set. Substring
+  // match on name only (list endpoint doesn't carry genre).
+  const filteredStreams = useMemo(
+    () => filterByQuery(streams, findQuery, (s) => s.name),
+    [streams, findQuery],
+  );
+  const sortedStreams = useMemo(
+    () => sortStreams(filteredStreams, sort),
+    [filteredStreams, sort],
+  );
 
   const historyByVodId = useMemo(() => {
     const map = new Map<string, HistoryItem>();
@@ -371,9 +384,23 @@ export function MoviesRoute() {
     (next: LangId) => {
       setTransitioning(true);
       setLang(next);
+      setFindQuery("");
     },
     [setLang],
   );
+
+  const handleFindTrigger = useCallback(() => {
+    setFocus("MOVIES_FIND_INPUT");
+  }, []);
+
+  const handleClearFilter = useCallback(() => {
+    setFindQuery("");
+    setFocus("MOVIES_FIND_TRIGGER");
+  }, []);
+
+  const handleSearchEverywhere = useCallback(() => {
+    navigate(`/search?q=${encodeURIComponent(findQuery)}`);
+  }, [navigate, findQuery]);
 
   const handleRetry = useCallback(() => {
     invalidateLanguageUnionCache();
@@ -434,6 +461,13 @@ export function MoviesRoute() {
 
             <LanguageRail value={lang} onChange={handleLangChange} />
 
+            <FindInput
+              value={findQuery}
+              onChange={setFindQuery}
+              surface="MOVIES"
+              placeholder="Find in Movies…"
+            />
+
             <div
               role="toolbar"
               aria-label="Movies sort"
@@ -479,6 +513,11 @@ export function MoviesRoute() {
                     onSelect={() => handleSortChange(opt.id)}
                   />
                 ))}
+                <FindTrigger
+                  surface="MOVIES"
+                  onSelect={handleFindTrigger}
+                  isActive={findQuery.length > 0}
+                />
               </div>
 
               <span
@@ -507,7 +546,9 @@ export function MoviesRoute() {
                 ) : null}
                 {transitioning
                   ? `Loading ${langLabel(lang) || "all"} movies…`
-                  : `${sortedStreams.length.toLocaleString()} movies`}
+                  : findQuery.trim().length > 0
+                    ? `${sortedStreams.length.toLocaleString()} of ${streams.length.toLocaleString()} movies`
+                    : `${sortedStreams.length.toLocaleString()} movies`}
               </span>
             </div>
             <style>{`
@@ -530,12 +571,20 @@ export function MoviesRoute() {
               aria-busy={transitioning || undefined}
             >
               {sortedStreams.length === 0 && !transitioning ? (
-                <EmptyStateWithLanguageSwitch
-                  currentLang={lang}
-                  onSwitch={setLang}
-                  headline={`No ${langLabel(lang)} movies in this catalog.`}
-                  message="The provider hasn't categorised any movies this way. Try another language."
-                />
+                findQuery.trim().length > 0 ? (
+                  <FindEmptyState
+                    query={findQuery}
+                    onClear={handleClearFilter}
+                    onSearchEverywhere={handleSearchEverywhere}
+                  />
+                ) : (
+                  <EmptyStateWithLanguageSwitch
+                    currentLang={lang}
+                    onSwitch={setLang}
+                    headline={`No ${langLabel(lang)} movies in this catalog.`}
+                    message="The provider hasn't categorised any movies this way. Try another language."
+                  />
+                )
               ) : (
                 <MovieGrid
                   streams={sortedStreams}
@@ -560,6 +609,76 @@ export function MoviesRoute() {
         ) : null}
       </main>
     </FocusContext.Provider>
+  );
+}
+
+function FindEmptyState({
+  query,
+  onClear,
+  onSearchEverywhere,
+}: {
+  query: string;
+  onClear: () => void;
+  onSearchEverywhere: () => void;
+}) {
+  const { ref: clearRef, focused: clearFocused } = useFocusable<HTMLButtonElement>({
+    focusKey: "MOVIES_FIND_EMPTY_CLEAR",
+    onEnterPress: onClear,
+  });
+  const { ref: goRef, focused: goFocused } = useFocusable<HTMLButtonElement>({
+    focusKey: "MOVIES_FIND_EMPTY_GO",
+    onEnterPress: onSearchEverywhere,
+  });
+
+  const btnStyle = (focused: boolean) => ({
+    padding: "var(--space-3) var(--space-5)",
+    borderRadius: "var(--radius-sm)",
+    border: focused
+      ? "2px solid var(--accent-copper)"
+      : "2px solid var(--bg-elevated)",
+    background: focused ? "var(--accent-copper)" : "var(--bg-surface)",
+    color: focused ? "var(--bg-base)" : "var(--text-primary)",
+    fontSize: "var(--text-label-size)",
+    letterSpacing: "var(--text-label-tracking)",
+    textTransform: "uppercase" as const,
+    cursor: "pointer" as const,
+  });
+
+  return (
+    <div
+      role="status"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "var(--space-4)",
+        padding: "var(--space-12) var(--space-6)",
+        color: "var(--text-secondary)",
+        textAlign: "center",
+      }}
+    >
+      <p style={{ margin: 0, fontSize: "var(--text-title-size)", color: "var(--text-primary)" }}>
+        No matches for &ldquo;{query}&rdquo; in Movies.
+      </p>
+      <div style={{ display: "flex", gap: "var(--space-3)" }}>
+        <button
+          ref={clearRef as RefObject<HTMLButtonElement>}
+          type="button"
+          onClick={onClear}
+          style={btnStyle(clearFocused)}
+        >
+          Clear filter
+        </button>
+        <button
+          ref={goRef as RefObject<HTMLButtonElement>}
+          type="button"
+          onClick={onSearchEverywhere}
+          style={btnStyle(goFocused)}
+        >
+          Search everywhere →
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/src/routes/SearchRoute.test.tsx
+++ b/src/routes/SearchRoute.test.tsx
@@ -198,11 +198,16 @@ describe("SearchRoute", () => {
     const input = screen.getByRole("searchbox");
     await user.type(input, "cn");
 
+    // After UX spec update there's a kind chip radio group with the same
+    // labels — assert the section region is what we expect, not just the
+    // text (which now matches multiple nodes).
     await waitFor(() => {
-      expect(screen.getByText("Live")).toBeInTheDocument();
+      expect(
+        screen.getByRole("region", { name: /^live$/i }),
+      ).toBeInTheDocument();
     });
-    expect(screen.getByText("Movies")).toBeInTheDocument();
-    expect(screen.getByText("Series")).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /^movies$/i })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /^series$/i })).toBeInTheDocument();
   });
 
   it("shows empty state when results are all empty for 2+ char query", async () => {

--- a/src/routes/SearchRoute.tsx
+++ b/src/routes/SearchRoute.tsx
@@ -1,24 +1,23 @@
 /**
- * SearchRoute — Phase 7 unified search.
+ * SearchRoute — unified search across Live / Movies / Series.
  *
- * Architecture:
- *  - Controlled <input> bound via norigin useFocusable (SEARCH_INPUT).
- *  - 300ms debounce via useDebounce; also triggers on Enter (onEnterPress).
- *  - Results grouped: Live / Movies / Series (vod in API = Movies in UI).
- *  - Each result card: useFocusable SEARCH_RESULT_<TYPE>_<ID> + navigate.
- *  - States: idle (< 2 chars), loading, results, empty, error.
+ * Updated 2026-04-24 (search-favorites session):
+ *   - Section order Movies → Series → Live (04 spec §3.4)
+ *   - Debounce 300ms → 250ms (04 spec §1.3)
+ *   - Kind chips (All · Live · Movies · Series) post-query only
+ *   - Kind chip filters are client-side; does NOT re-fetch
+ *   - Each result card has an OverflowMenu (Play / Add to favorites / More info)
  *
- * D-pad flow:
- *  ArrowUp from dock → SEARCH_INPUT
- *  ArrowDown from input → first result row
- *  ArrowLeft/Right within a row → adjacent cards
- *  ArrowDown between rows → next section
+ * D-pad flow (unchanged except for kind chips step):
+ *   Dock → SEARCH_INPUT
+ *   Input Down → SEARCH_KIND_ALL (when results exist) → first section's first card
+ *   Card Right → SEARCH_OVERFLOW_<TYPE>_<ID>
  *
  * CONTENT_AREA_SEARCH useFocusable is load-bearing — dropping it breaks
  * BottomDock's setFocus("CONTENT_AREA_SEARCH") Esc-key routing.
  */
 import type { RefObject } from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   useFocusable,
   FocusContext,
@@ -29,6 +28,7 @@ import { fetchSearch } from "../api/search";
 import type { SearchResults } from "../api/schemas";
 import { SearchInput } from "../features/search/SearchInput";
 import { SearchResultsSection } from "../features/search/SearchResultsSection";
+import { SearchKindChips, type SearchKind } from "../features/search/SearchKindChips";
 import { useDebounce } from "../features/search/useDebounce";
 
 // ─── useSearchQuery — encapsulates fetch + state management ─────────────────
@@ -40,16 +40,10 @@ function useSearchQuery(debouncedQuery: string) {
   const [lastSearchedQuery, setLastSearchedQuery] = useState("");
 
   useEffect(() => {
-    // Only fire if >= 2 chars — guard ensures no fetch for short queries.
-    // The effect dep array drives reset implicitly: when debouncedQuery < 2,
-    // we don't enter this block, so we rely on handleQueryChange to clear
-    // state when the raw query shortens (below the 2-char threshold).
     if (debouncedQuery.length < 2) return;
 
     let cancelled = false;
 
-    // Wrap the entire fetch + setLoading(true) inside a microtask so the
-    // setState calls happen asynchronously, satisfying react-hooks/set-state-in-effect.
     void Promise.resolve().then(() => {
       if (cancelled) return;
       setLoading(true);
@@ -100,7 +94,6 @@ function useSearchQuery(debouncedQuery: string) {
         setLoading(false);
       });
 
-    // Note: cannot return cleanup from useCallback — caller must manage it.
     return () => {
       cancelled = true;
     };
@@ -112,27 +105,33 @@ function useSearchQuery(debouncedQuery: string) {
 // ─── SearchRoute ─────────────────────────────────────────────────────────────
 
 export function SearchRoute() {
-  // MUST PRESERVE: norigin root registration for the content area.
-  // Dropping this breaks BottomDock's setFocus("CONTENT_AREA_SEARCH") Esc flow.
   const { ref, focusKey } = useFocusable({
     focusKey: "CONTENT_AREA_SEARCH",
     focusable: false,
     trackChildren: true,
-    // Absorb dead-direction bubble-ups at the route's outer edges; Down
-    // stays open so results can still reach BottomDock. See
-    // streamvault-v3-focus-vanish-bug.md.
     isFocusBoundary: true,
     focusBoundaryDirections: ["left", "right", "up"],
   });
 
-  const [query, setQuery] = useState("");
-  const debouncedQuery = useDebounce(query, 300);
+  // Preseed the query from ?q=… — used by /movies + /series "Search
+  // everywhere" CTA when an in-route filter has zero matches.
+  const initialQuery = useMemo(() => {
+    if (typeof window === "undefined") return "";
+    try {
+      const params = new URLSearchParams(window.location.search);
+      return params.get("q") ?? "";
+    } catch {
+      return "";
+    }
+  }, []);
+
+  const [query, setQuery] = useState(initialQuery);
+  const [kind, setKind] = useState<SearchKind>("all");
+  const debouncedQuery = useDebounce(query, 250);
 
   const { results, loading, error, lastSearchedQuery, clearResults, runSearch } =
     useSearchQuery(debouncedQuery);
 
-  // When raw query drops below 2 chars, clear results immediately so the
-  // user doesn't see stale data while typing.
   const handleQueryChange = useCallback(
     (value: string) => {
       setQuery(value);
@@ -143,17 +142,14 @@ export function SearchRoute() {
     [clearResults],
   );
 
-  // Immediate search on Enter — bypasses debounce
   const handleSubmit = useCallback(() => {
     runSearch(query);
   }, [query, runSearch]);
 
-  // Prime norigin focus on mount — land on SEARCH_INPUT
   useEffect(() => {
     setFocus("SEARCH_INPUT");
   }, []);
 
-  // Derived state
   const hasResults =
     results !== null &&
     (results.live.length > 0 ||
@@ -168,6 +164,10 @@ export function SearchRoute() {
     !hasResults &&
     lastSearchedQuery.length >= 2;
 
+  const showMovies = kind === "all" || kind === "vod";
+  const showSeries = kind === "all" || kind === "series";
+  const showLive = kind === "all" || kind === "live";
+
   return (
     <FocusContext.Provider value={focusKey}>
       <main
@@ -179,14 +179,12 @@ export function SearchRoute() {
             "calc(var(--dock-height) + var(--space-6) + var(--space-6))",
         }}
       >
-        {/* Search input */}
         <SearchInput
           value={query}
           onChange={handleQueryChange}
           onSubmit={handleSubmit}
         />
 
-        {/* Help text — too short */}
         {showHelp && (
           <p
             aria-live="polite"
@@ -200,7 +198,10 @@ export function SearchRoute() {
           </p>
         )}
 
-        {/* Loading skeleton */}
+        {hasResults && !loading && !error && (
+          <SearchKindChips value={kind} onChange={setKind} />
+        )}
+
         {loading && (
           <div
             aria-live="polite"
@@ -222,7 +223,6 @@ export function SearchRoute() {
           </div>
         )}
 
-        {/* Error state */}
         {error && !loading && (
           <p
             role="alert"
@@ -236,7 +236,6 @@ export function SearchRoute() {
           </p>
         )}
 
-        {/* Empty state */}
         {showEmpty && (
           <p
             role="status"
@@ -250,12 +249,17 @@ export function SearchRoute() {
           </p>
         )}
 
-        {/* Results grouped by section */}
         {!loading && hasResults && results !== null && (
           <div>
-            <SearchResultsSection title="Live" items={results.live} />
-            <SearchResultsSection title="Movies" items={results.vod} />
-            <SearchResultsSection title="Series" items={results.series} />
+            {showMovies && (
+              <SearchResultsSection title="Movies" items={results.vod} />
+            )}
+            {showSeries && (
+              <SearchResultsSection title="Series" items={results.series} />
+            )}
+            {showLive && (
+              <SearchResultsSection title="Live" items={results.live} />
+            )}
           </div>
         )}
       </main>

--- a/src/routes/SeriesRoute.tsx
+++ b/src/routes/SeriesRoute.tsx
@@ -40,6 +40,7 @@ import {
   type SeriesSortKey,
 } from "../features/series/sortSeries";
 import { LanguageRail } from "../components/LanguageRail";
+import { FindInput, FindTrigger, filterByQuery } from "../components/FindInput";
 import { ResumeHero } from "../features/movies/ResumeHero";
 import { ErrorShell } from "../primitives/ErrorShell";
 import { Skeleton } from "../primitives/Skeleton";
@@ -164,6 +165,7 @@ export function SeriesRoute() {
   const [error, setError] = useState(false);
   const [transitioning, setTransitioning] = useState(false);
   const [fetchGeneration, setFetchGeneration] = useState(0);
+  const [findQuery, setFindQuery] = useState("");
 
   // ─── Language union fetch ─────────────────────────────────────────────────
   useEffect(() => {
@@ -204,10 +206,14 @@ export function SeriesRoute() {
     };
   }, []);
 
-  // ─── Derived: sorted items ────────────────────────────────────────────────
+  // ─── Derived: filter → sorted items ───────────────────────────────────────
+  const filteredItems = useMemo(
+    () => filterByQuery(items, findQuery, (s) => s.name),
+    [items, findQuery],
+  );
   const sortedItems = useMemo(
-    () => sortSeriesItems(items, sort),
-    [items, sort],
+    () => sortSeriesItems(filteredItems, sort),
+    [filteredItems, sort],
   );
 
   // ─── Resume candidate — most-recent in-progress SERIES episode ────────────
@@ -303,9 +309,23 @@ export function SeriesRoute() {
     (next: LangId) => {
       setTransitioning(true);
       setLang(next);
+      setFindQuery("");
     },
     [setLang],
   );
+
+  const handleFindTrigger = useCallback(() => {
+    setFocus("SERIES_FIND_INPUT");
+  }, []);
+
+  const handleClearFilter = useCallback(() => {
+    setFindQuery("");
+    setFocus("SERIES_FIND_TRIGGER");
+  }, []);
+
+  const handleSearchEverywhere = useCallback(() => {
+    navigate(`/search?q=${encodeURIComponent(findQuery)}`);
+  }, [navigate, findQuery]);
 
   const handleRetry = useCallback(() => {
     invalidateSeriesLanguageUnionCache();
@@ -366,6 +386,13 @@ export function SeriesRoute() {
 
             <LanguageRail value={lang} onChange={handleLangChange} />
 
+            <FindInput
+              value={findQuery}
+              onChange={setFindQuery}
+              surface="SERIES"
+              placeholder="Find in Series…"
+            />
+
             <div
               role="toolbar"
               aria-label="Series sort"
@@ -411,6 +438,11 @@ export function SeriesRoute() {
                     onSelect={() => handleSortChange(opt.id)}
                   />
                 ))}
+                <FindTrigger
+                  surface="SERIES"
+                  onSelect={handleFindTrigger}
+                  isActive={findQuery.length > 0}
+                />
               </div>
 
               <span
@@ -439,7 +471,9 @@ export function SeriesRoute() {
                 ) : null}
                 {transitioning
                   ? `Loading ${langLabel(lang) || "all"} series…`
-                  : `${sortedItems.length.toLocaleString()} series`}
+                  : findQuery.trim().length > 0
+                    ? `${sortedItems.length.toLocaleString()} of ${items.length.toLocaleString()} series`
+                    : `${sortedItems.length.toLocaleString()} series`}
               </span>
             </div>
             <style>{`
@@ -462,12 +496,20 @@ export function SeriesRoute() {
               aria-busy={transitioning || undefined}
             >
               {sortedItems.length === 0 && !transitioning ? (
-                <EmptyStateWithLanguageSwitch
-                  currentLang={lang}
-                  onSwitch={setLang}
-                  headline={`No ${langLabel(lang)} series in this catalog.`}
-                  message="The provider hasn't categorised any series this way. Try another language."
-                />
+                findQuery.trim().length > 0 ? (
+                  <SeriesFindEmptyState
+                    query={findQuery}
+                    onClear={handleClearFilter}
+                    onSearchEverywhere={handleSearchEverywhere}
+                  />
+                ) : (
+                  <EmptyStateWithLanguageSwitch
+                    currentLang={lang}
+                    onSwitch={setLang}
+                    headline={`No ${langLabel(lang)} series in this catalog.`}
+                    message="The provider hasn't categorised any series this way. Try another language."
+                  />
+                )
               ) : (
                 <SeriesGrid
                   items={sortedItems}
@@ -487,5 +529,75 @@ export function SeriesRoute() {
         )}
       </main>
     </FocusContext.Provider>
+  );
+}
+
+function SeriesFindEmptyState({
+  query,
+  onClear,
+  onSearchEverywhere,
+}: {
+  query: string;
+  onClear: () => void;
+  onSearchEverywhere: () => void;
+}) {
+  const { ref: clearRef, focused: clearFocused } = useFocusable<HTMLButtonElement>({
+    focusKey: "SERIES_FIND_EMPTY_CLEAR",
+    onEnterPress: onClear,
+  });
+  const { ref: goRef, focused: goFocused } = useFocusable<HTMLButtonElement>({
+    focusKey: "SERIES_FIND_EMPTY_GO",
+    onEnterPress: onSearchEverywhere,
+  });
+
+  const btnStyle = (focused: boolean) => ({
+    padding: "var(--space-3) var(--space-5)",
+    borderRadius: "var(--radius-sm)",
+    border: focused
+      ? "2px solid var(--accent-copper)"
+      : "2px solid var(--bg-elevated)",
+    background: focused ? "var(--accent-copper)" : "var(--bg-surface)",
+    color: focused ? "var(--bg-base)" : "var(--text-primary)",
+    fontSize: "var(--text-label-size)",
+    letterSpacing: "var(--text-label-tracking)",
+    textTransform: "uppercase" as const,
+    cursor: "pointer" as const,
+  });
+
+  return (
+    <div
+      role="status"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "var(--space-4)",
+        padding: "var(--space-12) var(--space-6)",
+        color: "var(--text-secondary)",
+        textAlign: "center",
+      }}
+    >
+      <p style={{ margin: 0, fontSize: "var(--text-title-size)", color: "var(--text-primary)" }}>
+        No matches for &ldquo;{query}&rdquo; in Series.
+      </p>
+      <div style={{ display: "flex", gap: "var(--space-3)" }}>
+        <button
+          ref={clearRef as RefObject<HTMLButtonElement>}
+          type="button"
+          onClick={onClear}
+          style={btnStyle(clearFocused)}
+        >
+          Clear filter
+        </button>
+        <button
+          ref={goRef as RefObject<HTMLButtonElement>}
+          type="button"
+          onClick={onSearchEverywhere}
+          style={btnStyle(goFocused)}
+        >
+          Search everywhere →
+        </button>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #95, user-driven after a round of Fire TV prod testing. Two UX specs merged into one PR (Search/Favorites + Back-to-dock/TV readability). All UX decisions locked with the UX-lead agent before coding.

**Search route**
- Kind chips (All · Movies · Series · Live), client-side, session-scoped
- Section reorder Movies → Series → Live
- Debounce 300ms → 250ms
- OverflowMenu on every result card: Play · Add/Remove favorite · More info
- `?q=…` URL seed so the in-route Find "Search everywhere →" CTA pre-fills

**Favorites**
- Cards now activate per IA §2.3 (Live/VOD → player, Series → /series/:id)
- New `FavoritePosterCard` — 2:3 poster, parity with MovieCard/SeriesCard
- Per-card OverflowMenu (Play / Open / More info / Remove)
- Per-section empty states; whole-page empty only when all 3 sections are zero
- Sort toolbar (Recently added · A–Z), persisted

**In-route Find — Movies and Series**
- `FindInput` always rendered; D-pad reaches it via a new "🔍 Find" chip in the sort toolbar so routine browsing doesn't have focus stolen
- Multi-token substring filter over the already-loaded language union
- Count → "N of M" when filter active
- Empty-match state with `Clear filter` and `Search everywhere →` CTAs
- Filter resets on language change; Escape / Backspace-on-empty clears + returns focus to the 🔍 chip

**Fire TV readability (from user "cards too big" feedback on live TV)**
- Runtime `data-tv="true"` sniff on UA (Silk|AFT) in `main.tsx`
- TV-only token overrides in `brand/tokens.css`: label 14→22px, body 20→24px, title 32→36px
- MovieGrid drops one column per tier (6 at 1280+, 5 at 960+, etc.)
- SeriesGrid `minmax` 160→220px

**Back-to-dock exit (from user "can't exit app" feedback)**
- The PR #95 guard was too aggressive — Back on the dock was swallowed, no exit path
- Now: Back pressed anywhere in a route → focus jumps to the active dock tab. Back pressed again *while on the dock* passes through, and the popstate sentinel honours a 600ms "just Back'd from dock" window so Fire TV's hardware Back actually leaves the PWA

**PWA / Silk fullscreen (hides the URL bar user saw in the screenshot)**
- `public/manifest.webmanifest` with `display: fullscreen`
- `index.html` gains apple/mobile-web-app-capable metas + theme-color
- On Fire TV Silk, "Add to Home Screen" now launches chromeless

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test -- --run` — 42 files / 314 tests passing
- [x] `npm run build` — clean, 1.33 MB / 378 KB gzipped
- [ ] Manual prod: favorites activation (Live, VOD, Series)
- [ ] Manual prod: Find in Movies → filter narrows, count shows "N of M"
- [ ] Manual prod: Find empty → Search everywhere → pre-fills `/search?q=…`
- [ ] Manual prod: Search Kind chip → sections hide/show
- [ ] Manual prod: Search card ⋯ → Add to favorites → appears in /favorites
- [ ] Manual Fire TV: fewer cards per row + readable title
- [ ] Manual Fire TV: Back from dock exits app
- [ ] Manual Fire TV: "Add to Home Screen" launches without URL bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)