### PR TITLE
fix(nav): Back on detail routes goes to parent, not the dock

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -133,13 +133,27 @@ function AppShell() {
       const active = document.activeElement?.getAttribute("aria-label");
       const dockLabels = Object.values(DOCK_LABELS);
       if (active && dockLabels.includes(active)) {
-        // Back pressed while the dock is focused. Let the event through so
-        // the browser / Fire TV host can close the tab or PWA (a user on
-        // the dock signalling Back means "leave the app"). We also record
-        // the timestamp so the popstate sentinel below stops re-pushing
-        // the exit guard — otherwise Fire TV's hardware Back would be
-        // absorbed by the sentinel re-push and never reach the OS.
+        // Back on the dock → exit. Record the timestamp so the popstate
+        // sentinel stops re-pushing and the hardware Back reaches the OS.
         lastDockBackAtRef.current = Date.now();
+        return;
+      }
+
+      // 4-level hierarchy (UX lead confirmed 2026-04-24):
+      //   Detail route (/series/:id, /movies/:id, …) → browser history.back()
+      //     so React Router navigates to the parent list route.
+      //   Root route (/series, /movies, /live, /search, /settings) → jump
+      //     focus to the active dock tab, preventDefault so we stay on the
+      //     page. The *next* Back (now on the dock) exits per the branch
+      //     above.
+      // The previous implementation always setFocus'd to the dock, which
+      // stranded detail routes — user on /series/16420 couldn't get back
+      // to /series without manually navigating.
+      const segments = window.location.pathname.split("/").filter(Boolean);
+      const isDetailRoute = segments.length > 1;
+      if (isDetailRoute) {
+        // Let the browser's default (or the popstate listener below)
+        // handle the history pop. Don't preventDefault.
         return;
       }
       setFocus(`DOCK_${activeTab.toUpperCase()}`);


### PR DESCRIPTION
## Summary

Hotfix for a bug the user caught in prod after PR #96: on `/series/:id`, pressing Back jumped focus to the bottom dock while the URL stayed put. Expected behavior is Back → `/series` (the list).

## Root cause

The PR #96 `App.tsx` `handleEscape` always ran `setFocus('DOCK_<tab>') + preventDefault` for any non-dock-focused Back press, even on detail routes. That swallowed the event before the SeriesDetailRoute's own `navigate(-1)` could route back up.

## Fix — UX-lead-confirmed Option A

Standard 4-level Fire TV hierarchy (Netflix / Prime):

| Where | Back behavior |
|---|---|
| Detail route (`/series/:id`, future `/movies/:id`, …) | `history.back()` → parent list |
| Root route (`/series`, `/movies`, `/live`, `/search`, `/settings`) | setFocus to dock + preventDefault |
| Dock | pass through → exit app (PR #96 behavior, unchanged) |

Implementation: in `handleEscape`, read `window.location.pathname`, detect `segments.length > 1`, and return without preventDefault so the existing detail-route handler + popstate sentinel complete naturally.

## Test plan

- [x] Typecheck clean
- [x] 314 tests passing
- [x] Build clean, 1.33 MB / 378 KB gz
- [ ] Manual Fire TV: `/series/:id` → Back → lands on `/series` list
- [ ] Manual Fire TV: `/series` → Back → focus moves to dock
- [ ] Manual Fire TV: dock → Back → app exits
- [ ] Manual Fire TV: `/search` (root) → Back → focus moves to dock (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)