### PR TITLE
feat(nav): focus restoration + dock replace + back-press analytics

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,8 @@ import {
   doesFocusableExist,
 } from "@noriginmedia/norigin-spatial-navigation";
 import { BottomDock, type DockItem } from "./nav/BottomDock";
+import { resetOriginators } from "./nav/backStack";
+import { logEvent } from "./telemetry";
 import { LiveRoute } from "./routes/LiveRoute";
 import { MoviesRoute } from "./routes/MoviesRoute";
 import { SeriesRoute } from "./routes/SeriesRoute";
@@ -132,10 +134,19 @@ function AppShell() {
 
       const active = document.activeElement?.getAttribute("aria-label");
       const dockLabels = Object.values(DOCK_LABELS);
+      const segments = window.location.pathname.split("/").filter(Boolean);
+      const route = "/" + segments.join("/") || "/";
+      const depth = segments.length;
+
       if (active && dockLabels.includes(active)) {
         // Back on the dock → exit. Record the timestamp so the popstate
         // sentinel stops re-pushing and the hardware Back reaches the OS.
         lastDockBackAtRef.current = Date.now();
+        logEvent("back_pressed", {
+          route,
+          depth,
+          handled_by: "dock_exit",
+        });
         return;
       }
 
@@ -146,16 +157,22 @@ function AppShell() {
       //     focus to the active dock tab, preventDefault so we stay on the
       //     page. The *next* Back (now on the dock) exits per the branch
       //     above.
-      // The previous implementation always setFocus'd to the dock, which
-      // stranded detail routes — user on /series/16420 couldn't get back
-      // to /series without manually navigating.
-      const segments = window.location.pathname.split("/").filter(Boolean);
       const isDetailRoute = segments.length > 1;
       if (isDetailRoute) {
         // Let the browser's default (or the popstate listener below)
         // handle the history pop. Don't preventDefault.
+        logEvent("back_pressed", {
+          route,
+          depth,
+          handled_by: "detail_route_pop",
+        });
         return;
       }
+      logEvent("back_pressed", {
+        route,
+        depth,
+        handled_by: "root_to_dock",
+      });
       setFocus(`DOCK_${activeTab.toUpperCase()}`);
       e.preventDefault();
     };
@@ -274,7 +291,16 @@ function AppShell() {
       </Routes>
       <BottomDock
         activeItem={activeTab}
-        onNavigate={(item) => navigate(`/${item}`)}
+        onNavigate={(item) => {
+          // Dock taps are lateral surface swaps, not back-stack pushes:
+          // navigate with `replace: true` so a Back from the new
+          // surface doesn't return to the previous detail route. Also
+          // wipe any stored originators — tapping the dock is a
+          // deliberate fresh-start signal.
+          resetOriginators();
+          logEvent("dock_navigated", { to: item });
+          navigate(`/${item}`, { replace: true });
+        }}
         hidden={hideDock}
       />
       {/* Single player overlay — mounts here so it's above all routes */}

--- a/src/features/search/SearchResultsSection.tsx
+++ b/src/features/search/SearchResultsSection.tsx
@@ -21,6 +21,7 @@ import {
   removeFavorite,
   isFavorited,
 } from "../../api/favorites";
+import { rememberOriginator } from "../../nav/backStack";
 import type { CatalogItem, ContentType } from "../../api/schemas";
 import type { PlayerKind } from "../../player/PlayerProvider";
 
@@ -52,6 +53,9 @@ function SearchCard({ item }: SearchCardProps) {
 
   const activateItem = () => {
     if (item.type === "series") {
+      // Remember which search-result card launched the detail-route nav
+      // so Back pops the user back here, not to the first card.
+      rememberOriginator("/search", focusKey);
       navigate(`/series/${encodeURIComponent(item.id)}`);
       return;
     }

--- a/src/nav/backStack.test.ts
+++ b/src/nav/backStack.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  rememberOriginator,
+  consumeOriginator,
+  resetOriginators,
+  __peekOriginatorForTest,
+  __sizeForTest,
+} from "./backStack";
+
+describe("backStack", () => {
+  beforeEach(() => {
+    resetOriginators();
+  });
+
+  it("consumeOriginator returns null when nothing is stored", () => {
+    expect(consumeOriginator("/series")).toBe(null);
+  });
+
+  it("remember + consume returns the stored focusKey exactly once", () => {
+    rememberOriginator("/series", "SERIES_CARD_42");
+    expect(__peekOriginatorForTest("/series")).toBe("SERIES_CARD_42");
+    expect(consumeOriginator("/series")).toBe("SERIES_CARD_42");
+    expect(consumeOriginator("/series")).toBe(null);
+  });
+
+  it("per-route keys are independent", () => {
+    rememberOriginator("/series", "SERIES_CARD_A");
+    rememberOriginator("/search", "SEARCH_RESULT_SERIES_B");
+    expect(consumeOriginator("/series")).toBe("SERIES_CARD_A");
+    expect(consumeOriginator("/search")).toBe("SEARCH_RESULT_SERIES_B");
+  });
+
+  it("rememberOriginator ignores empty inputs", () => {
+    rememberOriginator("", "SERIES_CARD_X");
+    rememberOriginator("/series", "");
+    expect(__sizeForTest()).toBe(0);
+  });
+
+  it("subsequent rememberOriginator calls for the same route overwrite", () => {
+    rememberOriginator("/series", "SERIES_CARD_FIRST");
+    rememberOriginator("/series", "SERIES_CARD_SECOND");
+    expect(consumeOriginator("/series")).toBe("SERIES_CARD_SECOND");
+  });
+
+  it("resetOriginators clears every stored entry", () => {
+    rememberOriginator("/series", "SERIES_CARD_A");
+    rememberOriginator("/search", "SEARCH_RESULT_VOD_B");
+    expect(__sizeForTest()).toBe(2);
+    resetOriginators();
+    expect(__sizeForTest()).toBe(0);
+    expect(consumeOriginator("/series")).toBe(null);
+    expect(consumeOriginator("/search")).toBe(null);
+  });
+});

--- a/src/nav/backStack.ts
+++ b/src/nav/backStack.ts
@@ -1,0 +1,54 @@
+/**
+ * Per-route originator map — Netflix-style focus restoration.
+ *
+ * When a user activates a card on a list route and navigates to a detail
+ * route, the list route records which card they came from. On pop back,
+ * the list route consumes the saved focusKey and restores focus to it,
+ * so the user lands exactly where they left.
+ *
+ * Keying: by the pathname of the LIST route (the route we'll return to
+ * after the detail route is popped). Example:
+ *   user on /series focuses SERIES_CARD_16420 → clicks →
+ *   rememberOriginator('/series', 'SERIES_CARD_16420')
+ *   → navigate('/series/16420')
+ *   → user hits Back →
+ *   /series mounts → consumeOriginator('/series') → setFocus(...)
+ *
+ * Consumers clear the entry on read so stale originators can't leak into
+ * a later navigation. If the remembered focusKey no longer exists at
+ * restore time (filter changed, list reloaded), the route's default
+ * focus-seed logic applies.
+ */
+const originators = new Map<string, string>();
+
+export function rememberOriginator(listRoute: string, focusKey: string): void {
+  if (!listRoute || !focusKey) return;
+  originators.set(listRoute, focusKey);
+}
+
+/** Read + delete. Returns null if no originator is stored for the route. */
+export function consumeOriginator(listRoute: string): string | null {
+  const key = originators.get(listRoute);
+  if (key === undefined) return null;
+  originators.delete(listRoute);
+  return key;
+}
+
+/**
+ * Wipe all stored originators. Called when the user taps a dock tab —
+ * that's a deliberate fresh-start signal, so prior navigation state
+ * should not influence focus on the destination.
+ */
+export function resetOriginators(): void {
+  originators.clear();
+}
+
+/** Test-only inspector. */
+export function __peekOriginatorForTest(listRoute: string): string | null {
+  return originators.get(listRoute) ?? null;
+}
+
+/** Test-only size check. */
+export function __sizeForTest(): number {
+  return originators.size;
+}

--- a/src/routes/SearchRoute.tsx
+++ b/src/routes/SearchRoute.tsx
@@ -30,6 +30,8 @@ import { SearchInput } from "../features/search/SearchInput";
 import { SearchResultsSection } from "../features/search/SearchResultsSection";
 import { SearchKindChips, type SearchKind } from "../features/search/SearchKindChips";
 import { useDebounce } from "../features/search/useDebounce";
+import { consumeOriginator } from "../nav/backStack";
+import { logEvent } from "../telemetry";
 
 // ─── useSearchQuery — encapsulates fetch + state management ─────────────────
 
@@ -147,6 +149,19 @@ export function SearchRoute() {
   }, [query, runSearch]);
 
   useEffect(() => {
+    // If the user is returning from a detail route they opened from a
+    // search-result card, restore focus there instead of the input.
+    // consumeOriginator is read-once — on a fresh mount with no stored
+    // key, fall back to the input seed.
+    const saved = consumeOriginator("/search");
+    if (saved) {
+      logEvent("nav_originator_restored", {
+        route: "/search",
+        focus_key: saved,
+      });
+      setFocus(saved);
+      return;
+    }
     setFocus("SEARCH_INPUT");
   }, []);
 

--- a/src/routes/SeriesRoute.tsx
+++ b/src/routes/SeriesRoute.tsx
@@ -48,6 +48,11 @@ import { EmptyStateWithLanguageSwitch } from "../primitives/EmptyStateWithLangua
 import { useLangPref } from "../lib/useLangPref";
 import { fetchHistory } from "../api/history";
 import { usePlayerOpener } from "../player/usePlayerOpener";
+import {
+  rememberOriginator,
+  consumeOriginator,
+} from "../nav/backStack";
+import { logEvent } from "../telemetry";
 import type { HistoryItem, SeriesItem } from "../api/schemas";
 import type { LangId } from "../lib/langPref";
 
@@ -267,6 +272,31 @@ export function SeriesRoute() {
 
   useEffect(() => {
     if (!didInitialSeedRef.current) {
+      // Originator restore takes priority over resume-hero + first-card
+      // seed: if the user is returning here from a detail route they
+      // opened from a specific card, put focus back on that card.
+      // consumeOriginator is read-once — subsequent mounts fall back to
+      // the default seed logic.
+      if (sortedItems.length > 0) {
+        const saved = consumeOriginator("/series");
+        if (saved) {
+          const ids = new Set(sortedItems.map((s) => s.id));
+          const restoredId = saved.replace(/^SERIES_CARD_/, "");
+          if (ids.has(restoredId)) {
+            didInitialSeedRef.current = true;
+            lastSeededLangRef.current = lang;
+            logEvent("nav_originator_restored", {
+              route: "/series",
+              focus_key: saved,
+            });
+            const t = setTimeout(() => setFocus(saved), 0);
+            return () => clearTimeout(t);
+          }
+          // Saved card is no longer in the list (filter changed, data
+          // refreshed). Fall through to the default seed below.
+        }
+      }
+
       if (resumeCandidate) {
         didInitialSeedRef.current = true;
         lastSeededLangRef.current = lang;
@@ -295,6 +325,10 @@ export function SeriesRoute() {
   // ─── Handlers ─────────────────────────────────────────────────────────────
   const handleCardClick = useCallback(
     (id: string) => {
+      // Remember which card launched this detail-route nav so the user
+      // lands back on it when they press Back (Netflix-style focus
+      // restoration).
+      rememberOriginator("/series", `SERIES_CARD_${id}`);
       navigate(`/series/${encodeURIComponent(id)}`);
     },
     [navigate],

--- a/src/telemetry/index.test.ts
+++ b/src/telemetry/index.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  logEvent,
+  __resetTelemetryForTest,
+  __getTelemetryBufferForTest,
+} from "./index";
+
+describe("telemetry", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    __resetTelemetryForTest();
+    consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("pushes events into the ring buffer with name + props + timestamp", () => {
+    logEvent("back_pressed", { route: "/series/42", depth: 2, handled_by: "detail_route_pop" });
+    const buf = __getTelemetryBufferForTest();
+    expect(buf).toHaveLength(1);
+    expect(buf[0]!.name).toBe("back_pressed");
+    expect(buf[0]!.props).toEqual({
+      route: "/series/42",
+      depth: 2,
+      handled_by: "detail_route_pop",
+    });
+    expect(buf[0]!.at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("logs via console.info for live inspection", () => {
+    logEvent("dock_navigated", { to: "movies" });
+    expect(consoleSpy).toHaveBeenCalledWith("[telemetry] dock_navigated", {
+      to: "movies",
+    });
+  });
+
+  it("truncates the buffer to its cap (drops oldest)", () => {
+    // Cap is 100; push 105 and assert only last 100 remain.
+    for (let i = 0; i < 105; i += 1) {
+      logEvent("back_pressed", { i });
+    }
+    const buf = __getTelemetryBufferForTest();
+    expect(buf).toHaveLength(100);
+    expect(buf[0]!.props.i).toBe(5); // first 5 dropped
+    expect(buf[99]!.props.i).toBe(104);
+  });
+
+  it("accepts empty props", () => {
+    logEvent("back_pressed");
+    const buf = __getTelemetryBufferForTest();
+    expect(buf[0]!.props).toEqual({});
+  });
+});

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,0 +1,73 @@
+/**
+ * Lightweight client telemetry.
+ *
+ * Ships events via console.info (always, so prod traces are inspectable in
+ * Fire TV Silk devtools) and buffers the last 100 events on
+ * `window.__svTelemetry` in DEV so Playwright + in-browser debugging can
+ * assert on them.
+ *
+ * There is no server sink yet — when one lands, swap the console.info for
+ * sendBeacon / fetch without touching callers.
+ */
+export type TelemetryEventName =
+  | "back_pressed"
+  | "nav_originator_restored"
+  | "dock_navigated";
+
+export interface TelemetryEventProps {
+  [key: string]: string | number | boolean | null | undefined;
+}
+
+interface StoredEvent {
+  name: TelemetryEventName;
+  props: TelemetryEventProps;
+  at: string;
+}
+
+const MAX_BUFFER = 100;
+
+const buffer: StoredEvent[] = [];
+
+function pushToBuffer(evt: StoredEvent): void {
+  buffer.push(evt);
+  if (buffer.length > MAX_BUFFER) {
+    buffer.shift();
+  }
+}
+
+function attachDevHandle(): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (!import.meta.env.DEV) return;
+  } catch {
+    // import.meta.env unavailable in some test contexts
+    return;
+  }
+  (window as unknown as { __svTelemetry: StoredEvent[] }).__svTelemetry = buffer;
+}
+
+attachDevHandle();
+
+export function logEvent(
+  name: TelemetryEventName,
+  props: TelemetryEventProps = {},
+): void {
+  const evt: StoredEvent = {
+    name,
+    props,
+    at: new Date().toISOString(),
+  };
+  pushToBuffer(evt);
+  // eslint-disable-next-line no-console
+  console.info(`[telemetry] ${name}`, props);
+}
+
+/** Test-only: clear the in-memory buffer. */
+export function __resetTelemetryForTest(): void {
+  buffer.length = 0;
+}
+
+/** Test-only: read the current buffer. */
+export function __getTelemetryBufferForTest(): ReadonlyArray<StoredEvent> {
+  return buffer;
+}


### PR DESCRIPTION
## Summary

Implements the three follow-ups the UX lead flagged in PR #97, completing the back-navigation story for StreamVault v3.

### 1. Netflix-style focus restoration on Back
- New [src/nav/backStack.ts](src/nav/backStack.ts) — module-level `Map<listRoute, focusKey>` with `rememberOriginator` / `consumeOriginator` (read-once) / `resetOriginators` helpers.
- [SeriesRoute](src/routes/SeriesRoute.tsx) `handleCardClick` remembers the originating `SERIES_CARD_<id>` before `navigate`. The focus-seed effect consumes on mount and restores focus to that exact card — guarded by existence in the current `sortedItems` so a filter change / data reload doesn't strand the user.
- [SearchResultsSection](src/features/search/SearchResultsSection.tsx) does the same for series hits (`SEARCH_RESULT_SERIES_<id>` keyed to `/search`). [SearchRoute](src/routes/SearchRoute.tsx)'s mount effect consumes and restores instead of defaulting to `SEARCH_INPUT`.

### 2. Dock tap resets the per-tab back stack
- [BottomDock](src/App.tsx)'s `onNavigate` in App.tsx now calls `navigate(path, { replace: true })` so lateral surface swaps don't stack history entries, and invokes `resetOriginators()` to wipe any stored restore keys. Tapping the dock is a deliberate fresh-start signal — prior navigation state should not influence focus on the destination.

### 3. `back_pressed` analytics
- New [src/telemetry/index.ts](src/telemetry/index.ts) — `logEvent(name, props)` pushes into a 100-entry ring buffer, calls `console.info` always (so prod traces are inspectable in Fire TV Silk devtools), and exposes the buffer on `window.__svTelemetry` in DEV for Playwright / in-browser inspection.
- [App.tsx](src/App.tsx) `handleEscape` emits `back_pressed` with `{ route, depth, handled_by }` where `handled_by ∈ { 'dock_exit' | 'detail_route_pop' | 'root_to_dock' }`.
- Additional `dock_navigated` and `nav_originator_restored` events for observability.

## Test plan

- [x] 324 unit tests passing (10 new: `backStack.test.ts` + `telemetry/index.test.ts`)
- [x] Typecheck clean
- [x] Build clean, 1.33 MB / 378 KB gz
- [ ] Manual Fire TV: `/series` → focus card A → Enter → `/series/:id` → Back → lands on card A (not first card)
- [ ] Manual Fire TV: `/search` "vikram" → focus series result B → Enter → `/series/:id` → Back → lands on result B (not the input)
- [ ] Manual Fire TV: `/series/:id` → tap Movies dock → fresh `/movies`, Back from Movies → app exit (no return to `/series/:id`)
- [ ] Manual: open DevTools, inspect `window.__svTelemetry` after pressing Back a few times — should show the ring buffer with typed events

🤖 Generated with [Claude Code](https://claude.com/claude-code)