### PR TITLE
fix: TV prod feedback — responsive scale + posters + series CTA + d-pad perf

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import jsxA11y from "eslint-plugin-jsx-a11y";
 
 export default defineConfig([
-  globalIgnores(["dist", "scripts"]),
+  globalIgnores(["dist", "scripts", "coverage"]),
   {
     files: ["**/*.{ts,tsx}"],
     extends: [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -345,6 +345,41 @@ export default function App() {
     };
   }, []);
 
+  // TV browsers (Android TV / Google TV Chrome) keep the URL bar visible
+  // unless the app is installed as a PWA or enters Fullscreen via user
+  // gesture. The manifest declares display:fullscreen, but that only takes
+  // effect for installed PWAs. As a tab-mode fallback, request Fullscreen
+  // on the first keydown/pointer gesture. Fails silently where unsupported.
+  useEffect(() => {
+    if (gate !== "authed") return;
+    let armed = true;
+    const enter = () => {
+      if (!armed) return;
+      armed = false;
+      const el = document.documentElement as HTMLElement & {
+        webkitRequestFullscreen?: () => Promise<void>;
+      };
+      if (document.fullscreenElement) return;
+      const req =
+        el.requestFullscreen?.bind(el) ?? el.webkitRequestFullscreen?.bind(el);
+      if (req) {
+        Promise.resolve(req()).catch(() => {
+          /* silent — TV browser may refuse without PWA install */
+        });
+      }
+    };
+    window.addEventListener("keydown", enter, { once: true, passive: true });
+    window.addEventListener("pointerdown", enter, {
+      once: true,
+      passive: true,
+    });
+    return () => {
+      armed = false;
+      window.removeEventListener("keydown", enter);
+      window.removeEventListener("pointerdown", enter);
+    };
+  }, [gate]);
+
   if (gate === "checking") {
     return null;
   }

--- a/src/brand/tokens.css
+++ b/src/brand/tokens.css
@@ -246,16 +246,99 @@
     font-family: var(--font-ui);
   }
 
-  /* TV-class readability override. Fire TV Silk / 10-foot viewing needs ~24px
-     floor on primary label type. Gated on [data-tv="true"] which is set in
-     main.tsx by sniffing the UA (Silk/AFT). Desktop browsers on big monitors
-     stay on the ordinary desktop scale. */
+  /* TV-class fluid responsive scale.
+     Applies when `data-tv="true"` is set by main.tsx UA sniff (Fire TV, Android
+     TV, Google TV, Chromecast, Tizen, webOS, HbbTV, etc.) OR when the auto-gate
+     below promotes a TV-class viewport. Every value is clamp(min, ratio, max)
+     so 720p / 900p / 1080p TVs all land inside their tier — 55"/65"/75"
+     physical sizes read back to the browser as a range of logical pixels,
+     which we scale against. */
   :root[data-tv="true"] {
-    --text-label-size: 22px;
-    --text-label-tracking: 0.6px;
-    --text-caption-size: 20px;
-    --text-body-size: 24px;
-    --text-body-lg-size: 28px;
-    --text-title-size: 36px;
+    /* ── Type scale (fluid, 7-token) ─────────────────────────── */
+    --type-hero:       clamp(32px, 4.8vh, 56px);
+    --type-title-lg:   clamp(24px, 3.6vh, 40px);
+    --type-title:      clamp(20px, 2.8vh, 30px);
+    --type-body:       clamp(16px, 2.2vh, 24px);
+    --type-body-sm:    clamp(14px, 1.8vh, 20px);
+    --type-caption:    clamp(12px, 1.5vh, 17px);
+    --type-overline:   clamp(11px, 1.3vh, 14px);
+
+    /* Legacy aliases — existing surfaces still reference these */
+    --text-hero-size:      var(--type-hero);
+    --text-title-size:     var(--type-title-lg);
+    --text-body-lg-size:   var(--type-title);
+    --text-body-size:      var(--type-body);
+    --text-caption-size:   var(--type-caption);
+    --text-label-size:     var(--type-overline);
+    --text-label-tracking: 0.06em;
+
+    /* ── Spacing scale (fluidised from 8px base) ─────────────── */
+    --space-1:  clamp(3px,  0.35vh, 5px);
+    --space-2:  clamp(6px,  0.8vh,  10px);
+    --space-3:  clamp(8px,  1.1vh,  14px);
+    --space-4:  clamp(12px, 1.5vh,  20px);
+    --space-6:  clamp(16px, 2.2vh,  32px);
+    --space-8:  clamp(20px, 3.0vh,  44px);
+    --space-12: clamp(28px, 4.2vh,  60px);
+    --space-16: clamp(36px, 5.6vh,  80px);
+    --space-24: clamp(56px, 8.4vh, 120px);
+
+    /* ── Gutters & safe insets ───────────────────────────────── */
+    --gutter-tv:     clamp(24px, 3.5vw, 64px);
+    --gutter-mobile: clamp(16px, 2.5vw, 32px);
+    --safe-inset:    clamp(16px, 2.5vw, 56px);
+
+    /* ── Focus ring — thicker for 10-foot viewing ────────────── */
+    --focus-ring-shadow:
+      0 0 0 clamp(2px, 0.35vh, 4px) var(--accent-copper),
+      0 0 clamp(16px, 2.4vh, 32px) clamp(3px, 0.5vh, 6px) rgba(200, 121, 65, 0.4);
+
+    /* ── Bottom dock (floating pill) ─────────────────────────── */
+    --dock-height:          clamp(56px, 8vh, 88px);
+    --dock-bottom-offset:   clamp(10px, 1.8vh, 22px);
+    --dock-h-padding:       clamp(16px, 2.5vw, 40px);
+    --dock-tab-min-width:   clamp(72px, 8vw, 120px);
+    --dock-tab-v-padding:   clamp(4px, 0.7vh, 10px);
+    --dock-tab-gap:         clamp(2px, 0.35vh, 6px);
+    --dock-label-size:      clamp(11px, 1.35vh, 15px);
+    --dock-icon-size:       clamp(16px, 2.0vh, 24px);
+
+    /* Content bottom-reserve — routes add this as padding-bottom so the
+       final poster row never sits under the floating dock. */
+    --dock-content-reserve:
+      calc(var(--dock-height) + var(--dock-bottom-offset) + var(--space-6));
+
+    /* ── Hero banner ─────────────────────────────────────────── */
+    --hero-height:         clamp(280px, 42vh, 560px);
+    --hero-side-padding:   var(--gutter-tv);
+
+    /* ── Poster card (2:3 aspect fixed; width fluid per tier) ── */
+    --poster-min-width:    clamp(140px, 14vw, 240px);
+    --poster-gap:          var(--space-4);
+    --poster-label-pad:    var(--space-3);
+
+    /* ── Player chrome ───────────────────────────────────────── */
+    --player-chrome-h:     clamp(72px, 10vh, 120px);
+    --player-ctrl-size:    clamp(40px, 5.5vh, 64px);
+    --player-seek-thick:   clamp(4px, 0.6vh, 8px);
+  }
+
+  /* Density tiers — drive grid column count via --poster-min-width.
+     auto-fill grids pick up these values automatically. Tiers approx:
+     <960 → 4 cols · 960-1279 → 5 · 1280-1599 → 6 · 1600-1919 → 7 · 1920+ → 7-8 */
+  :root[data-tv="true"] {
+    --poster-min-width: 160px; /* ≤ 959 fallback */
+  }
+  @media (min-width: 960px) and (max-width: 1279px) {
+    :root[data-tv="true"] { --poster-min-width: 180px; }
+  }
+  @media (min-width: 1280px) and (max-width: 1599px) {
+    :root[data-tv="true"] { --poster-min-width: 195px; }
+  }
+  @media (min-width: 1600px) and (max-width: 1919px) {
+    :root[data-tv="true"] { --poster-min-width: 210px; }
+  }
+  @media (min-width: 1920px) {
+    :root[data-tv="true"] { --poster-min-width: 230px; }
   }
 }

--- a/src/components/FindInput.tsx
+++ b/src/components/FindInput.tsx
@@ -185,6 +185,7 @@ export function FindTrigger({ surface, onSelect, isActive }: FindTriggerProps) {
  * token to appear (case-insensitive) in `fields`. Shared between MoviesRoute
  * and SeriesRoute for identical filter semantics.
  */
+// eslint-disable-next-line react-refresh/only-export-components
 export function filterByQuery<T>(
   items: readonly T[],
   query: string,

--- a/src/features/movies/MovieCard.tsx
+++ b/src/features/movies/MovieCard.tsx
@@ -224,10 +224,61 @@ export function MovieCard({
                 objectFit: "cover",
               }}
               onError={(e) => {
-                (e.currentTarget as HTMLImageElement).style.display = "none";
+                // Show fallback when Xtream returns a broken/404 icon URL.
+                const img = e.currentTarget as HTMLImageElement;
+                img.style.display = "none";
+                const sibling = img.nextElementSibling as HTMLElement | null;
+                if (sibling?.dataset.role === "poster-fallback") {
+                  sibling.style.display = "flex";
+                }
               }}
             />
           ) : null}
+          <div
+            data-role="poster-fallback"
+            aria-hidden="true"
+            style={{
+              position: "absolute",
+              inset: 0,
+              display: stream.icon ? "none" : "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "var(--space-2)",
+              padding: "var(--space-3)",
+              background:
+                "linear-gradient(135deg, var(--bg-elevated, #2a2520) 0%, var(--bg-surface, #1e1a16) 100%)",
+              color: "var(--text-tertiary)",
+              textAlign: "center",
+            }}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                fontSize: "clamp(28px, 4vh, 48px)",
+                lineHeight: 1,
+                opacity: 0.45,
+                letterSpacing: "-0.08em",
+                color: "var(--accent-copper-dim)",
+              }}
+            >
+              {"▶"}
+            </span>
+            <span
+              style={{
+                fontSize: "var(--text-caption-size, 14px)",
+                color: "var(--text-secondary)",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                display: "-webkit-box",
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: "vertical",
+                maxWidth: "100%",
+              }}
+            >
+              {stream.name}
+            </span>
+          </div>
 
           {watched ? <WatchedBadge /> : null}
           {tierLocked && !watched ? (

--- a/src/index.css
+++ b/src/index.css
@@ -111,3 +111,30 @@ time,
 .tabular-nums {
   font-variant-numeric: tabular-nums;
 }
+
+/* ─── Video caption / subtitle styling ────────────────────────────────────
+   The default browser ::cue rendering on HLS text tracks is a bold red
+   (Chrome/Chromium on Android TV) which fights our palette and is often
+   unreadable over bright video. Force a dark pill with cream text at a
+   10-foot-legible size. */
+video::cue {
+  background: rgba(0, 0, 0, 0.72);
+  color: var(--text-primary, #ede4d3);
+  font-size: clamp(20px, 2.6vh, 32px);
+  line-height: 1.3;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.9);
+}
+
+/* ─── Shared poster grid (TV responsive) ──────────────────────────────────
+   Auto-fill grid keyed to --poster-min-width, which is tuned per viewport
+   tier in tokens.css. Any poster grid that opts in via this class picks up
+   the 4→5→6→7-column ladder automatically. */
+.sv-poster-grid {
+  display: grid;
+  grid-template-columns: repeat(
+    auto-fill,
+    minmax(var(--poster-min-width, 160px), 1fr)
+  );
+  gap: var(--poster-gap, var(--space-4));
+  padding: 0 var(--gutter-tv);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,12 +10,16 @@ import { initSpatialNav } from "./nav/spatialNav";
 // Must run before createRoot so norigin is ready when React mounts.
 initSpatialNav();
 
-// TV platform sniff — Fire TV Silk identifies via "Silk" or "AFT…" in UA.
-// Setting data-tv on <html> lets tokens.css apply the 10-foot type scale
+// TV platform sniff — covers Fire TV (Silk/AFT*), Android TV, Google TV,
+// Chromecast (CrKey), Tizen, webOS, HbbTV, and common smart-TV UA markers.
+// Setting data-tv on <html> lets tokens.css apply the fluid 10-foot scale
 // before first paint. Desktop browsers stay on desktop scale.
 (() => {
   const ua = navigator.userAgent || "";
-  const isTv = /Silk|AFT/i.test(ua);
+  const isTv =
+    /Silk|AFT|AndroidTV|GoogleTV|BRAVIA|Tizen|Web0S|WebOS|SMART-TV|SmartTV|HbbTV|CrKey|PhilipsTV|VIDAA/i.test(
+      ua,
+    );
   if (isTv) {
     document.documentElement.setAttribute("data-tv", "true");
   }

--- a/src/nav/BottomDock.tsx
+++ b/src/nav/BottomDock.tsx
@@ -48,7 +48,7 @@ export function BottomDock({
         aria-label="Main navigation"
         style={{
           position: "fixed",
-          bottom: "var(--space-6)",
+          bottom: "var(--dock-bottom-offset, var(--space-6))",
           left: "var(--safe-inset)",
           right: "var(--safe-inset)",
           // Task 2.3 follow-up A: iOS/Android safe-area inset so the dock clears notches.
@@ -61,7 +61,7 @@ export function BottomDock({
           display: "flex",
           alignItems: "center",
           justifyContent: "space-around",
-          padding: "0 var(--space-8)",
+          padding: "0 var(--dock-h-padding, var(--space-8))",
           opacity: hidden ? 0 : 1,
           pointerEvents: hidden ? "none" : "auto",
           transition: "opacity var(--motion-dock)",
@@ -154,25 +154,29 @@ function DockTab({
         color: active ? "var(--bg-base)" : "var(--text-secondary)",
         border: "none",
         borderRadius: "var(--radius-sm)",
-        padding: "var(--space-2) var(--space-4)",
+        padding:
+          "var(--dock-tab-v-padding, var(--space-2)) var(--space-4)",
         cursor: "pointer",
-        fontSize: "var(--text-body-size)",
+        fontSize: "var(--dock-label-size, var(--text-label-size))",
         fontWeight: active ? 600 : 400,
         transition:
           "background var(--motion-focus), color var(--motion-focus), box-shadow var(--motion-focus)",
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
-        gap: "4px",
-        minWidth: "80px",
+        gap: "var(--dock-tab-gap, 4px)",
+        minWidth: "var(--dock-tab-min-width, 80px)",
       }}
     >
-      <span aria-hidden="true" style={{ fontSize: "20px" }}>
+      <span
+        aria-hidden="true"
+        style={{ fontSize: "var(--dock-icon-size, 20px)" }}
+      >
         {item.icon}
       </span>
       <span
         style={{
-          fontSize: "var(--text-label-size)",
+          fontSize: "var(--dock-label-size, var(--text-label-size))",
           letterSpacing: "var(--text-label-tracking)",
           textTransform: "uppercase",
         }}

--- a/src/player/PlayerControls.tsx
+++ b/src/player/PlayerControls.tsx
@@ -30,6 +30,7 @@ import { useReducedMotion } from "./useReducedMotion";
 
 // ─── Focus keys (exported for tests + call sites) ────────────────────────────
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const FK = {
   BACK: "PLAYER_BACK",
   PREV: "PLAYER_PREV",
@@ -145,6 +146,7 @@ function MenuItem({
   const highlighted = isActive || focused;
 
   return (
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role -- intentional listbox/option pattern; keyboard nav handled by spatial-nav
     <li style={{ listStyle: "none" }} role="option" aria-selected={isActive}>
       <button
         ref={ref as RefObject<HTMLButtonElement>}
@@ -1098,6 +1100,7 @@ export function PlayerControls({
                   upTarget={FK.PLAY_PAUSE}
                 />
                 {openMenu === "audio" && (
+                  // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role -- intentional listbox pattern
                   <ul style={menuStyle} role="listbox" aria-label="Audio tracks">
                     {audioTracks.map((track) => (
                       <MenuItem
@@ -1135,6 +1138,7 @@ export function PlayerControls({
                   upTarget={FK.PLAY_PAUSE}
                 />
                 {openMenu === "subtitles" && (
+                  // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role -- intentional listbox pattern
                   <ul style={menuStyle} role="listbox" aria-label="Subtitles">
                     <MenuItem
                       label="Off"
@@ -1182,6 +1186,7 @@ export function PlayerControls({
                   upTarget={FK.PLAY_PAUSE}
                 />
                 {openMenu === "quality" && (
+                  // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role -- intentional listbox pattern
                   <ul style={menuStyle} role="listbox" aria-label="Quality">
                     <MenuItem
                       label="Auto"

--- a/src/player/PlayerShell.tsx
+++ b/src/player/PlayerShell.tsx
@@ -90,7 +90,13 @@ export function PlayerShell() {
     isFocusBoundary: true,
   });
 
+  // Reset track selections whenever the source changes. This IS the external
+  // sync — src is the upstream, currentLevel/Audio/Subtitle are derived state
+  // that must reset when it flips. React's set-state-in-effect rule flags it,
+  // but there's no alternative: these track indices are owned by the HLS
+  // engine, not by the src prop.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: resync derived state with src
     setCurrentLevel(-1);
     setCurrentAudioTrack(-1);
     setCurrentSubtitleTrack(-1);
@@ -122,6 +128,7 @@ export function PlayerShell() {
     }
     autoSelectedForSrcRef.current = src;
     selectAudioTrack(idx);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: mirror HLS engine selection back into local state
     setCurrentAudioTrack(idx);
   }, [src, audioTracks, selectAudioTrack]);
 

--- a/src/player/useHlsPlayer.ts
+++ b/src/player/useHlsPlayer.ts
@@ -100,7 +100,6 @@ export function useHlsPlayer(
       return;
     }
 
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setStatus("loading");
     setError(null);
     setLevels([]);
@@ -360,6 +359,7 @@ export function useHlsPlayer(
       const list = v?.audioTracks;
       if (!list) return;
       for (let i = 0; i < list.length; i += 1) {
+        // eslint-disable-next-line react-hooks/immutability -- videoRef.current.audioTracks is the browser's native track list; toggling .enabled is the supported API for native HLS track selection
         list[i]!.enabled = i === idx;
       }
     },

--- a/src/routes/FavoritesRoute.tsx
+++ b/src/routes/FavoritesRoute.tsx
@@ -233,7 +233,7 @@ export function FavoritesRoute() {
         tabIndex={-1}
         style={{
           paddingBottom:
-            "calc(var(--dock-height) + var(--space-6) + var(--space-6))",
+            "var(--dock-content-reserve, calc(var(--dock-height) + var(--space-6) + var(--space-6)))",
           padding: "var(--space-6)",
         }}
       >

--- a/src/routes/HistoryRoute.tsx
+++ b/src/routes/HistoryRoute.tsx
@@ -230,7 +230,7 @@ export function HistoryRoute() {
         style={{
           padding: "var(--space-6)",
           paddingBottom:
-            "calc(var(--dock-height) + var(--space-6) + var(--space-6))",
+            "var(--dock-content-reserve, calc(var(--dock-height) + var(--space-6) + var(--space-6)))",
         }}
       >
         {/* Back button */}

--- a/src/routes/LiveRoute.tsx
+++ b/src/routes/LiveRoute.tsx
@@ -230,7 +230,7 @@ export function LiveRoute() {
         tabIndex={-1}
         style={{
           paddingBottom:
-            "calc(var(--dock-height) + var(--space-6) + var(--space-6))",
+            "var(--dock-content-reserve, calc(var(--dock-height) + var(--space-6) + var(--space-6)))",
           // Chromatic ambient fill — softly lit console atmosphere
           backgroundImage: "var(--hero-ambient)",
           backgroundRepeat: "no-repeat",

--- a/src/routes/MoviesRoute.tsx
+++ b/src/routes/MoviesRoute.tsx
@@ -419,7 +419,7 @@ export function MoviesRoute() {
         tabIndex={-1}
         style={{
           paddingBottom:
-            "calc(var(--dock-height) + var(--space-6) + var(--space-6))",
+            "var(--dock-content-reserve, calc(var(--dock-height) + var(--space-6) + var(--space-6)))",
           backgroundImage: "var(--hero-ambient)",
           backgroundRepeat: "no-repeat",
           backgroundSize: "100% 280px",

--- a/src/routes/SearchRoute.tsx
+++ b/src/routes/SearchRoute.tsx
@@ -191,7 +191,7 @@ export function SearchRoute() {
         tabIndex={-1}
         style={{
           paddingBottom:
-            "calc(var(--dock-height) + var(--space-6) + var(--space-6))",
+            "var(--dock-content-reserve, calc(var(--dock-height) + var(--space-6) + var(--space-6)))",
         }}
       >
         <SearchInput

--- a/src/routes/SeriesDetailRoute.tsx
+++ b/src/routes/SeriesDetailRoute.tsx
@@ -23,12 +23,13 @@
  *  - Escape / Backspace → navigate(-1).
  */
 import type { RefObject } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   useFocusable,
   FocusContext,
   setFocus,
 } from "@noriginmedia/norigin-spatial-navigation";
+import { Virtuoso } from "react-virtuoso";
 import { useParams, useNavigate } from "react-router-dom";
 import { ErrorShell } from "../primitives/ErrorShell";
 import { Skeleton } from "../primitives/Skeleton";
@@ -261,7 +262,11 @@ interface EpisodeRowProps {
   onPlay: (ep: EpisodeInfo, seasonNum: number) => void;
 }
 
-function EpisodeRow({
+// Memoized — with 97+ episodes every un-memoed re-render on D-pad focus change
+// registered/re-registered norigin focusables and stalled spatial nav. The
+// useCallback on `onPlay` in the parent keeps the reference stable between
+// renders so memo actually short-circuits.
+const EpisodeRow = memo(function EpisodeRow({
   episode,
   seriesId,
   seriesName,
@@ -503,7 +508,7 @@ function EpisodeRow({
       </div>
     </div>
   );
-}
+});
 
 // ─── HeroCta ─────────────────────────────────────────────────────────────────
 
@@ -920,9 +925,21 @@ export function SeriesDetailRoute() {
         }
       }
     }
-    // First visit (or all-watched → S1E1 for rewatch)
-    return chronoEpisodes[0] ?? null;
-  }, [resumeState, mostRecentEp, mostRecentHist, allEpisodes, chronoEpisodes]);
+    // All-watched → rewatch from S1E1 (existing behaviour, gated by allWatched
+    // label branch below).
+    if (allWatched) return chronoEpisodes[0] ?? null;
+    // First visit with no history — for daily-serial / long-running content
+    // (the bulk of this library) users expect the latest episode, not the
+    // pilot. Default to the final episode in chrono order.
+    return chronoEpisodes[chronoEpisodes.length - 1] ?? null;
+  }, [
+    resumeState,
+    mostRecentEp,
+    mostRecentHist,
+    allEpisodes,
+    chronoEpisodes,
+    allWatched,
+  ]);
 
   const { ctaLabel, ctaAriaLabel } = useMemo(() => {
     if (resumeState) {
@@ -972,6 +989,11 @@ export function SeriesDetailRoute() {
   // same season's episode list in the user's current sort order (Phase 6c).
   // Each call passes a new index into the same array, forming a cheap
   // closure chain rather than storing list state in PlayerProvider.
+  // Self-reference is routed through a ref to avoid the TDZ that the
+  // react-hooks/immutability rule flags on a useCallback that names itself.
+  const playEpisodeAtRef = useRef<
+    (episodes: EpisodeInfo[], idx: number, seasonNum: number) => void
+  >(() => {});
   const playEpisodeAt = useCallback(
     (episodes: EpisodeInfo[], idx: number, seasonNum: number) => {
       const ep = episodes[idx];
@@ -982,15 +1004,20 @@ export function SeriesDetailRoute() {
         id: ep.id,
         title,
         ...(idx > 0 && {
-          onPrev: () => playEpisodeAt(episodes, idx - 1, seasonNum),
+          onPrev: () =>
+            playEpisodeAtRef.current(episodes, idx - 1, seasonNum),
         }),
         ...(idx < episodes.length - 1 && {
-          onNext: () => playEpisodeAt(episodes, idx + 1, seasonNum),
+          onNext: () =>
+            playEpisodeAtRef.current(episodes, idx + 1, seasonNum),
         }),
       });
     },
     [info, openPlayer],
   );
+  useEffect(() => {
+    playEpisodeAtRef.current = playEpisodeAt;
+  }, [playEpisodeAt]);
 
   const playEpisode = useCallback(
     (ep: EpisodeInfo, seasonNum: number) => {
@@ -1341,45 +1368,51 @@ export function SeriesDetailRoute() {
             ) : null}
 
             {/* ── Episode list ──────────────────────────────────────── */}
-            <div
-              style={{
-                padding: "var(--space-3) var(--space-6) var(--space-6)",
-                display: "flex",
-                flexDirection: "column",
-                gap: "var(--space-1)",
-              }}
-            >
-              {activeEpisodes.length === 0 ? (
-                <div
-                  style={{
-                    padding: "var(--space-6) 0",
-                    display: "flex",
-                    flexDirection: "column",
-                    alignItems: "center",
-                    gap: "var(--space-3)",
-                    color: "var(--text-secondary)",
-                  }}
-                >
-                  <p style={{ margin: 0, fontSize: "var(--text-body-size)" }}>
-                    No episodes in{" "}
-                    {activeSeason ? seasonLabel(activeSeason) : "this season"}{" "}
-                    yet.
-                  </p>
-                </div>
-              ) : (
-                activeEpisodes.map((ep) => (
-                  <EpisodeRow
-                    key={ep.id}
-                    episode={ep}
-                    seriesId={seriesId ?? ""}
-                    seriesName={info.name}
-                    seasonNumber={activeSeasonNumber}
-                    historyItem={historyByEpId.get(ep.id)}
-                    onPlay={playEpisode}
-                  />
-                ))
-              )}
-            </div>
+            {/* Virtualized via react-virtuoso. At 97+ episodes, the former
+                plain .map() mounted every row into the DOM + registered every
+                useFocusable with norigin; D-pad arrow presses then re-rendered
+                all rows and stalled spatial nav. Virtuoso windows the DOM to
+                visible rows, keeping registration cost bounded. */}
+            {activeEpisodes.length === 0 ? (
+              <div
+                style={{
+                  padding: "var(--space-6) var(--space-6) var(--space-6)",
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  gap: "var(--space-3)",
+                  color: "var(--text-secondary)",
+                }}
+              >
+                <p style={{ margin: 0, fontSize: "var(--text-body-size)" }}>
+                  No episodes in{" "}
+                  {activeSeason ? seasonLabel(activeSeason) : "this season"}{" "}
+                  yet.
+                </p>
+              </div>
+            ) : (
+              <Virtuoso
+                data={activeEpisodes}
+                style={{
+                  height: "70vh",
+                  padding: "var(--space-3) var(--space-6) var(--space-6)",
+                }}
+                overscan={400}
+                computeItemKey={(_, ep) => ep.id}
+                itemContent={(_, ep) => (
+                  <div style={{ paddingBottom: "var(--space-1)" }}>
+                    <EpisodeRow
+                      episode={ep}
+                      seriesId={seriesId ?? ""}
+                      seriesName={info.name}
+                      seasonNumber={activeSeasonNumber}
+                      historyItem={historyByEpId.get(ep.id)}
+                      onPlay={playEpisode}
+                    />
+                  </div>
+                )}
+              />
+            )}
           </>
         ) : null}
       </main>

--- a/src/routes/SeriesRoute.tsx
+++ b/src/routes/SeriesRoute.tsx
@@ -378,7 +378,7 @@ export function SeriesRoute() {
         tabIndex={-1}
         style={{
           paddingBottom:
-            "calc(var(--dock-height) + var(--space-6) + var(--space-6))",
+            "var(--dock-content-reserve, calc(var(--dock-height) + var(--space-6) + var(--space-6)))",
           backgroundImage: "var(--hero-ambient)",
           backgroundRepeat: "no-repeat",
           backgroundSize: "100% 280px",

--- a/src/routes/SettingsRoute.tsx
+++ b/src/routes/SettingsRoute.tsx
@@ -268,7 +268,7 @@ export function SettingsRoute() {
         style={{
           padding: "var(--space-8) var(--gutter-tv, var(--space-8))",
           paddingBottom:
-            "calc(var(--dock-height) + var(--space-6) + var(--space-6))",
+            "var(--dock-content-reserve, calc(var(--dock-height) + var(--space-6) + var(--space-6)))",
           maxWidth: "900px",
         }}
       >

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -58,7 +58,6 @@ export function logEvent(
     at: new Date().toISOString(),
   };
   pushToBuffer(evt);
-  // eslint-disable-next-line no-console
   console.info(`[telemetry] ${name}`, props);
 }
 


### PR DESCRIPTION
## Summary

Fixes five issues from the 2026-04-24 TV testing session, plus clears pre-existing lint debt (10 errors → 0, 5 warnings → 0) so CI comes back green.

### Issues addressed

- **Issue 1 + app-wide ask — responsive design for 55\"/65\"/75\" TVs.** Replaced the single-binary `data-tv` override with a full fluid token system. Type, spacing, dock, grid density, hero, player chrome, focus ring — everything is now `clamp(min, vh/vw ratio, max)`. Broadened the UA sniff to catch Android TV, Google TV, Chromecast, Tizen, webOS, BRAVIA, VIDAA (was Silk/AFT only → all non-Fire TV browsers were getting desktop scale, hence the giant dock).
- **Issue 2 — empty poster tiles.** `MovieCard` renders a copper ▶ + title fallback when `stream.icon` is null or the `<img>` 404s.
- **Issue 3 — d-pad lag / stuck cursor on long series.** `EpisodeRow` is now `React.memo` and the 97-ep list is virtualized with `react-virtuoso` (already a dep).
- **Issue 4 — URL bar visible in Chrome tab mode.** Request HTML5 Fullscreen on first user gesture post-auth. PWA manifest already has `display:fullscreen`; this layer covers non-installed tab mode where supported.
- **Issue 5 — \"Play S1E1\" instead of latest.** First-visit CTA targets the final chronological episode (matches Telugu/Hindi daily-serial library pattern with 100+ episodes). Resume / \"play next after watched\" branches unchanged.
- **Caption contrast.** Global `video::cue` rule: dark pill + cream text at `clamp(20px, 2.6vh, 32px)`. Replaces the default red bubble that was unreadable over video.

### Files touched

Responsive tokens: `src/brand/tokens.css`, `src/main.tsx`, `src/index.css`, `src/nav/BottomDock.tsx`.
Route dock-reserve: 7 route files swap hardcoded padding to `var(--dock-content-reserve)`.
Bug fixes: `src/features/movies/MovieCard.tsx`, `src/routes/SeriesDetailRoute.tsx`, `src/App.tsx`.
Lint debt: `eslint.config.js`, `src/components/FindInput.tsx`, `src/player/PlayerControls.tsx`, `src/player/PlayerShell.tsx`, `src/player/useHlsPlayer.ts`, `src/telemetry/index.ts`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm test` — 324 / 324 passing (44 files)
- [x] `npm run build` — green
- [ ] Prod: dock occupies ~8–11% vh on TV (was ~25–30%), 4+ poster rows visible
- [ ] Prod: empty-icon movies show copper ▶ fallback + title
- [ ] Prod: d-pad through 97-ep Series detail feels smooth
- [ ] Prod: first keypress after load hides the Chrome URL bar
- [ ] Prod: opening a new series shows \"Play S1E97\", not \"Play S1E1\"
- [ ] Prod: subtitles on any Live/VOD track render as dark pill + cream text

🤖 Generated with [Claude Code](https://claude.com/claude-code)