### PR TITLE
fix(tv): 3+ rows of 4+ posters visible above dock

### DIFF
--- a/src/brand/tokens.css
+++ b/src/brand/tokens.css
@@ -309,7 +309,10 @@
       calc(var(--dock-height) + var(--dock-bottom-offset) + var(--space-6));
 
     /* ── Hero banner ─────────────────────────────────────────── */
-    --hero-height:         clamp(280px, 42vh, 560px);
+    /* Tightened 2026-04-23 evening — was clamp(280px, 42vh, 560px). User
+       wants ≥ 3 rows of posters visible above the dock; the old value stole
+       half the viewport. 28vh leaves ~60-70% of vh for the grid. */
+    --hero-height:         clamp(200px, 28vh, 380px);
     --hero-side-padding:   var(--gutter-tv);
 
     /* ── Poster card (2:3 aspect fixed; width fluid per tier) ── */
@@ -323,22 +326,25 @@
     --player-seek-thick:   clamp(4px, 0.6vh, 8px);
   }
 
-  /* Density tiers — drive grid column count via --poster-min-width.
-     auto-fill grids pick up these values automatically. Tiers approx:
-     <960 → 4 cols · 960-1279 → 5 · 1280-1599 → 6 · 1600-1919 → 7 · 1920+ → 7-8 */
+  /* Density tiers — drive auto-fill grid column count via --poster-min-width.
+     User ask 2026-04-23 evening: ≥ 3 rows of 4+ cards visible above the dock.
+     With a fixed 2:3 poster aspect, row height shrinks with column width, so
+     denser columns = more rows visible in the same viewport. Tiers below
+     target: ≤ 959 → 4-5 cols · 960-1279 → 6-7 · 1280-1599 → 7-8 ·
+     1600-1919 → 8-9 · 1920+ → 9-10. */
   :root[data-tv="true"] {
-    --poster-min-width: 160px; /* ≤ 959 fallback */
+    --poster-min-width: 120px; /* ≤ 959 fallback */
   }
   @media (min-width: 960px) and (max-width: 1279px) {
-    :root[data-tv="true"] { --poster-min-width: 180px; }
+    :root[data-tv="true"] { --poster-min-width: 138px; }
   }
   @media (min-width: 1280px) and (max-width: 1599px) {
-    :root[data-tv="true"] { --poster-min-width: 195px; }
+    :root[data-tv="true"] { --poster-min-width: 155px; }
   }
   @media (min-width: 1600px) and (max-width: 1919px) {
-    :root[data-tv="true"] { --poster-min-width: 210px; }
+    :root[data-tv="true"] { --poster-min-width: 175px; }
   }
   @media (min-width: 1920px) {
-    :root[data-tv="true"] { --poster-min-width: 230px; }
+    :root[data-tv="true"] { --poster-min-width: 195px; }
   }
 }

--- a/src/features/movies/MovieCard.tsx
+++ b/src/features/movies/MovieCard.tsx
@@ -303,10 +303,10 @@ export function MovieCard({
 
         <div
           style={{
-            padding: "var(--space-2) var(--space-3)",
+            padding: "var(--space-1) var(--space-2)",
             paddingRight: focused
-              ? "calc(var(--space-3) + 40px)"
-              : "var(--space-3)",
+              ? "calc(var(--space-2) + 32px)"
+              : "var(--space-2)",
             color: "var(--text-primary)",
             fontSize: "var(--text-label-size)",
             letterSpacing: "var(--text-label-tracking)",
@@ -322,7 +322,7 @@ export function MovieCard({
         {(stream.year ?? stream.rating) && (
           <div
             style={{
-              padding: "0 var(--space-3) var(--space-2)",
+              padding: "0 var(--space-2) var(--space-1)",
               color: "var(--text-secondary)",
               fontSize: "var(--text-caption-size)",
               fontVariantNumeric: "tabular-nums",

--- a/src/features/movies/MovieGrid.tsx
+++ b/src/features/movies/MovieGrid.tsx
@@ -32,15 +32,18 @@ export interface MovieGridProps {
 }
 
 function columnsForWidth(width: number): number {
-  // Card-density tuned for 10-foot readability. On a real Fire TV (reported
-  // 2026-04-24) 6 cols at 1280 CSS px felt oversized relative to the TV
-  // type scale; dropping one column per tier lands cards at ~250-280 px wide,
-  // which matches Netflix / Prime grid density on 1080p TVs.
-  if (width >= 1600) return 6;
-  if (width >= 1280) return 5;
-  if (width >= 960) return 4;
-  if (width >= 640) return 3;
-  return 2;
+  // User ask 2026-04-23 (evening): at least 3 rows of 4+ poster cards visible
+  // above the dock on TV viewports. With 2:3 poster aspect, row height scales
+  // with column width — to fit 3 rows, cards must be narrower, which means
+  // more columns per tier. These counts land cards at roughly 130-180 CSS px
+  // wide on 1080p and ~100-130 px on 720p, which is denser than Netflix but
+  // gives the user the row count they requested.
+  if (width >= 1920) return 9;
+  if (width >= 1600) return 8;
+  if (width >= 1280) return 7;
+  if (width >= 960) return 6;
+  if (width >= 640) return 4;
+  return 3;
 }
 
 function useResponsiveColumns(): number {
@@ -97,10 +100,11 @@ export function MovieGrid({
               style={{
                 display: "grid",
                 gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
-                gap: "var(--space-4)",
+                gap: "var(--space-3)",
                 padding: "0 var(--space-6)",
-                marginTop: rowIndex === 0 ? "var(--space-6)" : 0,
-                marginBottom: "var(--space-4)",
+                // Tightened 2026-04-23 evening for 3+ visible rows on TV.
+                marginTop: rowIndex === 0 ? "var(--space-3)" : 0,
+                marginBottom: "var(--space-3)",
               }}
             >
               {row.map((stream) => {

--- a/src/features/series/SeriesGrid.tsx
+++ b/src/features/series/SeriesGrid.tsx
@@ -66,10 +66,14 @@ export function SeriesGrid({
       aria-label="Series grid"
       style={{
         display: "grid",
+        // User ask 2026-04-23 evening: ≥ 3 rows visible above the dock.
+        // Drive the minimum card width off --poster-min-width so Series
+        // grid density matches the Movies grid's density tiers in
+        // tokens.css (120/138/155/175/195 px across viewport width).
         gridTemplateColumns:
-          "repeat(auto-fill, minmax(min(220px, 100%), 1fr))",
+          "repeat(auto-fill, minmax(min(var(--poster-min-width, 140px), 100%), 1fr))",
         gap: "var(--space-4)",
-        padding: "var(--space-4) var(--space-6)",
+        padding: "var(--space-3) var(--space-6)",
       }}
     >
       {items.map((item) => (


### PR DESCRIPTION
## Summary

Follow-up to #99. User asked for at least 2 rows, then bumped to 3+ rows of 4+ poster cards visible above the dock on TV viewports.

With a fixed 2:3 poster aspect, row height scales with column width, so denser columns = shorter rows = more rows visible in the same viewport.

## Changes

- **MovieGrid.columnsForWidth** — 2/3/4/5/6 → 3/4/6/7/8/9 across the same breakpoints, adding a 1920+ tier at 9 cols.
- **--poster-min-width tiers** — 160/180/195/210/230 → 120/138/155/175/195. Feeds the auto-fill Series + Favorites grids.
- **SeriesGrid** — hardcoded minmax(220px) → `var(--poster-min-width)` so Series tracks Movies density.
- **--hero-height** — `clamp(280px, 42vh, 560px)` → `clamp(200px, 28vh, 380px)`. Old value ate ~40% vh when present.
- **Row + footer spacing** — `--space-6/4/3` → `--space-3/2/1` in MovieGrid row margins + MovieCard label/year padding. Saves ~20–30 px per viewport.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm test` — 324 / 324 passing
- [x] `npm run build` — green
- [ ] Prod: ≥ 3 rows of 4+ posters visible above the dock on user's TV

🤖 Generated with [Claude Code](https://claude.com/claude-code)