### PR TITLE
docs+ux: clarify Find (in-route) vs Search (dock) — both intentional

### DIFF
--- a/docs/ux/02-series.md
+++ b/docs/ux/02-series.md
@@ -64,6 +64,12 @@ Same structure as Movies (`03-movies.md §2`). Differences:
 - Grid not virtualized by default — series count per language is typically <500. Virtualize only if we hit 2k+ on "All".
 - Card Enter navigates to detail, not plays
 
+### 2.0 FIND chip — in-route substring filter
+
+Identical contract to Movies (`03-movies.md §5.1`): a `🔍 FIND` pill in the toolbar that expands into a client-side substring filter over the already-loaded series union. Zero network. Runs `filterByQuery(seriesList, query, (s) => s.name)`. Empty state escalates to `/search?q=<findQuery>` — the dock Search tab (`04-search-and-language-rail.md`) is the only way to cross into Movies / Live from here.
+
+**Find vs Search (mental model).** FIND narrows this screen. Search crosses libraries. Both exist intentionally — removing either breaks a real flow. See `03-movies.md §5.1` for the full rationale.
+
 ### 2.1 Card states
 
 Badges on focused OR idle cards (not hover-only):

--- a/docs/ux/03-movies.md
+++ b/docs/ux/03-movies.md
@@ -142,6 +142,16 @@ Full spec in `00-ia §4` and `04-search-and-language-rail §A`. On Movies:
 
 **Deferred (backend gap):** Year filter, Genre filter, Rating min, "Most watched" sort. All flagged in `99-grill-findings`.
 
+### 5.1 FIND chip — in-route substring filter
+
+Added post-spec 2026-04-24 (documented here 2026-04-23 PR). A pill labelled `🔍 FIND` sits to the right of Sort. Pressing Enter reveals an inline input (`components/FindInput.tsx`); pressing Back / Esc collapses it again. The input is optional — the Sort + chip-trigger pattern keeps the bar narrow for dock-first users.
+
+**Scope.** Client-side. `filterByQuery(streams, query, (s) => s.name)` — zero network, tokenised, case-insensitive, every token must appear in the name. Runs against whatever the current language-union already returned. It does NOT cross into Series or Live.
+
+**Mental model — Find vs Search.** "FIND" narrows what's on this screen. The dock Search tab (`04-search-and-language-rail.md`) is the cross-library escalation: FTS across all three libraries, all languages. When Find's result set is empty, the empty state offers "Search everywhere" → `/search?q=<findQuery>` so the user can escalate with one D-pad press.
+
+**Why both exist.** Find is zero-latency (no on-screen-keyboard round-trip), scoped to the slice the user is already browsing, and doesn't change the route. Search is the only way to find a title when the user doesn't know which library holds it. Removing either breaks a real flow — see `99-grill-findings` §Search.
+
 ---
 
 ## 6. Card states

--- a/docs/ux/04-search-and-language-rail.md
+++ b/docs/ux/04-search-and-language-rail.md
@@ -7,6 +7,30 @@
 
 ---
 
+## 0.a Find vs Search — the two-tier model
+
+StreamVault ships **two** search-like affordances. They are intentionally different and both are load-bearing. Removing either breaks a real flow.
+
+| | **Search** (dock tab) | **Find** (in-route chip) |
+|---|---|---|
+| Lives on | Bottom dock (`Search` tab → `/search`) | Movies + Series toolbars (`🔍 FIND` pill) |
+| Scope | Live + Movies + Series, **all languages** | Current library, current language union only |
+| Backend | `GET /api/search?q=` — Postgres FTS, stemmed, ranked | None — zero network, filters in-memory |
+| Use case | "Where is *Panchayat*? Is it a movie or a series?" | "Filter these 1,234 Telugu movies by name" |
+| Latency | Network + debounce (250ms) | Immediate (keystroke-local) |
+| Empty state | Plain "no results" | **Escalates to `/search?q=<findQuery>`** — one D-pad press to cross libraries |
+| Implementation | `src/routes/SearchRoute.tsx` | `src/components/FindInput.tsx`, consumed by Movies + Series routes |
+
+**Mental model:** _Find narrows what's on this screen. Search crosses libraries._
+
+**Why both.** Find is zero-latency — no on-screen-keyboard round-trip, no route change, no loss of scroll position — so it's the right primitive for "I already know which library it's in, I just want to shrink the grid". Search is the only way to answer "I don't know if this title is a Movie or a Series" and the only way to hit FTS / stemming. The Movies/Series empty state hands `findQuery` off to `/search?q=…`, which this route preseeds from the URL param — so users never hit a dead end.
+
+**Naming guidance.** Keep the toolbar pill labelled `🔍 FIND` (not "Search"). Keep the dock tab labelled `Search`. The input placeholder on `/search` reads "Find across Live, Movies & Series…" to reinforce the cross-library framing.
+
+See `03-movies.md §5.1` and `02-series.md §2.0` for the in-route Find spec.
+
+---
+
 ## 0. Reality anchor
 
 | Available | Missing |

--- a/src/features/search/SearchInput.tsx
+++ b/src/features/search/SearchInput.tsx
@@ -47,7 +47,7 @@ export function SearchInput({ value, onChange, onSubmit }: SearchInputProps) {
         type="search"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="Type to search…"
+        placeholder="Find across Live, Movies & Series…"
         autoComplete="off"
         spellCheck={false}
         aria-label="Search channels, movies, and series"

--- a/src/routes/SearchRoute.tsx
+++ b/src/routes/SearchRoute.tsx
@@ -1,5 +1,13 @@
 /**
- * SearchRoute — unified search across Live / Movies / Series.
+ * SearchRoute — cross-library FTS across Live / Movies / Series.
+ *
+ * Relationship to in-route Find:
+ *   The FIND chip on /movies and /series is a client-side substring filter
+ *   over the already-loaded grid, scoped to the current library + current
+ *   language. This dock Search is the cross-library escalation — Postgres
+ *   full-text search, stemmed, ranked, all languages, returns three buckets.
+ *   Movies/Series empty states link here via /search?q=<findQuery>, which
+ *   this route preseeds from the URL param.
  *
  * Updated 2026-04-24 (search-favorites session):
  *   - Section order Movies → Series → Live (04 spec §3.4)
@@ -201,16 +209,28 @@ export function SearchRoute() {
         />
 
         {showHelp && (
-          <p
+          <div
             aria-live="polite"
             style={{
+              padding: "0 var(--space-6) var(--space-4)",
               color: "var(--text-secondary)",
               fontSize: "var(--text-body-size)",
-              padding: "0 var(--space-6) var(--space-4)",
             }}
           >
-            Type at least 2 characters to search
-          </p>
+            <p style={{ margin: 0 }}>
+              Find across Live, Movies &amp; Series — all languages.
+            </p>
+            <p
+              style={{
+                margin: "var(--space-1) 0 0",
+                fontSize: "var(--text-caption-size)",
+                color: "var(--text-tertiary)",
+              }}
+            >
+              Type at least 2 characters. For filtering inside a single
+              library, use FIND on Movies or Series instead.
+            </p>
+          </div>
         )}
 
         {hasResults && !loading && !error && (


### PR DESCRIPTION
## Summary

User asked 2026-04-23 evening: *\"do we need 2 searches, 1 on main bottom dock, and 1 on movies and series? what is the use of main dock [Search]?\"*

UX verdict: yes, both are load-bearing and do different jobs. Removing either breaks a real flow (the Movies/Series empty state already hands \`findQuery\` off to \`/search?q=…\`). Shipping the *naming / labelling* fix, plus closing the spec gap — the in-route Find has been shipped since the search-favorites session but wasn't documented in any UX spec, which is why it felt redundant.

## Two-tier model

|  | **Search** (dock) | **Find** (in-route chip) |
|---|---|---|
| Scope | All 3 libraries, all languages | Current library, current language |
| Backend | Postgres FTS, stemmed, ranked | Zero network, in-memory substring |
| Use case | \"Which library is *Panchayat* in?\" | \"Filter these 1,234 Telugu movies\" |
| Empty fallback | plain no-results | Escalates to \`/search?q=<query>\` |

Mental model: _Find narrows what's on this screen; Search crosses libraries._

## Changes

- **SearchRoute placeholder + help copy** — clarifies cross-library scope.
- **UX spec `04-search-and-language-rail.md` §0.a** — new section up front with the comparison table + naming guidance.
- **UX spec `03-movies.md` §5.1** — documents FIND chip for the first time.
- **UX spec `02-series.md` §2.0** — mirror for Series.
- No behaviour change; no new components; no backend contract change.

## Test plan

- [x] typecheck clean
- [x] lint: 0 errors, 0 warnings
- [x] npm test: 324 / 324
- [x] npm run build: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)