### PR TITLE
feat(pwa): Settings install hint — structural fix for URL bar

### DIFF
--- a/src/features/install/InstallHint.tsx
+++ b/src/features/install/InstallHint.tsx
@@ -1,0 +1,214 @@
+/**
+ * InstallHint — one-time nudge in Settings to install StreamVault as a PWA.
+ *
+ * Once installed (display:fullscreen kicks in structurally), the URL bar is
+ * gone by manifest — no JS fullscreen dance needed. In-tab mode keeps the
+ * graceful fullscreen-on-gesture fallback (see App.tsx).
+ *
+ * Visibility rules:
+ *   • Hidden when running as an installed PWA (display-mode matches).
+ *   • Hidden after the user dismisses (`sv_pwa_hint_dismissed` in localStorage).
+ *   • Hidden when `sv_pwa_installed` has been written by the appinstalled handler.
+ *
+ * Install path:
+ *   • If beforeinstallprompt was captured (Chromium-based TVs + Android TV
+ *     Chrome) → "Install" button triggers the native prompt.
+ *   • Otherwise → platform-specific manual instructions (Fire TV Silk, iOS
+ *     Safari, etc.). Detected once from UA.
+ */
+import type { ReactElement, RefObject } from "react";
+import { useState } from "react";
+import { useFocusable } from "@noriginmedia/norigin-spatial-navigation";
+import {
+  hasCapturedPrompt,
+  isRunningAsPWA,
+  triggerInstallPrompt,
+} from "./installPrompt";
+
+const DISMISS_KEY = "sv_pwa_hint_dismissed";
+const INSTALLED_KEY = "sv_pwa_installed";
+
+type Platform = "fireTv" | "androidTv" | "iosSafari" | "desktop" | "other";
+
+function detectPlatform(): Platform {
+  const ua = navigator.userAgent || "";
+  if (/Silk|AFT/i.test(ua)) return "fireTv";
+  if (/AndroidTV|GoogleTV|CrKey|BRAVIA|SmartTV|SMART-TV/i.test(ua))
+    return "androidTv";
+  if (/iPhone|iPad|iPod/i.test(ua) && /Safari/i.test(ua) && !/CriOS|FxiOS/i.test(ua))
+    return "iosSafari";
+  if (/Chrome|Edg/i.test(ua)) return "desktop";
+  return "other";
+}
+
+const INSTRUCTIONS: Record<Platform, string> = {
+  fireTv:
+    "Open the Silk browser menu (☰) and choose 'Add to Home Screen'. Pin the icon to your home for full-screen launches.",
+  androidTv:
+    "Open the Chrome overflow menu (⋮) and choose 'Add to Home screen' or 'Install StreamVault'.",
+  iosSafari:
+    "Tap the Share icon, then 'Add to Home Screen'.",
+  desktop:
+    "Click the install icon (⊕ or ⤓) in the address bar, or use the browser's ⋮ menu → 'Install StreamVault'.",
+  other:
+    "Use your browser's menu and choose 'Add to Home screen' or 'Install'.",
+};
+
+function readFlag(key: string): boolean {
+  try {
+    return localStorage.getItem(key) === "1";
+  } catch {
+    return false;
+  }
+}
+function writeFlag(key: string, value: "1" | null): void {
+  try {
+    if (value === null) localStorage.removeItem(key);
+    else localStorage.setItem(key, value);
+  } catch {
+    /* private mode / storage blocked */
+  }
+}
+
+export function InstallHint(): ReactElement | null {
+  // Compute on mount — changes during a session are rare.
+  const [visible, setVisible] = useState(() => {
+    if (typeof window === "undefined") return false;
+    if (isRunningAsPWA()) return false;
+    if (readFlag(INSTALLED_KEY)) return false;
+    if (readFlag(DISMISS_KEY)) return false;
+    return true;
+  });
+  // Platform sniff is UA-based and stable across a session — compute once
+  // on mount so render stays pure.
+  const [platform] = useState<Platform>(() =>
+    typeof window === "undefined" ? "other" : detectPlatform(),
+  );
+
+  const { ref: installRef, focused: installFocused } =
+    useFocusable<HTMLButtonElement>({
+      focusKey: "SETTINGS_PWA_INSTALL",
+      onEnterPress: () => void handleInstall(),
+    });
+  const { ref: dismissRef, focused: dismissFocused } =
+    useFocusable<HTMLButtonElement>({
+      focusKey: "SETTINGS_PWA_DISMISS",
+      onEnterPress: () => handleDismiss(),
+    });
+
+  async function handleInstall(): Promise<void> {
+    const outcome = await triggerInstallPrompt();
+    if (outcome === "accepted") {
+      writeFlag(INSTALLED_KEY, "1");
+      setVisible(false);
+    }
+  }
+  function handleDismiss(): void {
+    writeFlag(DISMISS_KEY, "1");
+    setVisible(false);
+  }
+
+  if (!visible) return null;
+
+  const promptAvailable = hasCapturedPrompt();
+  const instructions = INSTRUCTIONS[platform];
+
+  return (
+    <section
+      aria-labelledby="install-heading"
+      style={{
+        margin: "0 0 var(--space-8) 0",
+        padding: "var(--space-6)",
+        border: "1px solid rgba(200, 121, 65, 0.35)",
+        borderRadius: "var(--radius-md, 12px)",
+        background:
+          "linear-gradient(135deg, rgba(200,121,65,0.08) 0%, rgba(30,26,22,0.6) 100%)",
+      }}
+    >
+      <h2
+        id="install-heading"
+        style={{
+          margin: "0 0 var(--space-2) 0",
+          fontSize: "var(--text-body-lg-size)",
+          fontWeight: 600,
+          color: "var(--text-primary)",
+        }}
+      >
+        Install StreamVault for full-screen
+      </h2>
+      <p
+        style={{
+          margin: "0 0 var(--space-4) 0",
+          color: "var(--text-secondary)",
+          fontSize: "var(--text-body-size)",
+          lineHeight: 1.4,
+        }}
+      >
+        Installing removes the browser URL bar for good and launches the app
+        in its own window. Your library, history, and preferences stay the
+        same.
+      </p>
+      {!promptAvailable && (
+        <p
+          style={{
+            margin: "0 0 var(--space-4) 0",
+            color: "var(--text-tertiary)",
+            fontSize: "var(--text-caption-size)",
+            lineHeight: 1.4,
+          }}
+        >
+          {instructions}
+        </p>
+      )}
+      <div
+        style={{
+          display: "flex",
+          gap: "var(--space-3)",
+          flexWrap: "wrap",
+        }}
+      >
+        {promptAvailable && (
+          <button
+            ref={installRef as RefObject<HTMLButtonElement>}
+            type="button"
+            onClick={() => void handleInstall()}
+            className="focus-ring"
+            style={{
+              background: installFocused
+                ? "var(--accent-copper)"
+                : "var(--accent-copper-dim)",
+              color: "var(--bg-base)",
+              border: "none",
+              borderRadius: "var(--radius-sm, 8px)",
+              padding: "var(--space-3) var(--space-6)",
+              fontSize: "var(--text-body-size)",
+              fontWeight: 600,
+              cursor: "pointer",
+            }}
+          >
+            Install
+          </button>
+        )}
+        <button
+          ref={dismissRef as RefObject<HTMLButtonElement>}
+          type="button"
+          onClick={handleDismiss}
+          className="focus-ring"
+          style={{
+            background: dismissFocused
+              ? "rgba(237, 228, 211, 0.14)"
+              : "transparent",
+            color: "var(--text-secondary)",
+            border: "1px solid rgba(237, 228, 211, 0.24)",
+            borderRadius: "var(--radius-sm, 8px)",
+            padding: "var(--space-3) var(--space-6)",
+            fontSize: "var(--text-body-size)",
+            cursor: "pointer",
+          }}
+        >
+          Not now
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/features/install/installPrompt.ts
+++ b/src/features/install/installPrompt.ts
@@ -1,0 +1,68 @@
+/**
+ * PWA install prompt capture + helpers.
+ *
+ * `beforeinstallprompt` fires exactly once per page load on browsers that
+ * support PWA install (Chromium-based). If we don't capture it, the event is
+ * lost and we can never trigger the install UI programmatically. `captureInstallPrompt()`
+ * runs from main.tsx before React mounts so we catch it regardless of which
+ * route the user lands on.
+ *
+ * Consumers (Settings InstallHint) read via `getCapturedPrompt()` and call
+ * `triggerInstallPrompt()` to fire the native install UI.
+ *
+ * Fire TV Silk / older TV browsers don't fire this event — consumers fall
+ * back to platform-specific manual instructions in that case.
+ */
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
+}
+
+let captured: BeforeInstallPromptEvent | null = null;
+
+export function captureInstallPrompt(): void {
+  window.addEventListener("beforeinstallprompt", (e) => {
+    e.preventDefault();
+    captured = e as BeforeInstallPromptEvent;
+  });
+  window.addEventListener("appinstalled", () => {
+    captured = null;
+    try {
+      localStorage.setItem("sv_pwa_installed", "1");
+    } catch {
+      /* storage may be blocked in private mode */
+    }
+  });
+}
+
+export function hasCapturedPrompt(): boolean {
+  return captured !== null;
+}
+
+export async function triggerInstallPrompt(): Promise<"accepted" | "dismissed" | "unavailable"> {
+  if (!captured) return "unavailable";
+  try {
+    await captured.prompt();
+    const { outcome } = await captured.userChoice;
+    captured = null;
+    return outcome;
+  } catch {
+    return "unavailable";
+  }
+}
+
+/** True when the app is running as an installed PWA (not an in-browser tab). */
+export function isRunningAsPWA(): boolean {
+  if (typeof window === "undefined") return false;
+  const mm = typeof window.matchMedia === "function" ? window.matchMedia : null;
+  if (
+    mm &&
+    (mm("(display-mode: fullscreen)").matches ||
+      mm("(display-mode: standalone)").matches)
+  ) {
+    return true;
+  }
+  const navAny = navigator as Navigator & { standalone?: boolean };
+  return navAny.standalone === true;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,9 +6,15 @@ import "./index.css";
 import "./primitives/index.css"; // aggregator — all primitive stylesheets
 import App from "./App.tsx";
 import { initSpatialNav } from "./nav/spatialNav";
+import { captureInstallPrompt } from "./features/install/installPrompt";
 
 // Must run before createRoot so norigin is ready when React mounts.
 initSpatialNav();
+
+// `beforeinstallprompt` fires once per load and must be captured synchronously
+// on the window, BEFORE React mounts — otherwise the event is lost and the
+// Settings InstallHint can't programmatically trigger the native install UI.
+captureInstallPrompt();
 
 // TV platform sniff — covers Fire TV (Silk/AFT*), Android TV, Google TV,
 // Chromecast (CrKey), Tizen, webOS, HbbTV, and common smart-TV UA markers.

--- a/src/routes/SettingsRoute.tsx
+++ b/src/routes/SettingsRoute.tsx
@@ -18,6 +18,7 @@ import { logout } from "../api/auth";
 import { ChangePasswordForm } from "../features/settings/ChangePasswordForm";
 import { PreferencesPanel } from "../features/settings/PreferencesPanel";
 import { AppInfoPanel } from "../features/settings/AppInfoPanel";
+import { InstallHint } from "../features/install/InstallHint";
 import "../features/settings/settings.css";
 
 // ─── Read username from the session sentinel ─────────────────────────────────
@@ -357,6 +358,7 @@ export function SettingsRoute() {
           Settings
         </h1>
 
+        <InstallHint />
         <AccountSection onLoggedOut={handleLoggedOut} />
         <ShortcutsSection />
         <PreferencesPanel />


### PR DESCRIPTION
## Why

The in-tab fullscreen fallback (event-armed pattern in #105) is a graceful hack. The structural fix for the URL bar is to run as an installed PWA — the manifest already declares \`display:fullscreen\`, so once installed there's literally no chrome.

## What

- \`src/features/install/installPrompt.ts\` — captures \`beforeinstallprompt\` before React mounts (the event fires once and is lost if we miss it), exposes \`hasCapturedPrompt\` / \`triggerInstallPrompt\` / \`isRunningAsPWA\`.
- \`src/features/install/InstallHint.tsx\` — dismissible card rendered at the top of Settings. Uses the captured prompt when available, falls back to platform-specific manual instructions (Fire TV Silk, Android TV, iOS Safari, desktop).
- Hidden when already installed (\`display-mode\` matches) or when the user has dismissed / installed previously.
- \`main.tsx\` wires up \`captureInstallPrompt()\` pre-mount.
- \`SettingsRoute\` renders \`<InstallHint />\` above \`AccountSection\`.

## Test plan

- [x] typecheck clean
- [x] lint 0 / 0
- [x] 327 / 327 tests
- [x] build green
- [ ] On TV: hint visible in Settings when not installed
- [ ] On TV: install via native prompt (where supported) or manual instructions
- [ ] Installed PWA run: hint hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)