### PR TITLE
feat(perf): Fire TV performance suite against prod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ coverage/
 # Playwright artefacts
 test-results/
 playwright-report/
+playwright-report-prod/
+# Perf suite output (regenerated per run)
+perf-artifacts/
+perf-report.md
+perf-report.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,17 +31,20 @@
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.4",
         "axe-core": "^4.11.3",
+        "chrome-launcher": "^1.2.1",
         "eslint": "^9.39.4",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "jsdom": "^29.0.2",
+        "lighthouse": "^12.8.2",
         "tailwindcss": "^4.2.2",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.4",
-        "vitest": "^4.1.4"
+        "vitest": "^4.1.4",
+        "web-vitals": "^4.2.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -737,6 +740,62 @@
         }
       }
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -870,6 +929,605 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
+      "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+      "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib": {
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.46.1.tgz",
+      "integrity": "sha512-AyXVnlCf/xV3K/rNumzKxZqsULyITJH6OVLiW6730JPRqWA7Zc9bvYoVNpN6iOpTU8CasH34SU/ksVJmObFibQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.43.1.tgz",
+      "integrity": "sha512-ht7YGWQuV5BopMcw5Q2hXn3I8eG8TH0J/kc/GMcW4CuNTgiP6wCu44BOnucJWL3CmFWaRHI//vWyAhaC8BwePw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/connect": "3.4.38"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-dataloader": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.16.1.tgz",
+      "integrity": "sha512-K/qU4CjnzOpNkkKO4DfCLSQshejRNAJtd4esgigo/50nxCB6XCyi1dhAblUHM9jG5dRm8eu0FB+t87nIo99LYQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-express": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.47.1.tgz",
+      "integrity": "sha512-QNXPTWteDclR2B4pDFpz0TNghgB33UMjUt14B+BZPmtH1MwUFAfLHBaP5If0Z5NZC+jaH8oF2glgYjrmhZWmSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.19.1.tgz",
+      "integrity": "sha512-6g0FhB3B9UobAR60BGTcXg4IHZ6aaYJzp0Ki5FhnxyAPt8Ns+9SSvgcrnsN2eGmk3RWG5vYycUGOEApycQL24A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-generic-pool": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.43.1.tgz",
+      "integrity": "sha512-M6qGYsp1cURtvVLGDrPPZemMFEbuMmCXgQYTReC/IbimV5sGrLBjB+/hANUpRZjX67nGLdKSVLZuQQAiNz+sww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.47.1.tgz",
+      "integrity": "sha512-EGQRWMGqwiuVma8ZLAZnExQ7sBvbOx0N/AE/nlafISPs8S+QtXX+Viy6dcQwVWwYHQPAcuY3bFt3xgoAwb4ZNQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-hapi": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.45.2.tgz",
+      "integrity": "sha512-7Ehow/7Wp3aoyCrZwQpU7a2CnoMq0XhIcioFuKjBb0PLYfBfmTsFTUyatlHu0fRxhwcRsSQRTvEhmZu8CppBpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.2.tgz",
+      "integrity": "sha512-1Uz5iJ9ZAlFOiPuwYg29Bf7bJJc/GeoeJIFKJYQf67nTVKFe8RHbEtxgkOmK4UGZNHKXcpW4P8cWBYzBn1USpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/instrumentation": "0.57.2",
+        "@opentelemetry/semantic-conventions": "1.28.0",
+        "forwarded-parse": "2.1.2",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-ioredis": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.47.1.tgz",
+      "integrity": "sha512-OtFGSN+kgk/aoKgdkKQnBsQFDiG8WdCxu+UrHr0bXScdAmtSzLSraLo7wFIb25RVHfRWvzI5kZomqJYEg/l1iA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/redis-common": "^0.36.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-kafkajs": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.7.1.tgz",
+      "integrity": "sha512-OtjaKs8H7oysfErajdYr1yuWSjMAectT7Dwr+axIoZqT9lmEOkD/H/3rgAs8h/NIuEi2imSXD+vL4MZtOuJfqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-knex": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.44.1.tgz",
+      "integrity": "sha512-U4dQxkNhvPexffjEmGwCq68FuftFK15JgUF05y/HlK3M6W/G2iEaACIfXdSnwVNe9Qh0sPfw8LbOPxrWzGWGMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-koa": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.47.1.tgz",
+      "integrity": "sha512-l/c+Z9F86cOiPJUllUCt09v+kICKvT+Vg1vOAJHtHPsJIzurGayucfCMq2acd/A/yxeNWunl9d9eqZ0G+XiI6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.44.1.tgz",
+      "integrity": "sha512-5MPkYCvG2yw7WONEjYj5lr5JFehTobW7wX+ZUFy81oF2lr9IPfZk9qO+FTaM0bGEiymwfLwKe6jE15nHn1nmHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.52.0.tgz",
+      "integrity": "sha512-1xmAqOtRUQGR7QfJFfGV/M2kC7wmI2WgZdpru8hJl3S0r4hW0n3OQpEHlSGXJAaNFyvT+ilnwkT+g5L4ljHR6g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongoose": {
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.46.1.tgz",
+      "integrity": "sha512-3kINtW1LUTPkiXFRSSBmva1SXzS/72we/jL22N+BnF3DFcoewkdkHPYOIdAAk9gSicJ4d5Ojtt1/HeibEc5OQg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.45.1.tgz",
+      "integrity": "sha512-TKp4hQ8iKQsY7vnp/j0yJJ4ZsP109Ht6l4RHTj0lNEG1TfgTrIH5vJMbgmoYXWzNHAqBH2e7fncN12p3BP8LFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/mysql": "2.15.26"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql2": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.2.tgz",
+      "integrity": "sha512-h6Ad60FjCYdJZ5DTz1Lk2VmQsShiViKe0G7sYikb0GHI0NVvApp2XQNRHNjEMz87roFttGPLHOYVPlfy+yVIhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/sql-common": "^0.40.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.51.1.tgz",
+      "integrity": "sha512-QxgjSrxyWZc7Vk+qGSfsejPVFL1AgAJdSBMYZdDUbwg730D09ub3PXScB9d04vIqPriZ+0dqzjmQx0yWKiCi2Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.26.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/sql-common": "^0.40.1",
+        "@types/pg": "8.6.1",
+        "@types/pg-pool": "2.0.6"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis-4": {
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.46.1.tgz",
+      "integrity": "sha512-UMqleEoabYMsWoTkqyt9WAzXwZ4BlFZHO40wr3d5ZvtjKCHlD4YXLm+6OLCeIi/HkX7EXvQaz8gtAwkwwSEvcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/redis-common": "^0.36.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.18.1.tgz",
+      "integrity": "sha512-5Cuy/nj0HBaH+ZJ4leuD7RjgvA844aY2WW+B5uLcWtxGjRZl3MNLuxnNg5DYWZNPO+NafSSnra0q49KWAHsKBg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/tedious": "^4.0.14"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.10.1.tgz",
+      "integrity": "sha512-rkOGikPEyRpMCmNu9AQuV5dtRlDmJp2dK5sw8roVshAGoB6hH/3QjDtRhdwd75SsJwgynWUNRUYe0wAkTo16tQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@opentelemetry/redis-common": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
+      "integrity": "sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.40.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.40.1.tgz",
+      "integrity": "sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.124.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
@@ -878,6 +1536,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@paulirish/trace_engine": {
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.59.tgz",
+      "integrity": "sha512-439NUzQGmH+9Y017/xCchBP9571J4bzhpcNhrxorf7r37wcyJZkgUfrUsRL3xl+JDcZ6ORhoFCzCw98c6S3YHw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "legacy-javascript": "latest",
+        "third-party-web": "latest"
       }
     },
     "node_modules/@playwright/test": {
@@ -894,6 +1563,54 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@prisma/instrumentation": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.11.1.tgz",
+      "integrity": "sha512-mrZOev24EDhnefmnZX7WVVT7v+r9LttPRqf54ONvj6re4XMF7wFTpK2tLJi4XHB7fFp/6xhYbgRel8YV7gQiyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.8"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
+      "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@remix-run/router": {
@@ -1168,6 +1885,133 @@
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sentry/core": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.47.1.tgz",
+      "integrity": "sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.47.1.tgz",
+      "integrity": "sha512-CDbkasBz3fnWRKSFs6mmaRepM2pa+tbZkrqhPWifFfIkJDidtVW40p6OnquTvPXyPAszCnDZRnZT14xyvNmKPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1",
+        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/instrumentation": "^0.57.2",
+        "@opentelemetry/instrumentation-amqplib": "^0.46.1",
+        "@opentelemetry/instrumentation-connect": "0.43.1",
+        "@opentelemetry/instrumentation-dataloader": "0.16.1",
+        "@opentelemetry/instrumentation-express": "0.47.1",
+        "@opentelemetry/instrumentation-fs": "0.19.1",
+        "@opentelemetry/instrumentation-generic-pool": "0.43.1",
+        "@opentelemetry/instrumentation-graphql": "0.47.1",
+        "@opentelemetry/instrumentation-hapi": "0.45.2",
+        "@opentelemetry/instrumentation-http": "0.57.2",
+        "@opentelemetry/instrumentation-ioredis": "0.47.1",
+        "@opentelemetry/instrumentation-kafkajs": "0.7.1",
+        "@opentelemetry/instrumentation-knex": "0.44.1",
+        "@opentelemetry/instrumentation-koa": "0.47.1",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.44.1",
+        "@opentelemetry/instrumentation-mongodb": "0.52.0",
+        "@opentelemetry/instrumentation-mongoose": "0.46.1",
+        "@opentelemetry/instrumentation-mysql": "0.45.1",
+        "@opentelemetry/instrumentation-mysql2": "0.45.2",
+        "@opentelemetry/instrumentation-pg": "0.51.1",
+        "@opentelemetry/instrumentation-redis-4": "0.46.1",
+        "@opentelemetry/instrumentation-tedious": "0.18.1",
+        "@opentelemetry/instrumentation-undici": "0.10.1",
+        "@opentelemetry/resources": "^1.30.1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
+        "@prisma/instrumentation": "6.11.1",
+        "@sentry/core": "9.47.1",
+        "@sentry/node-core": "9.47.1",
+        "@sentry/opentelemetry": "9.47.1",
+        "import-in-the-middle": "^1.14.2",
+        "minimatch": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-9.47.1.tgz",
+      "integrity": "sha512-7TEOiCGkyShJ8CKtsri9lbgMCbB+qNts2Xq37itiMPN2m+lIukK3OX//L8DC5nfKYZlgikrefS63/vJtm669hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "9.47.1",
+        "@sentry/opentelemetry": "9.47.1",
+        "import-in-the-middle": "^1.14.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/resources": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.47.1.tgz",
+      "integrity": "sha512-STtFpjF7lwzeoedDJV+5XA6P89BfmFwFftmHSGSe3UTI8z8IoiR5yB6X2vCjSPvXlfeOs13qCNNCEZyznxM8Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "9.47.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -1538,6 +2382,13 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1568,6 +2419,16 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1589,6 +2450,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mysql": {
+      "version": "2.15.26",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
+      "integrity": "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
@@ -1597,6 +2468,28 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
+      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
+      "integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "*"
       }
     },
     "node_modules/@types/react": {
@@ -1617,6 +2510,34 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/shimmer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tedious": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2097,6 +3018,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -2105,6 +3036,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2124,13 +3065,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2278,6 +3228,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2312,6 +3275,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -2350,12 +3324,124 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
+      "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
+      "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.19",
@@ -2368,6 +3454,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/bidi-js": {
@@ -2423,6 +3519,16 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/call-bind": {
@@ -2533,6 +3639,71 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chrome-launcher": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.1.tgz",
+      "integrity": "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^2.0.1"
+      },
+      "bin": {
+        "print-chrome-path": "bin/print-chrome-path.cjs"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/chromium-bidi/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2560,6 +3731,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/configstore": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
+      "integrity": "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "atomically": "^2.0.3",
+        "dot-prop": "^9.0.0",
+        "graceful-fs": "^4.2.11",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2581,6 +3771,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csp_evaluator": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/csp_evaluator/-/csp_evaluator-1.1.5.tgz",
+      "integrity": "sha512-EL/iN9etCTzw/fBnp0/uj0f5BOOGvZut2mzsiiBZ/FdT6gFQCKRO/tmcKOxn5drWZ2Ndm/xBb1SI4zwWbGtmIw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
@@ -2616,6 +3813,16 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -2735,6 +3942,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
@@ -2751,6 +3968,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/dequal": {
@@ -2773,6 +4005,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1507524",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1507524.tgz",
+      "integrity": "sha512-OjaNE7qpk6GRTXtqQjAE5bGx6+c4F1zZH0YXtpZQLM92HNXx4zMAaqlKhP4T52DosG6hDW8gPMNhGOF8xbwk/w==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -2780,6 +4019,22 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dot-prop": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2810,6 +4065,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
@@ -2822,6 +4087,20 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/entities": {
@@ -3022,6 +4301,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
     "node_modules/eslint": {
       "version": "9.39.4",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
@@ -3200,6 +4501,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -3256,6 +4571,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3266,10 +4591,38 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3286,6 +4639,16 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3372,6 +4735,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3448,6 +4818,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3487,6 +4867,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -3503,6 +4899,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/glob-parent": {
@@ -3705,6 +5116,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-link-header": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.3.tgz",
+      "integrity": "sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3714,6 +5163,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/image-ssim": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
+      "integrity": "sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -3730,6 +5186,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+      "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
       }
     },
     "node_modules/imurmurhash": {
@@ -3765,6 +5234,29 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -3851,6 +5343,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-data-view": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
@@ -3886,6 +5394,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3910,6 +5434,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -4140,6 +5674,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -4201,6 +5748,23 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-library-detector": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/js-library-detector/-/js-library-detector-6.7.0.tgz",
+      "integrity": "sha512-c80Qupofp43y4cJ7+8TTDN/AsDwLi5oOm/plBrWI+iQt485vKXCco+yVmOwEgdo9VOdsYTuV0UlTeetVPTriXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/js-tokens": {
@@ -4367,6 +5931,13 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/legacy-javascript": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/legacy-javascript/-/legacy-javascript-0.0.1.tgz",
+      "integrity": "sha512-lPyntS4/aS7jpuvOlitZDFifBCb4W8L/3QU0PLbUTUj+zYah8rfVjYic88yG7ZKTxhS5h9iz7duT8oUXKszLhg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4380,6 +5951,68 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lighthouse": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-12.8.2.tgz",
+      "integrity": "sha512-+5SKYzVaTFj22MgoYDPNrP9tlD2/Ay7j3SxPSFD9FpPyVxGr4UtOQGKyrdZ7wCmcnBaFk0mCkPfARU3CsE0nvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@paulirish/trace_engine": "0.0.59",
+        "@sentry/node": "^9.28.1",
+        "axe-core": "^4.10.3",
+        "chrome-launcher": "^1.2.0",
+        "configstore": "^7.0.0",
+        "csp_evaluator": "1.1.5",
+        "devtools-protocol": "0.0.1507524",
+        "enquirer": "^2.3.6",
+        "http-link-header": "^1.1.1",
+        "intl-messageformat": "^10.5.3",
+        "jpeg-js": "^0.4.4",
+        "js-library-detector": "^6.7.0",
+        "lighthouse-logger": "^2.0.2",
+        "lighthouse-stack-packs": "1.12.2",
+        "lodash-es": "^4.17.21",
+        "lookup-closest-locale": "6.2.0",
+        "metaviewport-parser": "0.3.0",
+        "open": "^8.4.0",
+        "parse-cache-control": "1.0.1",
+        "puppeteer-core": "^24.17.1",
+        "robots-parser": "^3.0.1",
+        "speedline-core": "^1.4.3",
+        "third-party-web": "^0.27.0",
+        "tldts-icann": "^7.0.12",
+        "ws": "^7.0.0",
+        "yargs": "^17.3.1",
+        "yargs-parser": "^21.0.0"
+      },
+      "bin": {
+        "chrome-debug": "core/scripts/manual-chrome-launcher.js",
+        "lighthouse": "cli/index.js",
+        "smokehouse": "cli/test/smokehouse/frontends/smokehouse-bin.js"
+      },
+      "engines": {
+        "node": ">=18.16"
+      }
+    },
+    "node_modules/lighthouse-logger": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
+      "integrity": "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "marky": "^1.2.2"
+      }
+    },
+    "node_modules/lighthouse-stack-packs": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.12.2.tgz",
+      "integrity": "sha512-Ug8feS/A+92TMTCK6yHYLwaFMuelK/hAKRMdldYkMNwv+d9PtWxjXEg6rwKtsUXTADajhdrhXyuNCJ5/sfmPFw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -4664,10 +6297,24 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lookup-closest-locale": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz",
+      "integrity": "sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4743,6 +6390,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/marky": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4759,6 +6413,13 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/metaviewport-parser": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.3.0.tgz",
+      "integrity": "sha512-EoYJ8xfjQ6kpe9VbVHvZTZHiOl4HL1Z18CrZ+qahvLXT7ZO4YTC2JMyt5FaUp9JJp6J4Ybb/z7IsCXZt86/QkQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -4782,6 +6443,20 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mpegts.js": {
       "version": "1.8.0",
@@ -4825,6 +6500,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.37",
@@ -4926,6 +6611,34 @@
       ],
       "license": "MIT"
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4994,6 +6707,40 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5006,6 +6753,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
+      "dev": true
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -5040,12 +6793,60 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5153,6 +6954,49 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5193,6 +7037,64 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5201,6 +7103,54 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.42.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.42.0.tgz",
+      "integrity": "sha512-T4zXokk/izH01fYPhyyev1A4piWiOKrYq7CUFpdoYQxmOnXoV6YjUabmfIjCYkNspSoAXIxRid3Tw+Vg0fthYg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.0",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1595872",
+        "typed-query-selector": "^2.12.1",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/devtools-protocol": {
+      "version": "0.0.1595872",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
+      "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/puppeteer-core/node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/react": {
@@ -5332,6 +7282,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -5342,6 +7302,43 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5350,6 +7347,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/robots-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.1.tgz",
+      "integrity": "sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/rolldown": {
@@ -5549,6 +7556,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -5632,6 +7646,58 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5640,6 +7706,21 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/speedline-core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/speedline-core/-/speedline-core-1.4.3.tgz",
+      "integrity": "sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "image-ssim": "^0.2.0",
+        "jpeg-js": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/stackback": {
@@ -5669,6 +7750,40 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -5744,6 +7859,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -5770,6 +7898,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5781,6 +7926,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/symbol-tree": {
@@ -5810,6 +7968,61 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/third-party-web": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.27.0.tgz",
+      "integrity": "sha512-h0JYX+dO2Zr3abCQpS6/uFjujaOjA1DyDzGQ41+oFn9VW/ARiq9g5ln7qEP9+BTzDpOMyIfsfj4OvfgXAsMUSA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -5875,6 +8088,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tldts-icann": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.28.tgz",
+      "integrity": "sha512-brkN3yIgYTzBpSxB71XYBwUMDgutmKmA+6TWzgGD/EPcvCc6LHMTRaYj9ik1u3BxhSW53qIK/7cgjA2rF7BgbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -5919,8 +8142,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5933,6 +8155,19 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -6012,6 +8247,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
+      "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "6.0.2",
@@ -6309,6 +8551,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -6348,6 +8604,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -6481,6 +8744,66 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -6498,12 +8821,72 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,12 @@
     "test:e2e": "playwright test",
     "test:e2e:prod": "playwright test --config=playwright.prod.config.ts",
     "typecheck": "tsc --noEmit",
-    "check-budget": "node scripts/check-bundle-budget.js"
+    "check-budget": "node scripts/check-bundle-budget.js",
+    "perf:prod": "node scripts/run-perf-prod.mjs",
+    "perf:playwright": "playwright test --config=playwright.perf.config.ts",
+    "perf:lh": "node tests/perf/lighthouse-routes.mjs",
+    "perf:report": "node scripts/build-perf-report.mjs",
+    "perf:serve": "python3 -m http.server 8080 --directory perf-artifacts"
   },
   "dependencies": {
     "@noriginmedia/norigin-spatial-navigation": "2.1.0",
@@ -38,16 +43,19 @@
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.4",
     "axe-core": "^4.11.3",
+    "chrome-launcher": "^1.2.1",
     "eslint": "^9.39.4",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "jsdom": "^29.0.2",
+    "lighthouse": "^12.8.2",
     "tailwindcss": "^4.2.2",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.4",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.4",
+    "web-vitals": "^4.2.4"
   }
 }

--- a/playwright.perf.config.ts
+++ b/playwright.perf.config.ts
@@ -1,0 +1,78 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Fire TV performance suite against production.
+ *
+ * Separate from `playwright.prod.config.ts` (prod smoke) because perf runs need:
+ *   - workers=1 (parallelism skews CPU throttling)
+ *   - retries=0 (a retried run is unrepresentative)
+ *   - NO video / trace (they steal CPU and skew numbers)
+ *   - Long timeouts (throttled + network)
+ *   - Chromium only (CDP perf domains; WebKit lacks CPUThrottlingRate)
+ *
+ * Run: `npm run perf:prod` — orchestrates health-check + playwright + lighthouse + report.
+ * Raw: `npm run perf:playwright` — just the Playwright side.
+ *
+ * Env:
+ *   STREAMVAULT_PROD_URL  — defaults to https://streamvault.srinivaskotha.uk
+ *   STREAMVAULT_E2E_USER  — login (prod credentials; reuses tests/prod/helpers.ts loginViaUI)
+ *   STREAMVAULT_E2E_PASS  — ditto
+ *   PERF_CPU_RATE         — CPU throttle multiplier (default 6; use 4 for Stick 4K Max)
+ *   PERF_BASELINE         — "1" to disable throttling (sanity baseline run)
+ */
+export default defineConfig({
+  testDir: "./tests/perf",
+  outputDir: "./perf-artifacts/playwright-output",
+  fullyParallel: false,
+  forbidOnly: !!process.env["CI"],
+  retries: 0,
+  workers: 1,
+  timeout: 180_000,
+  reporter: [
+    ["list"],
+    ["json", { outputFile: "perf-artifacts/playwright-metrics.json" }],
+  ],
+  use: {
+    baseURL:
+      process.env["STREAMVAULT_PROD_URL"] ??
+      "https://streamvault.srinivaskotha.uk",
+    trace: "off",
+    screenshot: "off",
+    video: "off",
+    ignoreHTTPSErrors: false,
+    launchOptions: {
+      args: [
+        "--no-sandbox",
+        "--disable-dev-shm-usage",
+        "--disable-gpu",
+        "--enable-precise-memory-info",
+      ],
+    },
+  },
+  projects: [
+    {
+      name: "fire-tv-stick-4k",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1920, height: 1080 },
+        deviceScaleFactor: 1,
+      },
+      metadata: {
+        cpuRate: 4,
+        label: "Fire TV Stick 4K / 4K Max",
+      },
+    },
+    {
+      name: "fire-tv-stick-lite",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1920, height: 1080 },
+        deviceScaleFactor: 1,
+      },
+      metadata: {
+        cpuRate: 6,
+        label: "Fire TV Stick Lite / older Silk",
+      },
+    },
+  ],
+});

--- a/scripts/build-perf-report.mjs
+++ b/scripts/build-perf-report.mjs
@@ -1,0 +1,388 @@
+#!/usr/bin/env node
+/**
+ * Builds perf-report.md + perf-report.json from:
+ *  - perf-artifacts/playwright-metrics.json   (Playwright JSON reporter)
+ *  - perf-artifacts/lh-<route>.json           (Lighthouse per-route)
+ *
+ * Maps metric thresholds → suspect code paths (pre-wired from the plan's
+ * Known Hotspots list). The mapping is intentionally opinionated — if a
+ * metric crosses AMBER/RED, we already know which code paths to investigate.
+ */
+import { readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const OUT = resolve(process.cwd(), "perf-artifacts");
+const MD_OUT = resolve(process.cwd(), "perf-report.md");
+const JSON_OUT = resolve(process.cwd(), "perf-report.json");
+
+// ── Threshold table (also documented in the plan + tests/perf/README.md) ───
+const T = {
+  LCP: { green: 2500, amber: 4000 }, // ms
+  INP: { green: 200, amber: 500 }, // ms
+  CLS: { green: 0.1, amber: 0.25 }, // unitless
+  TBT: { green: 200, amber: 600 }, // ms
+  transition: { green: 300, amber: 800 }, // ms
+  longTasksDuringTransition: { green: 0, amber: 2 }, // count
+  droppedFramePct: { green: 5, amber: 15 }, // %
+  heapDeltaMB: { green: 10, amber: 30 }, // MB
+};
+
+// ── Suspect-file map (plan's Known Hotspots) ──────────────────────────────
+const SUSPECTS = {
+  lcp: [
+    "[vite.config.ts](vite.config.ts) — no manualChunks; everything ships in one bundle",
+    "[src/App.tsx:12-34](src/App.tsx#L12-L34) — all routes eagerly imported (SeriesDetailRoute is 1,421 lines)",
+    "[src/features/movies/MovieCard.tsx:218](src/features/movies/MovieCard.tsx#L218) — posters have loading=\"lazy\" but no decoding=\"async\"",
+  ],
+  inp: [
+    "[src/App.tsx:267-308](src/App.tsx#L267-L308) — focus-recovery keyup handler on every D-pad press",
+    "[src/routes/MoviesRoute.tsx:485](src/routes/MoviesRoute.tsx#L485) — sticky toolbar backdrop-filter blur",
+  ],
+  cls: [
+    "[src/features/movies/MovieCard.tsx:218](src/features/movies/MovieCard.tsx#L218) — images without explicit width/height (layout shift on late decode)",
+  ],
+  transition: [
+    "[src/App.tsx:12-34](src/App.tsx#L12-L34) — eager route imports; destination route's JS already parsed but executed with throttled CPU",
+    "[src/routes/MoviesRoute.tsx:554-561](src/routes/MoviesRoute.tsx#L554-L561) — movies-pulse 900ms infinite animation consumes main-thread time during transition",
+  ],
+  longTasks: [
+    "[src/routes/SeriesDetailRoute.tsx](src/routes/SeriesDetailRoute.tsx) — 1,421-line component, heaviest single mount in the app",
+    "[src/App.tsx:267-308](src/App.tsx#L267-L308) — focus-recovery keyup, can block main thread briefly",
+  ],
+  droppedFrames: {
+    series: [
+      "[src/features/series/SeriesGrid.tsx](src/features/series/SeriesGrid.tsx) — plain CSS Grid, NOT virtualized (contrast MovieGrid's react-virtuoso)",
+    ],
+    movies: [
+      "[src/features/movies/MovieCard.tsx:218](src/features/movies/MovieCard.tsx#L218) — missing decoding=\"async\" causes main-thread decode stalls on scroll",
+    ],
+  },
+  heap: [
+    "[src/routes/SeriesDetailRoute.tsx](src/routes/SeriesDetailRoute.tsx) — 1,421-line component allocates a lot of state+JSX on mount",
+    "[src/App.tsx:12-34](src/App.tsx#L12-L34) — eager imports keep all route modules resident even when unused",
+  ],
+  tvUnused: [
+    "[src/main.tsx:17-26](src/main.tsx#L17-L26) — data-tv=\"true\" is set but [tokens.css](src/brand/tokens.css) has no [data-tv=\"true\"] selectors reducing animation / blur / backdrop-filter",
+  ],
+};
+
+// ── Tier function ──────────────────────────────────────────────────────────
+function tier(value, { green, amber }, lowerIsBetter = true) {
+  if (value == null || Number.isNaN(value)) return "N/A";
+  if (lowerIsBetter) {
+    if (value <= green) return "🟢 GREEN";
+    if (value <= amber) return "🟡 AMBER";
+    return "🔴 RED";
+  }
+  if (value >= green) return "🟢 GREEN";
+  if (value >= amber) return "🟡 AMBER";
+  return "🔴 RED";
+}
+
+function fmtMs(v) {
+  return v == null ? "—" : `${Math.round(v)}ms`;
+}
+function fmtBytes(v) {
+  return v == null ? "—" : `${(v / 1_048_576).toFixed(1)} MB`;
+}
+function fmtCls(v) {
+  return v == null ? "—" : v.toFixed(3);
+}
+
+// ── Ingest Playwright attachments ─────────────────────────────────────────
+function readPlaywrightAttachments() {
+  const path = resolve(OUT, "playwright-metrics.json");
+  if (!existsSync(path)) return { byName: {} };
+  const pw = JSON.parse(readFileSync(path, "utf8"));
+  const byName = {};
+  for (const suite of pw.suites ?? []) {
+    walkSuite(suite, byName);
+  }
+  return { byName };
+}
+
+function walkSuite(suite, byName) {
+  for (const s of suite.suites ?? []) walkSuite(s, byName);
+  for (const spec of suite.specs ?? []) {
+    for (const t of spec.tests ?? []) {
+      for (const r of t.results ?? []) {
+        for (const a of r.attachments ?? []) {
+          if (a.name?.startsWith("perf-") && a.path) {
+            try {
+              const parsed = JSON.parse(readFileSync(a.path, "utf8"));
+              byName[a.name] = parsed;
+            } catch (err) {
+              console.warn(`[report] failed to parse ${a.name}:`, err.message);
+            }
+          } else if (a.name?.startsWith("perf-") && a.body) {
+            try {
+              byName[a.name] = JSON.parse(
+                Buffer.from(a.body, "base64").toString("utf8"),
+              );
+            } catch {
+              /* */
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// ── Ingest Lighthouse JSONs ───────────────────────────────────────────────
+function readLighthouse() {
+  if (!existsSync(OUT)) return {};
+  const files = readdirSync(OUT).filter(
+    (f) => f.startsWith("lh-") && f.endsWith(".json"),
+  );
+  const out = {};
+  for (const f of files) {
+    try {
+      const lhr = JSON.parse(readFileSync(resolve(OUT, f), "utf8"));
+      const route = f.replace(/^lh-/, "").replace(/\.json$/, "");
+      out[route] = {
+        lcp: lhr.audits?.["largest-contentful-paint"]?.numericValue,
+        cls: lhr.audits?.["cumulative-layout-shift"]?.numericValue,
+        tbt: lhr.audits?.["total-blocking-time"]?.numericValue,
+        tti: lhr.audits?.["interactive"]?.numericValue,
+        fcp: lhr.audits?.["first-contentful-paint"]?.numericValue,
+        cpuSlowdownMultiplier:
+          lhr.configSettings?.throttling?.cpuSlowdownMultiplier,
+      };
+    } catch (err) {
+      console.warn(`[report] failed to parse ${f}:`, err.message);
+    }
+  }
+  return out;
+}
+
+// ── Build report ──────────────────────────────────────────────────────────
+function build() {
+  const { byName } = readPlaywrightAttachments();
+  const lh = readLighthouse();
+
+  const dock = byName["perf-dock-transitions.json"];
+  const cardToDetail = byName["perf-card-to-detail.json"];
+  const backNav = byName["perf-back-navigation.json"];
+  const gridMovies = byName["perf-grid-scroll-movies.json"];
+  const gridSeries = byName["perf-grid-scroll-series.json"];
+
+  const cpuRate =
+    dock?.cpuRate ??
+    cardToDetail?.cpuRate ??
+    backNav?.cpuRate ??
+    gridMovies?.cpuRate ??
+    "?";
+  const heapMethod =
+    cardToDetail?.measurementMethod ?? dock?.measurementMethod ?? "unknown";
+
+  const lines = [];
+  lines.push(`# StreamVault v3 perf report`);
+  lines.push("");
+  lines.push(`Generated: ${new Date().toISOString()}`);
+  lines.push("");
+  lines.push(`- CPU throttle rate: **${cpuRate}×**`);
+  lines.push(`- Heap measurement method: **${heapMethod}**`);
+  lines.push(`- Target: \`${process.env.STREAMVAULT_PROD_URL ?? "(default)"}\``);
+  lines.push("");
+  lines.push("## Legend");
+  lines.push("");
+  lines.push(
+    "| Metric | 🟢 GREEN | 🟡 AMBER | 🔴 RED |",
+  );
+  lines.push("|---|---|---|---|");
+  lines.push(`| LCP | <${T.LCP.green}ms | ${T.LCP.green}–${T.LCP.amber}ms | >${T.LCP.amber}ms |`);
+  lines.push(`| INP | <${T.INP.green}ms | ${T.INP.green}–${T.INP.amber}ms | >${T.INP.amber}ms |`);
+  lines.push(`| CLS | <${T.CLS.green} | ${T.CLS.green}–${T.CLS.amber} | >${T.CLS.amber} |`);
+  lines.push(`| TBT (Lighthouse) | <${T.TBT.green}ms | ${T.TBT.green}–${T.TBT.amber}ms | >${T.TBT.amber}ms |`);
+  lines.push(`| Transition | <${T.transition.green}ms | ${T.transition.green}–${T.transition.amber}ms | >${T.transition.amber}ms |`);
+  lines.push(`| Long tasks / transition | ${T.longTasksDuringTransition.green} | 1–${T.longTasksDuringTransition.amber} | >${T.longTasksDuringTransition.amber} |`);
+  lines.push(`| Dropped frame % | <${T.droppedFramePct.green}% | ${T.droppedFramePct.green}–${T.droppedFramePct.amber}% | >${T.droppedFramePct.amber}% |`);
+  lines.push(`| Heap delta (detail enter) | <${T.heapDeltaMB.green}MB | ${T.heapDeltaMB.green}–${T.heapDeltaMB.amber}MB | >${T.heapDeltaMB.amber}MB |`);
+  lines.push("");
+
+  // ── Lighthouse per-route ────────────────────────────────────────────────
+  lines.push("## Lighthouse per-route (cold load)");
+  lines.push("");
+  lines.push("| Route | LCP | CLS | TBT | TTI |");
+  lines.push("|---|---|---|---|---|");
+  const LH_ROUTES = ["home", "movies", "series", "live", "search", "settings"];
+  for (const r of LH_ROUTES) {
+    const m = lh[r];
+    if (!m) continue;
+    lines.push(
+      `| /${r === "home" ? "" : r} | ${fmtMs(m.lcp)} ${tier(m.lcp, T.LCP)} | ${fmtCls(m.cls)} ${tier(m.cls, T.CLS)} | ${fmtMs(m.tbt)} ${tier(m.tbt, T.TBT)} | ${fmtMs(m.tti)} |`,
+    );
+  }
+  lines.push("");
+
+  // ── Dock transitions ────────────────────────────────────────────────────
+  if (dock?.hops?.length) {
+    lines.push("## Dock transitions (click, throttled)");
+    lines.push("");
+    lines.push("| From | To | Transition | Long tasks during |");
+    lines.push("|---|---|---|---|");
+    for (const h of dock.hops) {
+      const longCount = h.longTasksDuringTransition?.length ?? 0;
+      lines.push(
+        `| /${h.from} | /${h.to} | ${fmtMs(h.transitionMs)} ${tier(h.transitionMs, T.transition)} | ${longCount} ${tier(longCount, T.longTasksDuringTransition)} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  // ── Card → Detail ───────────────────────────────────────────────────────
+  if (cardToDetail) {
+    const heapDeltaBytes = cardToDetail.heapDeltaBytes ?? 0;
+    const heapDeltaMB = heapDeltaBytes / 1_048_576;
+    const longCount = cardToDetail.longTasksDuringTransition?.length ?? 0;
+    lines.push("## Series card → /series/:id detail");
+    lines.push("");
+    lines.push("| Metric | Value | Tier |");
+    lines.push("|---|---|---|");
+    lines.push(
+      `| Transition | ${fmtMs(cardToDetail.transitionMs)} | ${tier(cardToDetail.transitionMs, T.transition)} |`,
+    );
+    lines.push(`| Long tasks during | ${longCount} | ${tier(longCount, T.longTasksDuringTransition)} |`);
+    lines.push(
+      `| Heap before | ${fmtBytes(cardToDetail.heapBeforeBytes)} | — |`,
+    );
+    lines.push(
+      `| Heap after | ${fmtBytes(cardToDetail.heapAfterBytes)} | — |`,
+    );
+    lines.push(
+      `| Heap delta | ${fmtBytes(heapDeltaBytes)} | ${tier(heapDeltaMB, T.heapDeltaMB)} |`,
+    );
+    lines.push("");
+  }
+
+  // ── Back navigation ─────────────────────────────────────────────────────
+  if (backNav) {
+    const longCount = backNav.longTasksDuringTransition?.length ?? 0;
+    lines.push("## /series/:id → Back → /series");
+    lines.push("");
+    lines.push("| Metric | Value | Tier |");
+    lines.push("|---|---|---|");
+    lines.push(
+      `| Transition | ${fmtMs(backNav.transitionMs)} | ${tier(backNav.transitionMs, T.transition)} |`,
+    );
+    lines.push(
+      `| Long tasks during | ${longCount} | ${tier(longCount, T.longTasksDuringTransition)} |`,
+    );
+    lines.push("");
+  }
+
+  // ── Grid scroll ─────────────────────────────────────────────────────────
+  if (gridMovies || gridSeries) {
+    lines.push("## Grid D-pad scroll (30 ArrowDown presses)");
+    lines.push("");
+    lines.push("| Route | Frames sampled | Dropped | % dropped | p50 | p95 | p99 |");
+    lines.push("|---|---|---|---|---|---|---|");
+    for (const [name, g] of [
+      ["/movies", gridMovies],
+      ["/series", gridSeries],
+    ]) {
+      if (!g) continue;
+      lines.push(
+        `| ${name} | ${g.totalFramesSampled} | ${g.droppedFrames} | ${g.droppedFramePct.toFixed(1)}% ${tier(g.droppedFramePct, T.droppedFramePct)} | ${g.frameDeltaMs.p50.toFixed(1)}ms | ${g.frameDeltaMs.p95.toFixed(1)}ms | ${g.frameDeltaMs.p99.toFixed(1)}ms |`,
+      );
+    }
+    lines.push("");
+  }
+
+  // ── Suspect hot paths (conditional on findings) ─────────────────────────
+  lines.push("## Suspect files (if any tier above is AMBER/RED)");
+  lines.push("");
+
+  const flags = new Set();
+  for (const r of LH_ROUTES) {
+    const m = lh[r];
+    if (!m) continue;
+    if (tier(m.lcp, T.LCP) !== "🟢 GREEN") flags.add("lcp");
+    if (tier(m.cls, T.CLS) !== "🟢 GREEN") flags.add("cls");
+    if (tier(m.tbt, T.TBT) !== "🟢 GREEN") flags.add("tbt");
+  }
+  for (const h of dock?.hops ?? []) {
+    if (tier(h.transitionMs, T.transition) !== "🟢 GREEN") flags.add("transition");
+    if (
+      tier(
+        h.longTasksDuringTransition?.length ?? 0,
+        T.longTasksDuringTransition,
+      ) !== "🟢 GREEN"
+    )
+      flags.add("longTasks");
+  }
+  if (cardToDetail) {
+    if (tier(cardToDetail.transitionMs, T.transition) !== "🟢 GREEN")
+      flags.add("transition");
+    const heapMB = (cardToDetail.heapDeltaBytes ?? 0) / 1_048_576;
+    if (tier(heapMB, T.heapDeltaMB) !== "🟢 GREEN") flags.add("heap");
+  }
+  if (gridMovies && tier(gridMovies.droppedFramePct, T.droppedFramePct) !== "🟢 GREEN")
+    flags.add("droppedFrames-movies");
+  if (gridSeries && tier(gridSeries.droppedFramePct, T.droppedFramePct) !== "🟢 GREEN")
+    flags.add("droppedFrames-series");
+
+  if (flags.size === 0) {
+    lines.push("_All GREEN — no suspects surfaced. Re-run at higher throttle rate (`PERF_CPU_RATE=6`) if the user still reports lag._");
+  } else {
+    if (flags.has("lcp")) listSuspects(lines, "LCP / first paint", SUSPECTS.lcp);
+    if (flags.has("cls")) listSuspects(lines, "CLS / layout shift", SUSPECTS.cls);
+    if (flags.has("tbt") || flags.has("longTasks"))
+      listSuspects(
+        lines,
+        "TBT / main-thread blocking",
+        [...SUSPECTS.inp, ...SUSPECTS.longTasks],
+      );
+    if (flags.has("transition"))
+      listSuspects(lines, "Slow transitions", SUSPECTS.transition);
+    if (flags.has("droppedFrames-movies"))
+      listSuspects(lines, "Movies grid dropped frames", SUSPECTS.droppedFrames.movies);
+    if (flags.has("droppedFrames-series"))
+      listSuspects(lines, "Series grid dropped frames", SUSPECTS.droppedFrames.series);
+    if (flags.has("heap")) listSuspects(lines, "Heap growth on detail enter", SUSPECTS.heap);
+    lines.push("");
+    lines.push(
+      "### TV-specific ambient suspects (always worth checking on Fire TV)",
+    );
+    lines.push("");
+    for (const s of SUSPECTS.tvUnused) lines.push(`- ${s}`);
+    lines.push("");
+  }
+
+  // ── Reproducibility hints ───────────────────────────────────────────────
+  lines.push("## Reproducibility");
+  lines.push("");
+  lines.push("- Baseline sanity: `PERF_BASELINE=1 npm run perf:prod` — throttling disabled; LCP on /home should be <1.5s. If not, the network between the runner and prod is the bottleneck, not the app.");
+  lines.push("- Rate comparison: set `PERF_CPU_RATE=4` (Stick 4K) vs `PERF_CPU_RATE=6` (Stick Lite). Numbers should scale roughly linearly in LCP/TBT; non-linear scaling = network-bound regime.");
+  lines.push("- Stddev check: run 3×, per-metric stddev should be <15% on GREEN routes. Higher = rogue background CPU on the runner.");
+  lines.push("");
+
+  writeFileSync(MD_OUT, lines.join("\n"));
+  writeFileSync(
+    JSON_OUT,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        cpuRate,
+        heapMethod,
+        playwright: byName,
+        lighthouse: lh,
+        flags: [...flags],
+      },
+      null,
+      2,
+    ),
+  );
+  console.log(`[report] wrote ${MD_OUT}`);
+  console.log(`[report] wrote ${JSON_OUT}`);
+}
+
+function listSuspects(lines, title, items) {
+  lines.push(`### ${title}`);
+  lines.push("");
+  for (const s of items) lines.push(`- ${s}`);
+  lines.push("");
+}
+
+build();

--- a/scripts/run-perf-prod.mjs
+++ b/scripts/run-perf-prod.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * End-to-end perf-prod orchestrator.
+ *
+ * 1. Health-check prod URL. Fail loudly on 4xx/5xx/timeout — a misleading
+ *    green report from a local preview is worse than no report.
+ * 2. Wipe perf-artifacts/ (stale JSON would poison the report).
+ * 3. Run Playwright perf specs (JSON reporter).
+ * 4. Run Lighthouse (per-route HTML+JSON).
+ * 5. Build perf-report.md + perf-report.json.
+ * 6. Print summary + path.
+ *
+ * --local fallback: use http://localhost:4173 after `npm run build && npm run preview`.
+ */
+import { spawn } from "node:child_process";
+import { mkdirSync, rmSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const args = process.argv.slice(2);
+const useLocal = args.includes("--local");
+const BASE =
+  process.env.STREAMVAULT_PROD_URL ??
+  (useLocal
+    ? "http://localhost:4173"
+    : "https://streamvault.srinivaskotha.uk");
+const OUT = resolve(process.cwd(), "perf-artifacts");
+
+function log(msg) {
+  console.log(`[perf] ${msg}`);
+}
+
+async function health() {
+  log(`health-check ${BASE} …`);
+  try {
+    const res = await fetch(BASE, { method: "GET", redirect: "follow" });
+    if (!res.ok) {
+      console.error(`[perf] ${BASE} returned HTTP ${res.status}. Aborting.`);
+      process.exit(2);
+    }
+    log(`${BASE} → ${res.status} ✓`);
+  } catch (err) {
+    console.error(`[perf] ${BASE} unreachable:`, err.message);
+    console.error(
+      "[perf] Use `--local` to run against a local preview build instead.",
+    );
+    process.exit(2);
+  }
+}
+
+function run(cmd, cmdArgs, env = {}) {
+  return new Promise((resolvePromise, reject) => {
+    const p = spawn(cmd, cmdArgs, {
+      stdio: "inherit",
+      env: { ...process.env, ...env },
+    });
+    p.on("exit", (code) => {
+      if (code === 0) resolvePromise();
+      else reject(new Error(`${cmd} ${cmdArgs.join(" ")} exited with ${code}`));
+    });
+  });
+}
+
+async function main() {
+  // Require env for the auth-using steps; surface clearly.
+  if (!process.env.STREAMVAULT_E2E_USER || !process.env.STREAMVAULT_E2E_PASS) {
+    console.error(
+      "[perf] STREAMVAULT_E2E_USER and STREAMVAULT_E2E_PASS must be set.",
+    );
+    process.exit(2);
+  }
+
+  await health();
+
+  if (existsSync(OUT)) {
+    rmSync(OUT, { recursive: true, force: true });
+  }
+  mkdirSync(OUT, { recursive: true });
+
+  const env = {
+    STREAMVAULT_PROD_URL: BASE,
+  };
+
+  log("Running Playwright perf specs …");
+  await run("npx", ["playwright", "test", "--config=playwright.perf.config.ts"], env);
+
+  log("Running Lighthouse per-route …");
+  await run("node", ["tests/perf/lighthouse-routes.mjs"], env);
+
+  log("Building report …");
+  await run("node", ["scripts/build-perf-report.mjs"], env);
+
+  log(`Done. See ${resolve(process.cwd(), "perf-report.md")}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -1,0 +1,130 @@
+# Fire TV perf suite
+
+Reproducibly measures navigation lag on a low-RAM TV class against production.
+Answers the question: _when the user says "navigation gets stuck", where in the
+code is it actually stuck?_
+
+**Non-goal:** this suite does not fix any perf issue. It measures and points at
+suspect files. Fixing is a separate PR.
+
+## Quick start
+
+```bash
+# One-time: install Playwright browsers if you haven't.
+npx playwright install chromium
+
+# Set auth for prod.
+export STREAMVAULT_E2E_USER=sv_e2e_test
+export STREAMVAULT_E2E_PASS=<redacted>
+
+# Default: Fire TV Stick Lite class (6× CPU + Slow 4G).
+npm run perf:prod
+cat perf-report.md
+
+# Baseline sanity (no throttling — should be fast).
+PERF_BASELINE=1 npm run perf:prod
+
+# Fire TV Stick 4K / Max class (lighter throttle).
+PERF_CPU_RATE=4 npm run perf:prod
+
+# Against local preview (when prod is unreachable).
+npm run build && npm run preview &
+npm run perf:prod -- --local
+```
+
+## What it runs
+
+1. **Playwright perf specs** against prod, headless Chromium with CDP CPU
+   throttling (6×), Slow 4G network, Silk UA:
+   - `dock-transitions.spec.ts` — click through every dock tab; per-hop time + long tasks
+   - `card-to-detail.spec.ts` — Series card → `/series/:id`; heap delta + long tasks
+   - `back-navigation.spec.ts` — detail → Back; restoration cost
+   - `grid-scroll.spec.ts` — D-pad Down ×30 on /movies + /series; dropped frame %
+2. **Lighthouse** per route (`/movies`, `/series`, `/live`, `/search`,
+   `/settings`) with the same throttling preset.
+3. **Report** combines both into `perf-report.md` (terminal-friendly) +
+   `perf-report.json` (diffable).
+
+## Output
+
+All artifacts in `perf-artifacts/`:
+
+- `playwright-metrics.json` — Playwright JSON reporter
+- `lh-<route>.json` — Lighthouse per-route
+- `perf-report.md` / `perf-report.json` — final report (in repo root)
+
+## Thresholds
+
+| Metric | 🟢 GREEN | 🟡 AMBER | 🔴 RED |
+|---|---|---|---|
+| LCP | <2.5s | 2.5–4s | >4s |
+| INP | <200ms | 200–500ms | >500ms |
+| CLS | <0.1 | 0.1–0.25 | >0.25 |
+| TBT | <200ms | 200–600ms | >600ms |
+| Transition (click → paint) | <300ms | 300–800ms | >800ms |
+| Long tasks / transition | 0 | 1–2 | 3+ |
+| Dropped frame % (grid scroll) | <5% | 5–15% | >15% |
+| Heap delta (detail enter) | <10MB | 10–30MB | >30MB |
+
+AMBER/RED cells are hyperlinked in the report to the suspect source files
+(see `scripts/build-perf-report.mjs` `SUSPECTS` map).
+
+## Headless VPS
+
+Runs headlessly on any Linux VPS — no X server required. Bundled Chromium is
+downloaded by `npx playwright install chromium` into `~/.cache/ms-playwright`.
+Chrome launch flags (`--headless=new --no-sandbox --disable-dev-shm-usage
+--disable-gpu --enable-precise-memory-info`) are set for you.
+
+To view Lighthouse's HTML report (optional — the numbers are already in
+`perf-report.md`):
+
+```bash
+npm run perf:serve  # python3 -m http.server 8080 --directory perf-artifacts
+# From your laptop:
+ssh -L 8080:localhost:8080 <vps>
+# Open http://localhost:8080/lh-movies.html in browser
+```
+
+## Verifying the numbers are real
+
+Run through these sanity checks before trusting the report:
+
+| Check | Expected | If off |
+|---|---|---|
+| `PERF_BASELINE=1` vs default | ~3–5× LCP ratio | CDP throttling not applied (check `Emulation.setCPUThrottlingRate` order in `fixtures.ts`) |
+| `navigator.userAgent` in tests | contains "Silk" | UA override not propagating |
+| `documentElement.dataset.tv` | `"true"` | UA sniff in `src/main.tsx:17-26` not matching — file an app bug |
+| `window.__svVitals` after nav | has LCP + CLS | init-script CSP block or web-vitals IIFE load failed |
+| `lhr.configSettings.throttling.cpuSlowdownMultiplier` | 6 (or 4) | Lighthouse CLI overrode settings — check invocation |
+| `SeriesDetailRoute` enter produces ≥1 long task | ≥1 | PerformanceObserver registered too late |
+| Heap delta on `/settings` alone | <2MB | GC noise; increase post-navigation settle |
+| 3× runs, stddev | <15% on GREEN routes | non-deterministic: rogue bg CPU or leaked CDP session |
+
+## How to extend
+
+Add another hop, route, or transition:
+
+- **New dock hop:** append to `HOPS` in `dock-transitions.spec.ts`.
+- **New Lighthouse route:** append to `ROUTES` in `lighthouse-routes.mjs`.
+- **New suspect mapping:** edit `SUSPECTS` in `scripts/build-perf-report.mjs`.
+- **Different throttle:** `PERF_CPU_RATE=<N>` env var wins over project metadata.
+
+## Why no CI job yet
+
+The suite is inherently variable — runner CPU contention can swing metrics ±15%.
+Adding a red-gate-on-PR would either need wide thresholds (useless) or flake
+heavily. Run manually until we have a trend baseline; then consider a nightly
+cron that uploads the report as a PR comment.
+
+## Known limitations
+
+- `performance.measureUserAgentSpecificMemory()` requires crossOriginIsolated
+  (COOP+COEP) — StreamVault prod doesn't send those headers. We fall back to
+  `performance.memory.usedJSHeapSize` (Chrome only, less accurate). The report
+  stamps `measurementMethod: "precise" | "fallback"` so you know which was used.
+- Grid-scroll test seeds focus by clicking the first card — D-pad focus handoff
+  from the dock is brittle in headless and is NOT what this test measures.
+- Lighthouse auth uses Playwright's CDP connection to `chrome-launcher`'s
+  Chrome instance (cookies + localStorage seeded before each audit). If prod's
+  auth model changes, update the seeding block in `lighthouse-routes.mjs`.

--- a/tests/perf/back-navigation.spec.ts
+++ b/tests/perf/back-navigation.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "./fixtures";
+import { loginViaUI } from "../prod/helpers";
+
+/**
+ * Detail → Back: press the browser Back key from /series/:id and measure the
+ * cost of tearing down SeriesDetailRoute + restoring the /series list focus.
+ *
+ * Exercises:
+ *  - React Router pop transition
+ *  - backStack.ts focus restoration (src/nav/backStack.ts)
+ *  - focus-recovery keyup handler (src/App.tsx:267-308, suspected hotspot)
+ */
+
+test("series detail → Back → /series list under throttle", async ({
+  perfPage,
+  routeReady,
+  transition,
+  harvest,
+  cpuRate,
+}, testInfo) => {
+  await loginViaUI(perfPage);
+  await perfPage.goto("/series");
+  await routeReady('[data-page="series"]');
+  await perfPage.waitForTimeout(1500);
+
+  // Enter a series detail first.
+  const firstCard = perfPage.locator('a[href^="/series/"]').first();
+  await firstCard.waitFor({ state: "visible", timeout: 15_000 });
+  await firstCard.click({ timeout: 10_000 });
+  await perfPage.waitForURL(/\/series\/[^/]+/);
+  await routeReady('[data-page="series-detail"]');
+  await perfPage.waitForTimeout(1000);
+
+  // Measure the Back transition: hardware Back (Escape on Fire TV) maps to
+  // history.back() via App.tsx handleEscape. We simulate via Escape key —
+  // same codepath as a Fire TV remote Back press.
+  const { transitionMs, longTasksDuringTransition } = await transition(
+    async () => {
+      await perfPage.keyboard.press("Escape");
+    },
+    { urlPattern: /\/series$/, sentinel: '[data-page="series"]' },
+  );
+
+  // Additional settle to capture any post-paint focus restore long tasks.
+  await perfPage.waitForTimeout(500);
+  const metrics = await harvest();
+
+  await testInfo.attach("perf-back-navigation.json", {
+    body: JSON.stringify(
+      {
+        cpuRate,
+        transitionMs,
+        longTasksDuringTransition,
+        vitals: metrics.vitals,
+      },
+      null,
+      2,
+    ),
+    contentType: "application/json",
+  });
+
+  expect(transitionMs).toBeGreaterThan(0);
+});

--- a/tests/perf/card-to-detail.spec.ts
+++ b/tests/perf/card-to-detail.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "./fixtures";
+import { loginViaUI } from "../prod/helpers";
+
+/**
+ * Card → detail: from /series list, open a series card and measure the cost
+ * of mounting SeriesDetailRoute (1,421 lines, known hotspot — see plan §Known
+ * hotspots item 1).
+ *
+ * Movies open a detail SHEET (MovieDetailSheet) not a route, so the card-to-
+ * detail navigation test uses Series where a real route transition happens.
+ */
+
+test("series card → /series/:id detail route under throttle", async ({
+  perfPage,
+  routeReady,
+  transition,
+  harvest,
+  cpuRate,
+}, testInfo) => {
+  await loginViaUI(perfPage);
+  await perfPage.goto("/series");
+  await routeReady('[data-page="series"]');
+  // Let virtuoso (or whatever list) paint and web-vitals settle.
+  await perfPage.waitForTimeout(1500);
+
+  // First Series card. Cards are anchors / buttons rendering each series.
+  // Use `a[href^="/series/"]` which is stable across the SeriesCard component
+  // refactors we've been through.
+  const firstCard = perfPage.locator('a[href^="/series/"]').first();
+  await firstCard.waitFor({ state: "visible", timeout: 15_000 });
+
+  const heapBefore = await readHeap(perfPage);
+
+  const { transitionMs, longTasksDuringTransition } = await transition(
+    async () => {
+      await firstCard.click({ timeout: 10_000 });
+    },
+    {
+      urlPattern: /\/series\/[^/]+/,
+      sentinel: '[data-page="series-detail"]',
+    },
+  );
+
+  // Stabilize: a post-paint settle so the heap reading captures the committed
+  // detail route, not a transient intermediate state.
+  await perfPage.waitForTimeout(1000);
+  const heapAfter = await readHeap(perfPage);
+  const metrics = await harvest();
+
+  await testInfo.attach("perf-card-to-detail.json", {
+    body: JSON.stringify(
+      {
+        cpuRate,
+        transitionMs,
+        longTasksDuringTransition,
+        heapBeforeBytes: heapBefore.bytes,
+        heapAfterBytes: heapAfter.bytes,
+        heapDeltaBytes: heapAfter.bytes - heapBefore.bytes,
+        measurementMethod: heapAfter.method,
+        vitals: metrics.vitals,
+      },
+      null,
+      2,
+    ),
+    contentType: "application/json",
+  });
+
+  expect(transitionMs).toBeGreaterThan(0);
+});
+
+async function readHeap(
+  page: import("@playwright/test").Page,
+): Promise<{ bytes: number; method: "precise" | "fallback" | "unavailable" }> {
+  return await page.evaluate(async () => {
+    try {
+      const api = (
+        performance as unknown as {
+          measureUserAgentSpecificMemory?: () => Promise<{ bytes: number }>;
+        }
+      ).measureUserAgentSpecificMemory;
+      if (api) {
+        const r = await api.call(performance);
+        return { bytes: r.bytes, method: "precise" as const };
+      }
+    } catch {
+      /* fallback */
+    }
+    const pm = (performance as unknown as { memory?: { usedJSHeapSize: number } })
+      .memory;
+    if (pm) return { bytes: pm.usedJSHeapSize, method: "fallback" as const };
+    return { bytes: 0, method: "unavailable" as const };
+  });
+}

--- a/tests/perf/dock-transitions.spec.ts
+++ b/tests/perf/dock-transitions.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect, type PerfMetrics } from "./fixtures";
+import { loginViaUI } from "../prod/helpers";
+
+/**
+ * Dock tab transitions: press the dock tab, measure time to destination paint.
+ *
+ * Covers the user complaint: "navigation gets stuck / lag a sec / no smooth
+ * transitions" when flipping between tabs. We hit every dock tab and attach a
+ * per-transition record onto the test info.
+ */
+
+interface DockRecord {
+  from: string;
+  to: string;
+  transitionMs: number;
+  longTasksDuringTransition: Array<{ dur: number; start: number }>;
+}
+
+// Dock order (see src/nav/BottomDock.tsx DOCK_ITEMS): Movies, Series, Live,
+// Search, Settings. Login lands on /movies, so we start there.
+const HOPS: Array<{
+  from: string;
+  to: string;
+  urlPattern: RegExp;
+  sentinel: string;
+  dockKey: string;
+}> = [
+  {
+    from: "movies",
+    to: "series",
+    urlPattern: /\/series(?!\/)/,
+    sentinel: '[data-page="series"]',
+    dockKey: "DOCK_SERIES",
+  },
+  {
+    from: "series",
+    to: "live",
+    urlPattern: /\/live/,
+    sentinel: '[data-page="live"]',
+    dockKey: "DOCK_LIVE",
+  },
+  {
+    from: "live",
+    to: "search",
+    urlPattern: /\/search/,
+    sentinel: '[data-page="search"]',
+    dockKey: "DOCK_SEARCH",
+  },
+  {
+    from: "search",
+    to: "settings",
+    urlPattern: /\/settings/,
+    sentinel: '[data-page="settings"]',
+    dockKey: "DOCK_SETTINGS",
+  },
+];
+
+test("dock transitions: walk the whole dock under throttle", async ({
+  perfPage,
+  routeReady,
+  transition,
+  harvest,
+  cpuRate,
+}, testInfo) => {
+  await loginViaUI(perfPage);
+  await routeReady('[data-page="movies"]');
+  // Settle: let the initial render + web-vitals observers fire before we
+  // start measuring dock hops.
+  await perfPage.waitForTimeout(1500);
+
+  const hops: DockRecord[] = [];
+
+  for (const hop of HOPS) {
+    const { transitionMs, longTasksDuringTransition } = await transition(
+      async () => {
+        // Prefer clicking the dock link — matches how a mouse/touch user
+        // navigates. For D-pad nav see card-to-detail.spec.ts which uses
+        // keyboard.press. We're measuring route-transition cost, not focus-
+        // engine cost.
+        await perfPage
+          .locator(`nav[aria-label="Main navigation"] a`, {
+            has: perfPage.locator(`[aria-label="${capitalize(hop.to)}"]`),
+          })
+          .first()
+          .click({ timeout: 5000 })
+          .catch(async () => {
+            // Fallback: navigate directly. The click failure itself is a
+            // finding (dock link unclickable under throttle).
+            await perfPage.goto(`/${hop.to}`);
+          });
+      },
+      { urlPattern: hop.urlPattern, sentinel: hop.sentinel },
+    );
+    hops.push({
+      from: hop.from,
+      to: hop.to,
+      transitionMs,
+      longTasksDuringTransition,
+    });
+    // Small settle window so the next transition starts from a quiet state.
+    await perfPage.waitForTimeout(500);
+  }
+
+  const metrics: PerfMetrics = await harvest();
+
+  await testInfo.attach("perf-dock-transitions.json", {
+    body: JSON.stringify(
+      { cpuRate, hops, vitals: metrics.vitals, measurementMethod: metrics.measurementMethod },
+      null,
+      2,
+    ),
+    contentType: "application/json",
+  });
+
+  // Baseline sanity: at least one hop should succeed. Hard assertion here
+  // only — threshold grading is done by build-perf-report.mjs.
+  expect(hops.length).toBe(HOPS.length);
+});
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/tests/perf/fixtures.ts
+++ b/tests/perf/fixtures.ts
@@ -1,0 +1,286 @@
+/* eslint-disable react-hooks/rules-of-hooks -- Playwright fixture API uses
+   `use()` which trips the React hook rule; these are not React hooks. */
+import { test as base, type Page, type CDPSession } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve, dirname } from "node:path";
+
+/**
+ * Fire TV perf fixture.
+ *
+ * Applies CDP CPU + network throttling and Silk UA BEFORE the first navigation,
+ * then injects `web-vitals`, a longtask observer, and a rAF frame sampler via
+ * `page.addInitScript` so they attach before any script runs.
+ *
+ * Footguns handled here (rather than in each spec):
+ *  - `Performance.enable` must precede any `getMetrics` (else empty result).
+ *  - Throttling must be set BEFORE `page.goto` (cold-load uncounted otherwise).
+ *  - `cdp.detach()` in afterEach to avoid session leak across tests.
+ *  - `performance.measureUserAgentSpecificMemory()` requires crossOriginIsolated;
+ *    we expose `sampleHeap()` which tries the precise API then falls back to
+ *    `performance.memory.usedJSHeapSize` (Chrome dev flag, included in launch args).
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WEB_VITALS_IIFE = readFileSync(
+  resolve(__dirname, "../../node_modules/web-vitals/dist/web-vitals.iife.js"),
+  "utf8",
+);
+
+// Silk UA taken from a real Fire TV Stick 4K (AFTKA build). UA alone is enough
+// to trip the data-tv="true" branch in src/main.tsx.
+const SILK_UA =
+  "Mozilla/5.0 (Linux; Android 9; AFTKA Build/PS7288.4122N) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Silk/119.3.3 like Chrome/119.0.6045.193 Safari/537.36";
+
+// Slow 4G preset matches household Wi-Fi TV after router degrades. Keeps the
+// bottleneck CPU-bound (where the lag lives); Regular 3G would under-throttle
+// network waits that mask CPU signals.
+const SLOW_4G = {
+  offline: false,
+  latency: 750, // ms
+  downloadThroughput: (1.6 * 1024 * 1024) / 8, // 1.6 Mbps → bytes/s
+  uploadThroughput: (0.75 * 1024 * 1024) / 8,
+};
+
+export interface PerfMetrics {
+  vitals: Array<{ name: string; value: number; id: string; rating?: string }>;
+  longTasks: Array<{ name: string; dur: number; start: number }>;
+  frames: number[];
+  heapStart?: number;
+  heapEnd?: number;
+  measurementMethod: "precise" | "fallback" | "unavailable";
+}
+
+export interface PerfFixture {
+  perfPage: Page;
+  cpuRate: number;
+  /** Wait for the first route's sentinel, then return timing anchor. */
+  routeReady: (sentinel: string) => Promise<void>;
+  /** Read accumulated metrics and reset frame / long-task buffers. */
+  harvest: () => Promise<PerfMetrics>;
+  /** Wall-clock transition measurement; pass the destination `data-page` sentinel. */
+  transition: (
+    action: () => Promise<void>,
+    dest: { urlPattern: RegExp; sentinel: string },
+  ) => Promise<{
+    transitionMs: number;
+    longTasksDuringTransition: Array<{ dur: number; start: number }>;
+  }>;
+}
+
+export const test = base.extend<PerfFixture>({
+  cpuRate: [
+    // Default 6× (Fire TV Stick Lite class). Project metadata overrides.
+    // eslint-disable-next-line no-empty-pattern -- Playwright fixture signature.
+    async ({}, use, testInfo) => {
+      const metaRate = (testInfo.project.metadata as { cpuRate?: number })
+        ?.cpuRate;
+      const envRate = process.env["PERF_CPU_RATE"]
+        ? Number(process.env["PERF_CPU_RATE"])
+        : undefined;
+      const baseline = process.env["PERF_BASELINE"] === "1";
+      const rate = baseline ? 1 : (envRate ?? metaRate ?? 6);
+      await use(rate);
+    },
+    { option: true },
+  ],
+
+  perfPage: async ({ page, cpuRate }, use) => {
+    const cdp: CDPSession = await page.context().newCDPSession(page);
+
+    // Enable domains BEFORE any navigation / metric read.
+    await cdp.send("Network.enable");
+    await cdp.send("Performance.enable");
+
+    // UA override must be set before addInitScript so the app's UA sniff in
+    // src/main.tsx sees Silk on the very first evaluation.
+    await cdp.send("Emulation.setUserAgentOverride", { userAgent: SILK_UA });
+
+    // Throttling BEFORE first navigation. Baseline mode (rate 1) intentionally
+    // skips network emulation — we want a clean upper bound.
+    if (cpuRate > 1) {
+      await cdp.send("Emulation.setCPUThrottlingRate", { rate: cpuRate });
+      await cdp.send("Network.emulateNetworkConditions", SLOW_4G);
+    }
+
+    // Init scripts run before any page script on EVERY navigation. Single
+    // combined script avoids three addInitScript calls racing each other.
+    await page.addInitScript(
+      ({ webVitalsSrc }: { webVitalsSrc: string }) => {
+        // --- web-vitals (IIFE exposes `webVitals` global) --------------------
+        const g = window as unknown as {
+          __svVitals: Array<{
+            name: string;
+            value: number;
+            id: string;
+            rating?: string;
+          }>;
+          __svLong: Array<{ name: string; dur: number; start: number }>;
+          __svFrames: number[];
+          webVitals?: {
+            onLCP: (cb: (m: unknown) => void) => void;
+            onCLS: (cb: (m: unknown) => void) => void;
+            onINP: (cb: (m: unknown) => void) => void;
+            onFCP: (cb: (m: unknown) => void) => void;
+            onTTFB: (cb: (m: unknown) => void) => void;
+          };
+        };
+        g.__svVitals = [];
+        g.__svLong = [];
+        g.__svFrames = [];
+
+        try {
+          new Function(webVitalsSrc)();
+        } catch (e) {
+          console.error("[perf] web-vitals inject failed", e);
+        }
+        const wv = g.webVitals;
+        if (wv) {
+          const push = (m: unknown) => {
+            const mm = m as {
+              name: string;
+              value: number;
+              id: string;
+              rating?: string;
+            };
+            g.__svVitals.push({
+              name: mm.name,
+              value: mm.value,
+              id: mm.id,
+              rating: mm.rating,
+            });
+          };
+          wv.onLCP(push);
+          wv.onCLS(push);
+          wv.onINP(push);
+          wv.onFCP(push);
+          wv.onTTFB(push);
+        }
+
+        // --- Long tasks ------------------------------------------------------
+        try {
+          new PerformanceObserver((list) => {
+            for (const e of list.getEntries()) {
+              g.__svLong.push({
+                name: e.name,
+                dur: e.duration,
+                start: e.startTime,
+              });
+            }
+          }).observe({ entryTypes: ["longtask"] });
+        } catch {
+          // longtask unsupported in some browsers; tolerated.
+        }
+
+        // --- Frame sampler (rAF delta in ms) ---------------------------------
+        let last = performance.now();
+        const tick = (now: number) => {
+          g.__svFrames.push(now - last);
+          last = now;
+          requestAnimationFrame(tick);
+        };
+        requestAnimationFrame(tick);
+      },
+      { webVitalsSrc: WEB_VITALS_IIFE },
+    );
+
+    // Stash cpuRate + network settings in the page so the reporter can annotate.
+    await page.addInitScript((meta: { cpuRate: number }) => {
+      (window as unknown as { __svPerfMeta: unknown }).__svPerfMeta = meta;
+    }, { cpuRate });
+
+    await use(page);
+
+    await cdp.detach().catch(() => {
+      /* already detached on page close */
+    });
+  },
+
+  routeReady: async ({ page }, use) => {
+    // Wait on the passed sentinel — usually `[data-page="..."]` (emitted by
+    // every route). Keeps the perf suite decoupled from app-side edits.
+    const routeReady = async (sentinel: string) => {
+      await page.waitForSelector(sentinel, { timeout: 30_000 });
+    };
+    await use(routeReady);
+  },
+
+  harvest: async ({ page }, use) => {
+    const harvest = async (): Promise<PerfMetrics> => {
+      const snapshot = await page.evaluate(() => {
+        const g = window as unknown as {
+          __svVitals: PerfMetrics["vitals"];
+          __svLong: PerfMetrics["longTasks"];
+          __svFrames: number[];
+        };
+        const out = {
+          vitals: [...g.__svVitals],
+          longTasks: [...g.__svLong],
+          frames: [...g.__svFrames],
+        };
+        // Reset frame buffer (but KEEP vitals + longTasks — they accumulate).
+        g.__svFrames = [];
+        return out;
+      });
+
+      // Heap: try precise API, fall back to performance.memory (gated by
+      // --enable-precise-memory-info which is set in launchOptions).
+      const heap = await page.evaluate(async () => {
+        try {
+          const api = (
+            performance as unknown as {
+              measureUserAgentSpecificMemory?: () => Promise<{ bytes: number }>;
+            }
+          ).measureUserAgentSpecificMemory;
+          if (api) {
+            const r = await api.call(performance);
+            return { bytes: r.bytes, method: "precise" as const };
+          }
+        } catch {
+          /* fallback */
+        }
+        const pm = (performance as unknown as { memory?: { usedJSHeapSize: number } })
+          .memory;
+        if (pm) return { bytes: pm.usedJSHeapSize, method: "fallback" as const };
+        return { bytes: 0, method: "unavailable" as const };
+      });
+
+      return {
+        ...snapshot,
+        heapEnd: heap.bytes,
+        measurementMethod: heap.method,
+      };
+    };
+    await use(harvest);
+  },
+
+  transition: async ({ page }, use) => {
+    const transition = async (
+      action: () => Promise<void>,
+      dest: { urlPattern: RegExp; sentinel: string },
+    ) => {
+      const t0 = await page.evaluate(() => performance.now());
+      const longBefore = await page.evaluate(() => {
+        const g = window as unknown as { __svLong: Array<{ start: number }> };
+        return g.__svLong.length;
+      });
+      await action();
+      await page.waitForURL(dest.urlPattern, { timeout: 30_000 });
+      await page.waitForSelector(dest.sentinel, { timeout: 30_000 });
+      const t1 = await page.evaluate(() => performance.now());
+      const longDuring = await page.evaluate((before) => {
+        const g = window as unknown as {
+          __svLong: Array<{ dur: number; start: number }>;
+        };
+        return g.__svLong
+          .slice(before)
+          .map((l) => ({ dur: l.dur, start: l.start }));
+      }, longBefore);
+      return { transitionMs: t1 - t0, longTasksDuringTransition: longDuring };
+    };
+    await use(transition);
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/tests/perf/grid-scroll.spec.ts
+++ b/tests/perf/grid-scroll.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, type PerfMetrics } from "./fixtures";
+import { loginViaUI } from "../prod/helpers";
+
+/**
+ * D-pad grid scroll: press ArrowDown ×30 through Movies (virtualized via
+ * react-virtuoso) and Series (plain CSS Grid, NOT virtualized — known
+ * hotspot, see plan §Known hotspots item 4). Measure dropped frames.
+ *
+ * Dropped frame = rAF delta > 32ms (missed 60fps budget of 16.67ms, with
+ * 2× headroom). Report % of total sampled frames.
+ */
+
+const PRESSES = 30;
+
+for (const route of ["movies", "series"] as const) {
+  test(`grid scroll (${route}): D-pad Down ×${PRESSES}, dropped frame %`, async ({
+    perfPage,
+    routeReady,
+    harvest,
+    cpuRate,
+  }, testInfo) => {
+    await loginViaUI(perfPage);
+    await perfPage.goto(`/${route}`);
+    await routeReady(`[data-page="${route}"]`);
+    await perfPage.waitForTimeout(2000); // Let list fully paint + initial scroll settle.
+
+    // Focus the first card — click is the most reliable seed under Silk; D-pad
+    // focus handoff from dock is brittle and not what this test measures.
+    const firstCard = perfPage
+      .locator(
+        route === "movies"
+          ? '[data-page="movies"] button, [data-page="movies"] a'
+          : '[data-page="series"] a[href^="/series/"]',
+      )
+      .first();
+    await firstCard.waitFor({ state: "visible", timeout: 15_000 });
+    await firstCard.focus();
+
+    // Clear sampler so we only capture during-scroll frames.
+    await perfPage.evaluate(() => {
+      (window as unknown as { __svFrames: number[] }).__svFrames = [];
+    });
+
+    const pressStart = await perfPage.evaluate(() => performance.now());
+    for (let i = 0; i < PRESSES; i += 1) {
+      await perfPage.keyboard.press("ArrowDown");
+      // Tiny wait so we don't coalesce all presses into one frame — mirrors a
+      // real user's key repeat (~100ms).
+      await perfPage.waitForTimeout(80);
+    }
+    const pressEnd = await perfPage.evaluate(() => performance.now());
+
+    const metrics: PerfMetrics = await harvest();
+    const frames = metrics.frames;
+    const total = frames.length;
+    const dropped = frames.filter((f) => f > 32).length;
+    const droppedPct = total > 0 ? (dropped / total) * 100 : 0;
+    const p50 = percentile(frames, 50);
+    const p95 = percentile(frames, 95);
+    const p99 = percentile(frames, 99);
+
+    await testInfo.attach(`perf-grid-scroll-${route}.json`, {
+      body: JSON.stringify(
+        {
+          cpuRate,
+          route,
+          presses: PRESSES,
+          wallDurationMs: pressEnd - pressStart,
+          totalFramesSampled: total,
+          droppedFrames: dropped,
+          droppedFramePct: droppedPct,
+          frameDeltaMs: { p50, p95, p99 },
+          longTasksTotal: metrics.longTasks.length,
+          vitals: metrics.vitals,
+        },
+        null,
+        2,
+      ),
+      contentType: "application/json",
+    });
+
+    expect(total).toBeGreaterThan(0);
+  });
+}
+
+function percentile(xs: number[], p: number): number {
+  if (xs.length === 0) return 0;
+  const sorted = [...xs].sort((a, b) => a - b);
+  const idx = Math.min(
+    sorted.length - 1,
+    Math.floor((p / 100) * sorted.length),
+  );
+  return sorted[idx] ?? 0;
+}

--- a/tests/perf/lighthouse-routes.mjs
+++ b/tests/perf/lighthouse-routes.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * Lighthouse audit for each logged-in route on prod.
+ *
+ * Why programmatic `lighthouse` and not `@lhci/cli`? LHCI's value is PR-history
+ * trending — we don't need that yet (see plan). `lighthouse` the library lets
+ * us inject auth + tune CPU throttling per Fire TV class.
+ *
+ * Auth: Lighthouse doesn't persist login. We launch Chrome via chrome-launcher,
+ * connect Playwright over CDP for the login step (reuses our existing
+ * Playwright dep — no puppeteer needed), dump cookies + localStorage, then run
+ * Lighthouse against the same Chrome instance with auth pre-seeded.
+ *
+ * Output: `perf-artifacts/lh-<route>.json` per route.
+ *
+ * Env:
+ *   STREAMVAULT_PROD_URL  — default https://streamvault.srinivaskotha.uk
+ *   STREAMVAULT_E2E_USER  — login (required)
+ *   STREAMVAULT_E2E_PASS  — login (required)
+ *   PERF_CPU_RATE         — default 6. Mobile Slow 4G baseline.
+ */
+import lighthouse from "lighthouse";
+import * as chromeLauncher from "chrome-launcher";
+import { chromium } from "playwright";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const BASE =
+  process.env.STREAMVAULT_PROD_URL ?? "https://streamvault.srinivaskotha.uk";
+const USER = process.env.STREAMVAULT_E2E_USER;
+const PASS = process.env.STREAMVAULT_E2E_PASS;
+const RATE = Number(process.env.PERF_CPU_RATE ?? 6);
+const OUT = resolve(process.cwd(), "perf-artifacts");
+
+const ROUTES = ["/movies", "/series", "/live", "/search", "/settings"];
+
+async function main() {
+  if (!USER || !PASS) {
+    console.error(
+      "Missing STREAMVAULT_E2E_USER / STREAMVAULT_E2E_PASS. Aborting.",
+    );
+    process.exit(2);
+  }
+  mkdirSync(OUT, { recursive: true });
+
+  const chrome = await chromeLauncher.launch({
+    chromeFlags: [
+      "--headless=new",
+      "--no-sandbox",
+      "--disable-dev-shm-usage",
+      "--disable-gpu",
+      "--enable-precise-memory-info",
+      "--remote-debugging-port=0", // chrome-launcher picks the port
+    ],
+  });
+
+  const settings = {
+    formFactor: "mobile",
+    throttlingMethod: "simulate",
+    throttling: {
+      cpuSlowdownMultiplier: RATE,
+      rttMs: 750,
+      throughputKbps: 1600,
+      requestLatencyMs: 0,
+      downloadThroughputKbps: 0,
+      uploadThroughputKbps: 0,
+    },
+    screenEmulation: {
+      mobile: false,
+      width: 1920,
+      height: 1080,
+      deviceScaleFactor: 1,
+      disabled: false,
+    },
+    emulatedUserAgent:
+      "Mozilla/5.0 (Linux; Android 9; AFTKA Build/PS7288.4122N) AppleWebKit/537.36 " +
+      "(KHTML, like Gecko) Silk/119.3.3 like Chrome/119.0.6045.193 Safari/537.36",
+    onlyCategories: ["performance"],
+  };
+
+  // ── 1. Login via Playwright over CDP, dump auth state ───────────────────
+  const browser = await chromium.connectOverCDP(
+    `http://127.0.0.1:${chrome.port}`,
+  );
+  const context = browser.contexts()[0] ?? (await browser.newContext());
+  const loginPage = await context.newPage();
+  await loginPage.goto(BASE);
+  await loginPage.waitForSelector("input#username", { timeout: 15_000 });
+  await loginPage.fill("input#username", USER);
+  await loginPage.fill("input#password", PASS);
+  await loginPage.click('button[type="submit"]');
+  await loginPage.waitForSelector('nav[aria-label="Main navigation"]', {
+    timeout: 15_000,
+  });
+  const cookies = await context.cookies();
+  const storage = await loginPage.evaluate(() => ({
+    access: localStorage.getItem("sv_access_token"),
+    refresh: localStorage.getItem("sv_refresh_token"),
+  }));
+  await loginPage.close();
+
+  // ── 2. Per-route Lighthouse run. Before each audit, seed localStorage on a
+  // scratch page in the same Chrome — Lighthouse will open its own page but
+  // same-origin localStorage is shared with any existing same-origin tab in
+  // the same Chrome profile. Cookies are context-wide already.
+  for (const route of ROUTES) {
+    const url = `${BASE}${route}`;
+    console.log(`[lh] ${route} …`);
+
+    const seed = await context.newPage();
+    await seed.goto(BASE, { waitUntil: "domcontentloaded" });
+    await seed.evaluate(
+      (s) => {
+        if (s.access) localStorage.setItem("sv_access_token", s.access);
+        if (s.refresh) localStorage.setItem("sv_refresh_token", s.refresh);
+      },
+      storage,
+    );
+    await seed.close();
+
+    let lhr;
+    try {
+      const result = await lighthouse(
+        url,
+        { port: chrome.port },
+        { extends: "lighthouse:default", settings },
+      );
+      lhr = result?.lhr;
+    } catch (err) {
+      console.error(`[lh] ${route} audit failed:`, err);
+      continue;
+    }
+
+    const filename =
+      route.replace(/^\//, "").replace(/\//g, "-") || "home";
+    const outPath = resolve(OUT, `lh-${filename}.json`);
+    writeFileSync(outPath, JSON.stringify(lhr, null, 2));
+    console.log(`[lh] ${route} → ${outPath}`);
+  }
+
+  await browser.close();
+  await chrome.kill();
+}
+
+// Cookies object note: Playwright Cookie uses `expires` (seconds) and
+// `sameSite`; chrome-remote-interface uses different casing. We don't set
+// cookies — we just read them (Playwright set them naturally during login),
+// so no conversion is needed.
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Measure-only perf suite that reproduces the "navigation gets stuck / lag a sec" complaint against `https://streamvault.srinivaskotha.uk` under Fire TV-class CPU + network throttling.
- Maps measured metrics → pre-wired suspect source files so an actionable follow-up PR is obvious.
- **Does not fix** any perf issue — fixing is a separate PR.

## What's in

- [playwright.perf.config.ts](playwright.perf.config.ts) — perf-only Playwright config (workers=1, retries=0, no trace, `fire-tv-stick-4k` + `fire-tv-stick-lite` projects).
- [tests/perf/fixtures.ts](tests/perf/fixtures.ts) — CDP throttle fixture: `Emulation.setCPUThrottlingRate`, `Network.emulateNetworkConditions` (Slow 4G), Silk UA override, `web-vitals` injected from `node_modules` (no unpkg/CSP risk), longtask observer, rAF frame sampler, heap sampler with precise→fallback path.
- Four perf specs (see `tests/perf/*.spec.ts`): `dock-transitions`, `card-to-detail`, `back-navigation`, `grid-scroll` (parameterized across /movies virtualized vs /series un-virtualized).
- [tests/perf/lighthouse-routes.mjs](tests/perf/lighthouse-routes.mjs) — programmatic Lighthouse over 5 routes with auth handoff via Playwright's CDP connection to `chrome-launcher`'s Chrome (no `puppeteer-core` dep added).
- [scripts/run-perf-prod.mjs](scripts/run-perf-prod.mjs) — orchestrator (health-check → wipe artifacts → Playwright → Lighthouse → build report).
- [scripts/build-perf-report.mjs](scripts/build-perf-report.mjs) — emits `perf-report.md` + `perf-report.json` with threshold grading; AMBER/RED rows auto-link to pre-wired suspect files (plan's Known Hotspots: eager route imports, `backdrop-filter` blurs, `movies-pulse` 900ms loop, un-virtualized `SeriesGrid`, missing `decoding=\"async\"`, focus-recovery keyup handler, `data-tv` CSS gap).
- [tests/perf/README.md](tests/perf/README.md) — how to run, VPS/headless notes, threshold table, sanity-check matrix.

## DevDeps added

- `lighthouse@^12`, `web-vitals@^4`, `chrome-launcher` — all devDeps. App bundle budget (600 KB gzip) untouched.

## How to run

```bash
export STREAMVAULT_E2E_USER=sv_e2e_test
export STREAMVAULT_E2E_PASS=...
npm run perf:prod                # 6× CPU + Slow 4G (Stick Lite class)
PERF_CPU_RATE=4 npm run perf:prod  # Stick 4K Max class
PERF_BASELINE=1 npm run perf:prod  # sanity: no throttling
cat perf-report.md
```

Runs fully headless on a Linux VPS — no X server required. `npm run perf:serve` exposes Lighthouse HTML on :8080 for ssh port-forward.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint tests/perf/` clean
- [x] `playwright test --config=playwright.perf.config.ts --list` discovers 10 tests × 2 projects
- [x] Orchestrator fails loudly on missing creds
- [ ] Full dry-run against prod with live creds (next step for user)
- [ ] Verify throttle sanity (baseline vs 6× ratio ~3–5×)
- [ ] Confirm `window.__svVitals` populates during a run
- [ ] Confirm `documentElement.dataset.tv === \"true\"` under Silk UA

## Follow-ups (not this PR)

- Fix issues surfaced by the first report (separate branch once we have data).
- Decide if we want a nightly CI cron; skipped for now because perf metrics are inherently variable (±15%) and a red-gate-on-PR would flake.

## Depends on

PR #107 (CI fix) to land first so this doesn't need `--admin` merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)