### PR TITLE
fix(perf): session reuse + selectors + Lighthouse discovery (first prod run)

### DIFF
--- a/playwright.perf.config.ts
+++ b/playwright.perf.config.ts
@@ -1,4 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
+import { fileURLToPath } from "node:url";
+import { resolve, dirname } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 /**
  * Fire TV performance suite against production.
@@ -28,6 +33,7 @@ export default defineConfig({
   retries: 0,
   workers: 1,
   timeout: 180_000,
+  globalSetup: resolve(__dirname, "tests/perf/global-setup.ts"),
   reporter: [
     ["list"],
     ["json", { outputFile: "perf-artifacts/playwright-metrics.json" }],
@@ -36,6 +42,7 @@ export default defineConfig({
     baseURL:
       process.env["STREAMVAULT_PROD_URL"] ??
       "https://streamvault.srinivaskotha.uk",
+    storageState: "perf-artifacts/auth.json",
     trace: "off",
     screenshot: "off",
     video: "off",

--- a/scripts/run-perf-prod.mjs
+++ b/scripts/run-perf-prod.mjs
@@ -13,7 +13,7 @@
  * --local fallback: use http://localhost:4173 after `npm run build && npm run preview`.
  */
 import { spawn } from "node:child_process";
-import { mkdirSync, rmSync, existsSync } from "node:fs";
+import { mkdirSync, rmSync, existsSync, unlinkSync } from "node:fs";
 import { resolve } from "node:path";
 
 const args = process.argv.slice(2);
@@ -81,10 +81,26 @@ async function main() {
   };
 
   log("Running Playwright perf specs …");
-  await run("npx", ["playwright", "test", "--config=playwright.perf.config.ts"], env);
+  try {
+    await run("npx", ["playwright", "test", "--config=playwright.perf.config.ts"], env);
+  } catch (err) {
+    log(`Playwright exited non-zero (${err.message}); continuing to Lighthouse + report so partial data still gets summarized.`);
+  }
 
   log("Running Lighthouse per-route …");
-  await run("node", ["tests/perf/lighthouse-routes.mjs"], env);
+  try {
+    await run("node", ["tests/perf/lighthouse-routes.mjs"], env);
+  } catch (err) {
+    log(`Lighthouse exited non-zero (${err.message}); continuing to report.`);
+  }
+
+  // Wipe the reusable storage state — it holds a JWT pair, no reason to
+  // keep it past the run.
+  const authPath = resolve(OUT, "auth.json");
+  if (existsSync(authPath)) {
+    unlinkSync(authPath);
+    log("wiped auth.json");
+  }
 
   log("Building report …");
   await run("node", ["scripts/build-perf-report.mjs"], env);

--- a/src/features/series/SeriesCard.tsx
+++ b/src/features/series/SeriesCard.tsx
@@ -196,6 +196,7 @@ export function SeriesCard({
         type="button"
         aria-label={item.name}
         onClick={() => onClick(item.id)}
+        data-testid="series-card"
         className="focus-ring"
         style={{
           position: "relative",

--- a/tests/perf/back-navigation.spec.ts
+++ b/tests/perf/back-navigation.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from "./fixtures";
-import { loginViaUI } from "../prod/helpers";
 
 /**
  * Detail → Back: press the browser Back key from /series/:id and measure the
@@ -18,14 +17,21 @@ test("series detail → Back → /series list under throttle", async ({
   harvest,
   cpuRate,
 }, testInfo) => {
-  await loginViaUI(perfPage);
+  // Auth pre-seeded via global-setup + storageState.
   await perfPage.goto("/series");
   await routeReady('[data-page="series"]');
   await perfPage.waitForTimeout(1500);
 
   // Enter a series detail first.
-  const firstCard = perfPage.locator('a[href^="/series/"]').first();
-  await firstCard.waitFor({ state: "visible", timeout: 15_000 });
+  const firstCard = perfPage
+    .locator('[data-testid="series-card"]')
+    .or(
+      perfPage.locator(
+        '[data-page="series"] button[aria-label]:not([aria-pressed]):not([aria-checked]):not([data-resume-hero-button])',
+      ),
+    )
+    .first();
+  await firstCard.waitFor({ state: "visible", timeout: 60_000 });
   await firstCard.click({ timeout: 10_000 });
   await perfPage.waitForURL(/\/series\/[^/]+/);
   await routeReady('[data-page="series-detail"]');

--- a/tests/perf/card-to-detail.spec.ts
+++ b/tests/perf/card-to-detail.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from "./fixtures";
-import { loginViaUI } from "../prod/helpers";
 
 /**
  * Card → detail: from /series list, open a series card and measure the cost
@@ -17,17 +16,24 @@ test("series card → /series/:id detail route under throttle", async ({
   harvest,
   cpuRate,
 }, testInfo) => {
-  await loginViaUI(perfPage);
+  // Auth pre-seeded via global-setup + storageState.
   await perfPage.goto("/series");
   await routeReady('[data-page="series"]');
   // Let virtuoso (or whatever list) paint and web-vitals settle.
   await perfPage.waitForTimeout(1500);
 
   // First Series card. Cards are anchors / buttons rendering each series.
-  // Use `a[href^="/series/"]` which is stable across the SeriesCard component
+  // Use `[data-testid="series-card"]` which is stable across the SeriesCard component
   // refactors we've been through.
-  const firstCard = perfPage.locator('a[href^="/series/"]').first();
-  await firstCard.waitFor({ state: "visible", timeout: 15_000 });
+  const firstCard = perfPage
+    .locator('[data-testid="series-card"]')
+    .or(
+      perfPage.locator(
+        '[data-page="series"] button[aria-label]:not([aria-pressed]):not([aria-checked]):not([data-resume-hero-button])',
+      ),
+    )
+    .first();
+  await firstCard.waitFor({ state: "visible", timeout: 60_000 });
 
   const heapBefore = await readHeap(perfPage);
 

--- a/tests/perf/dock-transitions.spec.ts
+++ b/tests/perf/dock-transitions.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect, type PerfMetrics } from "./fixtures";
-import { loginViaUI } from "../prod/helpers";
 
 /**
  * Dock tab transitions: press the dock tab, measure time to destination paint.
@@ -62,7 +61,8 @@ test("dock transitions: walk the whole dock under throttle", async ({
   harvest,
   cpuRate,
 }, testInfo) => {
-  await loginViaUI(perfPage);
+  // Auth pre-seeded via global-setup + storageState.
+  await perfPage.goto("/");
   await routeReady('[data-page="movies"]');
   // Settle: let the initial render + web-vitals observers fire before we
   // start measuring dock hops.

--- a/tests/perf/fixtures.ts
+++ b/tests/perf/fixtures.ts
@@ -97,7 +97,24 @@ export const test = base.extend<PerfFixture>({
     // src/main.tsx sees Silk on the very first evaluation.
     await cdp.send("Emulation.setUserAgentOverride", { userAgent: SILK_UA });
 
-    // Throttling BEFORE first navigation. Baseline mode (rate 1) intentionally
+    // Stub /api/auth/refresh to return 200 without hitting the backend.
+    // Why: the real backend ROTATES the refresh token on every call (security
+    // best practice). Global-setup logs in and saves one set of cookies; each
+    // spec loads those cookies into a fresh context and the app's boot-refresh
+    // call would rotate the token for ITS context only — invalidating the
+    // shared refresh_token that every other test relies on. Stubbing keeps the
+    // app in the "authenticated" code path while preserving the valid
+    // access_token cookie for real API reads (catalog, history, etc.). Same
+    // pattern as tests/e2e/helpers.ts:seedFakeAuth.
+    await page.route("**/api/auth/refresh", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Tokens refreshed" }),
+      });
+    });
+
+    // Throttling AFTER route setup. Baseline mode (rate 1) intentionally
     // skips network emulation — we want a clean upper bound.
     if (cpuRate > 1) {
       await cdp.send("Emulation.setCPUThrottlingRate", { rate: cpuRate });
@@ -260,7 +277,12 @@ export const test = base.extend<PerfFixture>({
       action: () => Promise<void>,
       dest: { urlPattern: RegExp; sentinel: string },
     ) => {
-      const t0 = await page.evaluate(() => performance.now());
+      // Use Date.now() — wall-clock, immune to document-origin resets. When
+      // the action falls back to a hard goto (SPA nav failed under throttle),
+      // the destination document has a NEW `performance.timeOrigin` and
+      // performance.now() resets, producing negative deltas. Date.now() is
+      // monotonic across full navigations.
+      const t0 = await page.evaluate(() => Date.now());
       const longBefore = await page.evaluate(() => {
         const g = window as unknown as { __svLong: Array<{ start: number }> };
         return g.__svLong.length;
@@ -268,7 +290,7 @@ export const test = base.extend<PerfFixture>({
       await action();
       await page.waitForURL(dest.urlPattern, { timeout: 30_000 });
       await page.waitForSelector(dest.sentinel, { timeout: 30_000 });
-      const t1 = await page.evaluate(() => performance.now());
+      const t1 = await page.evaluate(() => Date.now());
       const longDuring = await page.evaluate((before) => {
         const g = window as unknown as {
           __svLong: Array<{ dur: number; start: number }>;

--- a/tests/perf/global-setup.ts
+++ b/tests/perf/global-setup.ts
@@ -1,0 +1,39 @@
+import { chromium, type FullConfig } from "@playwright/test";
+import { loginViaUI } from "../prod/helpers";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+/**
+ * Global setup: log in ONCE and save the auth state so every perf spec can
+ * reuse it via `storageState`. Avoids the backend's login rate-limit of
+ * 5 attempts per 15-minute window (see streamvault-backend
+ * src/middleware/rateLimiter.ts) — otherwise a 10-spec run (2 projects × 5
+ * specs) blows past the ceiling on the 6th test.
+ *
+ * Output path: perf-artifacts/auth.json. Written only in-process, wiped by
+ * `run-perf-prod.mjs` at the start of each run alongside the rest of
+ * perf-artifacts/ — no long-lived token on disk.
+ */
+export default async function globalSetup(config: FullConfig) {
+  const baseURL =
+    process.env["STREAMVAULT_PROD_URL"] ??
+    config.projects[0]?.use.baseURL ??
+    "https://streamvault.srinivaskotha.uk";
+  const statePath = "perf-artifacts/auth.json";
+  mkdirSync(dirname(statePath), { recursive: true });
+
+  const browser = await chromium.launch({
+    args: ["--no-sandbox", "--disable-dev-shm-usage"],
+  });
+  const context = await browser.newContext({ baseURL });
+  const page = await context.newPage();
+
+  console.log("[perf-setup] logging in once for the whole suite…");
+  await loginViaUI(page);
+  await context.storageState({ path: statePath });
+  console.log(`[perf-setup] auth state written to ${statePath}`);
+
+  await page.close();
+  await context.close();
+  await browser.close();
+}

--- a/tests/perf/grid-scroll.spec.ts
+++ b/tests/perf/grid-scroll.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect, type PerfMetrics } from "./fixtures";
-import { loginViaUI } from "../prod/helpers";
 
 /**
  * D-pad grid scroll: press ArrowDown ×30 through Movies (virtualized via
@@ -19,7 +18,7 @@ for (const route of ["movies", "series"] as const) {
     harvest,
     cpuRate,
   }, testInfo) => {
-    await loginViaUI(perfPage);
+    // Auth pre-seeded via global-setup + storageState.
     await perfPage.goto(`/${route}`);
     await routeReady(`[data-page="${route}"]`);
     await perfPage.waitForTimeout(2000); // Let list fully paint + initial scroll settle.
@@ -30,10 +29,10 @@ for (const route of ["movies", "series"] as const) {
       .locator(
         route === "movies"
           ? '[data-page="movies"] button, [data-page="movies"] a'
-          : '[data-page="series"] a[href^="/series/"]',
+          : '[data-page="series"] [data-testid="series-card"], [data-page="series"] button[aria-label]:not([aria-pressed]):not([aria-checked]):not([data-resume-hero-button])',
       )
       .first();
-    await firstCard.waitFor({ state: "visible", timeout: 15_000 });
+    await firstCard.waitFor({ state: "visible", timeout: 60_000 });
     await firstCard.focus();
 
     // Clear sampler so we only capture during-scroll frames.

--- a/tests/perf/lighthouse-routes.mjs
+++ b/tests/perf/lighthouse-routes.mjs
@@ -22,8 +22,33 @@
 import lighthouse from "lighthouse";
 import * as chromeLauncher from "chrome-launcher";
 import { chromium } from "playwright";
-import { mkdirSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { homedir } from "node:os";
+
+// chrome-launcher auto-discovers Chrome/Chromium on desktop installs but
+// can't find Playwright's bundled browser on headless VPSes. Point
+// CHROME_PATH at the newest Playwright-installed chromium binary if the
+// user hasn't set it explicitly.
+if (!process.env.CHROME_PATH) {
+  const pwCache = join(homedir(), ".cache/ms-playwright");
+  if (existsSync(pwCache)) {
+    const dirs = readdirSync(pwCache)
+      .filter((d) => d.startsWith("chromium-") && !d.includes("headless"))
+      .sort()
+      .reverse();
+    for (const dir of dirs) {
+      for (const sub of ["chrome-linux64/chrome", "chrome-linux/chrome"]) {
+        const p = join(pwCache, dir, sub);
+        if (existsSync(p)) {
+          process.env.CHROME_PATH = p;
+          break;
+        }
+      }
+      if (process.env.CHROME_PATH) break;
+    }
+  }
+}
 
 const BASE =
   process.env.STREAMVAULT_PROD_URL ?? "https://streamvault.srinivaskotha.uk";

--- a/tests/prod/helpers.ts
+++ b/tests/prod/helpers.ts
@@ -25,10 +25,12 @@ export async function loginViaUI(page: Page): Promise<void> {
   await page.fill("input#password", password);
   await page.click('button[type="submit"]');
 
-  // Post-login: dock should appear within 5s. If this times out, login
-  // failed silently — check credentials or the /api/auth/login response.
+  // Post-login: dock should appear. Wait generously — the perf suite runs
+  // with CDP 6× CPU throttling where the post-login render itself exceeds
+  // 10s (actual measured signal, not flake). Normal smoke runs resolve in
+  // <2s so the bump doesn't slow the happy path, only the tail.
   await page.waitForSelector('nav[aria-label="Main navigation"]', {
-    timeout: 10_000,
+    timeout: 45_000,
   });
 }
 


### PR DESCRIPTION
## Summary

First end-to-end run of the Fire TV perf suite against prod surfaced six infra issues — all in the test harness, not the app. This PR fixes all of them. Findings from the partial-successful 8/10 spec run captured below.

## Infra fixes
- **Session reuse** — backend rotates refresh tokens on every call and rate-limits login to 5/15 min. A 10-spec run was blowing both limits. Added `tests/perf/global-setup.ts` (one UI login, saves `storageState`), enabled `storageState` + `globalSetup` in [playwright.perf.config.ts](playwright.perf.config.ts), removed `loginViaUI` from every spec, and added a `page.route` stub for `/api/auth/refresh` (matches `seedFakeAuth` pattern).
- **Negative transition times** — `performance.now()` resets across document origins (hit on the dock-click goto-fallback path). Switched to `Date.now()` in [tests/perf/fixtures.ts](tests/perf/fixtures.ts).
- **Login timeout** — 10s was too tight under 6× CPU throttle; bumped to 45s in [tests/prod/helpers.ts](tests/prod/helpers.ts).
- **Series card selector** — `a[href^="/series/"]` never matched (SeriesCard renders a `<button>`). Added `data-testid="series-card"` to [SeriesCard.tsx](src/features/series/SeriesCard.tsx), with aria-label fallback in specs for current deployed bundles.
- **Lighthouse Chrome discovery** — auto-point `CHROME_PATH` at Playwright's bundled chromium when not set.
- **Partial-failure tolerance** — orchestrator now continues to Lighthouse + report even if some specs fail.

## Findings from first run (against current prod bundle `index-QQU8sADD.js`)

| Surface | Measurement | Tier |
|---|---|---|
| Series card → /series/:id detail | **4,955 ms, 20 long tasks** | 🔴 RED |
| /series D-pad scroll (30 presses) | **96% dropped frames**, p99 917 ms | 🔴 RED |
| /movies D-pad scroll (30 presses) | 35% dropped frames, p99 217 ms | 🔴 RED |
| Heap delta on detail enter | 3.2 MB (fallback method) | 🟢 GREEN |

Dock-transition numbers were unreliable in that run (pre-`Date.now()` fix). `back-navigation` failed — `waitForURL(/\/series$/)` timed out after Back click; likely a real Back-stack issue worth a separate look.

## Immediate read

The user complaint — "navigation gets stuck / lag a sec / no smooth transitions" — is reproducible and quantifiable. On a Fire TV Stick Lite-class budget:
- opening a Series detail takes **5 seconds**
- scrolling through Series drops **96% of frames**

## Next

After this lands + auto-deploys, re-run `npm run perf:prod` to get clean numbers. Then a follow-up PR targeting the two biggest RED hotspots:
1. Virtualize `SeriesGrid` (plain CSS grid today; MovieGrid already uses react-virtuoso) — biggest leverage on /series scroll
2. Lazy-chunk more of SeriesDetailRoute's sub-features so initial mount isn't 20 long tasks

## Test plan
- [x] Typecheck clean
- [x] Perf suite passes 8/10 against prod, 2 remaining failures are investigative (not infra)
- [ ] CI green on this PR
- [ ] Post-merge, re-run perf:prod and confirm transition times are positive

🤖 Generated with [Claude Code](https://claude.com/claude-code)