### PR TITLE
perf(tv): kill focused-card scale + fix dock-transitions selector

### DIFF
--- a/src/brand/tokens.css
+++ b/src/brand/tokens.css
@@ -372,4 +372,15 @@
   :root[data-tv="true"] *::after {
     animation-iteration-count: 1 !important;
   }
+
+  /* Kill focused-card transforms on TV. MovieCard/SeriesCard apply
+     `transform: scale(1.03)` when focused to draw the eye on desktop —
+     harmless there, but on Fire TV the resulting GPU composite on every
+     D-pad key-press caused p95 frame spikes of 180+ms during grid
+     scroll (measured 2026-04-24 post-PR-#112). Border + box-shadow
+     focus indicators remain; those don't force a composite. */
+  :root[data-tv="true"] [data-card-focusable] {
+    transform: none !important;
+    will-change: auto !important;
+  }
 }

--- a/src/features/movies/MovieCard.tsx
+++ b/src/features/movies/MovieCard.tsx
@@ -165,6 +165,7 @@ export function MovieCard({
 
   return (
     <div
+      data-card-focusable
       style={{
         position: "relative",
         transform: focused ? "scale(1.03)" : "scale(1)",

--- a/src/features/series/SeriesCard.tsx
+++ b/src/features/series/SeriesCard.tsx
@@ -185,6 +185,7 @@ export function SeriesCard({
 
   return (
     <div
+      data-card-focusable
       style={{
         position: "relative",
         transform: focused ? "scale(1.03)" : "scale(1)",

--- a/tests/perf/dock-transitions.spec.ts
+++ b/tests/perf/dock-transitions.spec.ts
@@ -73,21 +73,18 @@ test("dock transitions: walk the whole dock under throttle", async ({
   for (const hop of HOPS) {
     const { transitionMs, longTasksDuringTransition } = await transition(
       async () => {
-        // Prefer clicking the dock link — matches how a mouse/touch user
-        // navigates. For D-pad nav see card-to-detail.spec.ts which uses
-        // keyboard.press. We're measuring route-transition cost, not focus-
-        // engine cost.
+        // BottomDock renders <button> tabs, not <a>. Target by aria-label
+        // on the dock button — matches how a mouse/touch user navigates AND
+        // how the SPA router resolves. The previous `nav ... a` selector
+        // never matched → click timed out → fallback `page.goto()` made
+        // every "transition" a hard-reload, which is why the first measured
+        // run showed a uniform 9-second cost.
         await perfPage
-          .locator(`nav[aria-label="Main navigation"] a`, {
-            has: perfPage.locator(`[aria-label="${capitalize(hop.to)}"]`),
-          })
+          .locator(
+            `nav[aria-label="Main navigation"] button[aria-label="${capitalize(hop.to)}"]`,
+          )
           .first()
-          .click({ timeout: 5000 })
-          .catch(async () => {
-            // Fallback: navigate directly. The click failure itself is a
-            // finding (dock link unclickable under throttle).
-            await perfPage.goto(`/${hop.to}`);
-          });
+          .click({ timeout: 10_000 });
       },
       { urlPattern: hop.urlPattern, sentinel: hop.sentinel },
     );


### PR DESCRIPTION
## Summary

Second-wave chase at the two remaining 🔴 RED boxes from [PR #112's validation run](https://github.com/srinivas-kotha/streamvault-v3-frontend/pull/112).

## What changed

1. **Dock-transitions test selector fix.** Previous selector was `nav[aria-label=\"Main navigation\"] a` — but BottomDock renders `<button>` tabs, not `<a>`. Zero matches → click timed out → `page.goto()` fallback kicked in → every measured "transition" was actually a hard page reload. That's why all four dock hops showed a near-uniform 9s cost. Now targets `nav[...] button[aria-label=\"...\"]` directly. Removed the goto fallback — if the click fails, the test fails (that's a finding). **Real users never experienced the 9s** — it was a measurement artifact.

2. **`transform: scale(1.03)` on focused cards, gated off for TV.** [MovieCard.tsx:170](src/features/movies/MovieCard.tsx#L170) + [SeriesCard.tsx:190](src/features/series/SeriesCard.tsx#L190) apply this on every focus change. On Fire TV the resulting GPU composite per D-pad keypress is a real contributor to the p95 180ms+ frame spikes during grid scroll. The scale is a cosmetic nicety — the copper focus-ring border + box-shadow are enough signal. Kept for desktop/mobile, killed for TV. Implemented via one `data-card-focusable` attribute + one CSS rule in [tokens.css](src/brand/tokens.css) — no inline-style churn, no per-component branches.

## Expected impact (to be validated)

| Metric | Before | Target |
|---|---|---|
| Dock transitions (real measurement) | 9 s 🔴 | sub-second 🟢 |
| /movies scroll dropped frames | 39% 🔴 | <15% 🟢 |
| /series scroll dropped frames | 31% 🔴 | <15% 🟢 |

## Test plan
- [x] Typecheck + 331/331 unit tests green
- [x] Bundle budget green (CSS-only app change)
- [ ] Post-deploy `npm run perf:prod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)