### PR TITLE
fix(player): arrow-hold survives status flip on first seek (movies fast-fwd)

### DIFF
--- a/src/player/PlayerControls.test.tsx
+++ b/src/player/PlayerControls.test.tsx
@@ -512,6 +512,41 @@ describe("PlayerControls", () => {
     expect(onSeek).not.toHaveBeenCalled();
   });
 
+  // Regression for prod 2026-04-24: arrow-hold did nothing because the first
+  // seek flipped video status playing→seeking, which recreated togglePlayPause,
+  // which re-ran the keydown effect, whose cleanup called clearArrowHold —
+  // killing the 400ms timer before it could fire. Listener is now installed
+  // once with refs for the unstable callbacks so status churn can't tear it down.
+  it("arrow-hold ticks survive a status change between keydown and the first tick", () => {
+    const onSeek = vi.fn() as Mock;
+    const { rerender } = render(
+      <PlayerControls {...makeProps({ kind: "vod", currentTime: 100, status: "playing", onSeek })} />,
+    );
+    currentFocusKey = "PLAYER_PLAY_PAUSE";
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
+    });
+    // Simulate the video element flipping to "seeking" 100ms in (what really
+    // happens when an external seek call fires the seeking event). Pre-fix
+    // this re-render destroyed the hold timer.
+    act(() => {
+      vi.advanceTimersByTime(100);
+      rerender(
+        <PlayerControls {...makeProps({ kind: "vod", currentTime: 100, status: "seeking", onSeek })} />,
+      );
+    });
+    // 400ms hold delay then 500ms first interval tick = 900ms total.
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+    expect(onSeek).toHaveBeenCalledWith(130);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keyup", { key: "ArrowRight" }));
+    });
+  });
+
   // ─── 6e: Prev/Next moved to top bar (UX option 1) ───────────────────────
 
   it("Prev/Next render in the top bar, not the control bar", () => {

--- a/src/player/PlayerControls.tsx
+++ b/src/player/PlayerControls.tsx
@@ -533,6 +533,30 @@ export function PlayerControls({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // The keydown listener needs the latest togglePlayPause/wake/openMenu/etc.,
+  // but if those go in the effect's dep array the listener is torn down on
+  // every status change. That destroyed in-flight hold timers (prod 2026-04-24:
+  // arrow-hold did nothing — pressing Right seeks, status flips to "seeking",
+  // togglePlayPause is recreated, effect tears down, clearArrowHold cancels
+  // the 400ms timer before it can fire). Stash everything that mutates in
+  // refs so the listener is installed exactly once.
+  const togglePlayPauseRef = useRef(togglePlayPause);
+  togglePlayPauseRef.current = togglePlayPause;
+  const wakeRef = useRef(wake);
+  wakeRef.current = wake;
+  const openMenuRef = useRef(openMenu);
+  openMenuRef.current = openMenu;
+  const onSeekRef = useRef(onSeek);
+  onSeekRef.current = onSeek;
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  const onNextRef = useRef(onNext);
+  onNextRef.current = onNext;
+  const onPrevRef = useRef(onPrev);
+  onPrevRef.current = onPrev;
+  const isLiveRef = useRef(isLive);
+  isLiveRef.current = isLive;
+
   // Capture-phase key interceptor: wake-only on first arrow when hidden,
   // Enter short-circuits pause/play (spec §4.3). Also handles media keys
   // (TV remote) and Escape.
@@ -556,10 +580,10 @@ export function PlayerControls({
         kc === 4;
       if (isBack) {
         e.preventDefault();
-        if (openMenu) {
+        if (openMenuRef.current) {
           setOpenMenu(null);
         } else {
-          onClose();
+          onCloseRef.current();
         }
         return;
       }
@@ -575,41 +599,41 @@ export function PlayerControls({
         kc === 127;
       if (isPlayPauseKey) {
         e.preventDefault();
-        togglePlayPause();
-        wake();
+        togglePlayPauseRef.current();
+        wakeRef.current();
         return;
       }
 
       const isRewindKey = k === "MediaRewind" || k === "j" || kc === 89;
-      if (isRewindKey && !isLive) {
+      if (isRewindKey && !isLiveRef.current) {
         e.preventDefault();
-        onSeek(currentTimeRef.current - 10);
-        wake();
+        onSeekRef.current(currentTimeRef.current - 10);
+        wakeRef.current();
         return;
       }
 
       const isFfKey =
         k === "MediaFastForward" || k === "l" || kc === 90;
-      if (isFfKey && !isLive) {
+      if (isFfKey && !isLiveRef.current) {
         e.preventDefault();
-        onSeek(currentTimeRef.current + 10);
-        wake();
+        onSeekRef.current(currentTimeRef.current + 10);
+        wakeRef.current();
         return;
       }
 
       // Fire TV's ⏭ / ⏮ media keys map to prev/next episode if provided.
       const isMediaNext = k === "MediaTrackNext" || kc === 87;
-      if (isMediaNext && onNext) {
+      if (isMediaNext && onNextRef.current) {
         e.preventDefault();
-        onNext();
-        wake();
+        onNextRef.current();
+        wakeRef.current();
         return;
       }
       const isMediaPrev = k === "MediaTrackPrevious" || kc === 88;
-      if (isMediaPrev && onPrev) {
+      if (isMediaPrev && onPrevRef.current) {
         e.preventDefault();
-        onPrev();
-        wake();
+        onPrevRef.current();
+        wakeRef.current();
         return;
       }
 
@@ -624,18 +648,18 @@ export function PlayerControls({
         if (isArrow) {
           e.preventDefault();
           e.stopPropagation();
-          wake();
+          wakeRef.current();
           return;
         }
         if (isEnter) {
           e.preventDefault();
           e.stopPropagation();
-          togglePlayPause();
-          wake();
+          togglePlayPauseRef.current();
+          wakeRef.current();
           return;
         }
       } else {
-        if (isArrow || isEnter) wake();
+        if (isArrow || isEnter) wakeRef.current();
       }
 
       // Arm arrow-hold acceleration when ArrowLeft/Right is pressed on a
@@ -644,8 +668,8 @@ export function PlayerControls({
       // on the focused button — this effect only adds the ticking interval
       // that kicks in once the user has held the key past ARROW_HOLD_DELAY_MS.
       if (
-        !isLive &&
-        !openMenu &&
+        !isLiveRef.current &&
+        !openMenuRef.current &&
         visibleRef.current &&
         !e.repeat &&
         (k === "ArrowLeft" || k === "ArrowRight") &&
@@ -657,10 +681,10 @@ export function PlayerControls({
           arrowHoldKeyRef.current = k;
           arrowHoldStartTimerRef.current = setTimeout(() => {
             arrowHoldIntervalRef.current = setInterval(() => {
-              onSeek(
+              onSeekRef.current(
                 currentTimeRef.current + direction * HOLD_SEEK_STEP_S,
               );
-              wake();
+              wakeRef.current();
             }, HOLD_SEEK_TICK_MS);
           }, ARROW_HOLD_DELAY_MS);
         }
@@ -676,7 +700,7 @@ export function PlayerControls({
       }
     };
 
-    const onMouseMove = () => wake();
+    const onMouseMove = () => wakeRef.current();
 
     window.addEventListener("keydown", onKeyDown, true);
     window.addEventListener("keyup", onKeyUp, true);
@@ -687,17 +711,7 @@ export function PlayerControls({
       window.removeEventListener("keyup", onKeyUp, true);
       window.removeEventListener("mousemove", onMouseMove);
     };
-  }, [
-    onClose,
-    onSeek,
-    isLive,
-    openMenu,
-    togglePlayPause,
-    wake,
-    onNext,
-    onPrev,
-    clearArrowHold,
-  ]);
+  }, [clearArrowHold]);
 
   const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
 


### PR DESCRIPTION
## Summary

Prod feedback 2026-04-24: PR #110's arrow-hold fast-forward still felt broken on movies — *\"forward for a sec, hold press not working.\"* Single press jumped +10s once, but the accelerated +30s/500ms tick never kicked in.

## Root cause

`PlayerControls.tsx` keydown effect's deps included `togglePlayPause`, which is recreated whenever `isPlaying = status === \"playing\"` flips:

1. User presses Right on Play/Pause
2. `arrowOverrides.right` fires `onSeek(+10)` → video element fires `seeking` event
3. `setStatus(\"seeking\")` → `isPlaying` flips true→false
4. `togglePlayPause` recreated (different identity)
5. keydown effect tears down → cleanup calls `clearArrowHold()`
6. The 400ms hold timer (just armed in the same keydown handler) is killed
7. Fire TV / Silk doesn't emit OS key-repeat, so no new keydown fires while the user keeps holding the remote
8. Hold acceleration never recovers — only the initial +10s ever happens

`openMenu` was in the dep list for the same reason and would cause the same teardown if it changed mid-hold.

## Fix

Install the window keydown / keyup / mousemove listeners exactly once. Stash all callbacks/state that mutate (`togglePlayPause`, `wake`, `openMenu`, `onSeek`, `onClose`, `onNext`, `onPrev`, `isLive`) in refs that the listener reads at call time. Effect deps reduce to `[clearArrowHold]` (stable — `useCallback` with `[]`).

## Test plan

- [x] 332/332 unit tests green (added regression test that rerenders with `status=\"seeking\"` 100ms into a hold and asserts the +30s tick still fires at t=900ms)
- [x] Typecheck clean
- [x] Bundle: 309.70 KB gzip (well under 600 KB budget)
- [ ] Manual prod verification on Fire TV: hold ◀/▶ on a movie, expect +10s instant + then +30s every 500ms after the 400ms hold delay until release

🤖 Generated with [Claude Code](https://claude.com/claude-code)