### PR TITLE
feat(player): tap-rate fast-forward (10s → 30s → 60s) — replaces hold timer

### DIFF
--- a/docs/ux/05-player.md
+++ b/docs/ux/05-player.md
@@ -85,11 +85,19 @@ When a control is disabled (e.g. Seek on Live, Next-episode on a movie), D-pad *
 
 This keeps the control count adaptive: Live shows 7 buttons (no ±10s), Movies show 8 (no prev/next episode), Series show 9 (all of them).
 
-### 3.2 Long-press on ±10s → variable seek
+### 3.2 Tap-rate accelerator on ±10s
 
-`ArrowLeft` or `ArrowRight` held down while focused on ⏮ or ⏭ seeks in **30-second jumps** every 500ms. Release to stop. No second button; the primary button serves both.
+Each press of ◀◀ or ▶▶ — `Enter` on the focused button OR `ArrowLeft`/`ArrowRight` on any transport-row button (Play/Pause, ◀◀, ▶▶) — feeds a single rate accelerator. The per-tap delta scales with tap density:
 
-Rationale: fast-forward/rewind on D-pad is traditionally "hold to scrub." We honor the muscle memory.
+| Taps in last 1s | Per-tap delta |
+|---|---|
+| 1–2 | ±10 s |
+| 3–5 | ±30 s |
+| 6+  | ±60 s |
+
+Direction reset (Right→Left or Left→Right) clears the window so an over-shoot doesn't snap back N×. A copper "▶▶ 3×" / "◀◀ 6×" badge appears above the scrubber while the multiplier is above 1× and fades 1.2 s after the last tap.
+
+**Rationale (revised 2026-04-25 after two failed hold-timer attempts in PRs #110 / #115):** Silk on Fire TV emits held d-pad as rapid keydown+keyup pairs, not a sustained keydown. The user described it as "click click click for every 10 seconds." A timer-based hold model never armed reliably; a rate-based model treats both *held arrows* and *fast taps* identically because the only signal we measure is *seek-action frequency*. The user does not need to learn anything new — keep tapping, the jumps grow.
 
 ---
 
@@ -316,7 +324,7 @@ No "Try again" button (won't help) — just "Back to browse".
 | 3 | First wake press shows controls only; doesn't trigger action | Wake + action in one press (too many accidental skips) |
 | 4 | `Enter` short-circuits pause/play even when controls hidden | Require wake first (too slow for the #1 user action) |
 | 5 | Disabled controls are `focusable:false`, not dimmed | Dimmed-but-focusable (lands on dead targets) |
-| 6 | Hold ±10s button = 30s jumps | Separate fast-forward button (scarce control bar space) |
+| 6 | Tap-rate accelerator on ±10s (10s → 30s → 60s by tap density) | Hold-timer (PRs #110/#115 — Silk on Fire TV emits hold as auto-tap pairs, timer never armed reliably in prod) |
 | 7 | Quality popover orders highest-first | Lowest-first (open-intent is "lower it") |
 | 8 | Volume is in-app (stream gain), remote volume keys affect TV | In-app intercepts remote (breaks Fire TV norm) |
 | 9 | Popovers close on Left/Right + advance to next control | Popovers require Back to close (slower to walk all three) |

--- a/src/player/PlayerControls.test.tsx
+++ b/src/player/PlayerControls.test.tsx
@@ -235,43 +235,19 @@ describe("PlayerControls", () => {
 
   // ─── 6b: hold-to-scrub ──────────────────────────────────────────────────
 
-  it("first Enter on seek fires single ±10s; held Enter starts 30s interval", () => {
+  it("first Enter on seek button fires single ±10s (tap-rate base step)", () => {
     const onSeek = vi.fn() as Mock;
-    const props = makeProps({ currentTime: 120, onSeek });
-    render(<PlayerControls {...props} />);
+    render(<PlayerControls {...makeProps({ currentTime: 120, onSeek })} />);
 
     act(() => pressEnter("PLAYER_SEEK_BACK", 1));
-    expect(onSeek).toHaveBeenNthCalledWith(1, 110);
-
-    act(() => {
-      vi.advanceTimersByTime(500);
-    });
-    expect(onSeek).toHaveBeenNthCalledWith(2, 90);
-
-    act(() => {
-      vi.advanceTimersByTime(500);
-    });
-    expect(onSeek).toHaveBeenNthCalledWith(3, 90);
+    expect(onSeek).toHaveBeenCalledTimes(1);
+    expect(onSeek).toHaveBeenLastCalledWith(110);
 
     act(() => releaseEnter("PLAYER_SEEK_BACK"));
     act(() => {
       vi.advanceTimersByTime(2000);
     });
-    expect(onSeek).toHaveBeenCalledTimes(3);
-  });
-
-  it("Enter auto-repeat (pressedKeys.enter > 1) does NOT double-fire the initial seek", () => {
-    const onSeek = vi.fn() as Mock;
-    render(<PlayerControls {...makeProps({ currentTime: 60, onSeek })} />);
-
-    act(() => pressEnter("PLAYER_SEEK_FORWARD", 1));
     expect(onSeek).toHaveBeenCalledTimes(1);
-
-    act(() => pressEnter("PLAYER_SEEK_FORWARD", 2));
-    act(() => pressEnter("PLAYER_SEEK_FORWARD", 3));
-    expect(onSeek).toHaveBeenCalledTimes(1);
-
-    act(() => releaseEnter("PLAYER_SEEK_FORWARD"));
   });
 
   // ─── 6b: volume slider ──────────────────────────────────────────────────
@@ -432,119 +408,112 @@ describe("PlayerControls", () => {
     expect(onSeek).toHaveBeenCalledWith(190);
   });
 
-  // ─── Arrow-hold acceleration ────────────────────────────────────────────
+  // ─── Tap-rate accelerator (spec §3.2) ────────────────────────────────────
+  //
+  // After two failed attempts (PRs #110 / #115) at hold-timer FF, prod
+  // feedback 2026-04-25: "click click click for every 10 seconds." Silk on
+  // Fire TV emits held d-pad as rapid keydown+keyup pairs; the timer-based
+  // model never fires reliably. Replaced with rate-aware delta on each tap:
+  // 1–2 taps in 1s → ±10s, 3–5 → ±30s, 6+ → ±60s. Direction reset clears
+  // the window so an over-shoot doesn't snap back N×.
 
-  it("holding ArrowRight on Play/Pause ticks +30s every 500ms until keyup", () => {
+  it("first ArrowRight tap on Play/Pause seeks +10s (1× rate)", () => {
     const onSeek = vi.fn() as Mock;
     render(<PlayerControls {...makeProps({ kind: "vod", currentTime: 100, onSeek })} />);
-    currentFocusKey = "PLAYER_PLAY_PAUSE";
-
-    act(() => {
-      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
-    });
-    // No tick before the hold delay.
-    act(() => {
-      vi.advanceTimersByTime(300);
-    });
-    expect(onSeek).not.toHaveBeenCalled();
-
-    // Hold delay (400ms) elapses → first tick fires; each subsequent tick
-    // every 500ms. currentTime prop doesn't update in the test harness, so
-    // every tick sees currentTimeRef=100 and seeks to 130 — in production
-    // the player's timeupdate handler advances the prop between ticks.
-    act(() => {
-      vi.advanceTimersByTime(100 + 500);
-    });
-    expect(onSeek).toHaveBeenCalledTimes(1);
-    expect(onSeek).toHaveBeenLastCalledWith(130);
-
-    act(() => {
-      vi.advanceTimersByTime(500);
-    });
-    expect(onSeek).toHaveBeenCalledTimes(2);
-
-    act(() => {
-      window.dispatchEvent(new KeyboardEvent("keyup", { key: "ArrowRight" }));
-    });
-    act(() => {
-      vi.advanceTimersByTime(2000);
-    });
-    expect(onSeek).toHaveBeenCalledTimes(2);
+    act(() => pressArrow("PLAYER_PLAY_PAUSE", "right"));
+    expect(onSeek).toHaveBeenCalledWith(110);
   });
 
-  it("holding ArrowLeft on Play/Pause ticks -30s", () => {
+  // currentTime prop is frozen at 100 across all taps in these tests (the
+  // production player would advance it via the timeupdate handler between
+  // taps); the assertions below check ONLY the per-tap delta the rate
+  // accelerator chose, not the cumulative position.
+  it("3 rapid ArrowRight taps escalate the third to +30s (3× rate)", () => {
     const onSeek = vi.fn() as Mock;
-    render(<PlayerControls {...makeProps({ kind: "vod", currentTime: 200, onSeek })} />);
-    currentFocusKey = "PLAYER_PLAY_PAUSE";
-
-    act(() => {
-      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft" }));
-      vi.advanceTimersByTime(400 + 500);
-    });
-    expect(onSeek).toHaveBeenLastCalledWith(170);
-
-    act(() => {
-      window.dispatchEvent(new KeyboardEvent("keyup", { key: "ArrowLeft" }));
-    });
+    render(<PlayerControls {...makeProps({ kind: "vod", currentTime: 100, onSeek })} />);
+    act(() => pressArrow("PLAYER_PLAY_PAUSE", "right"));
+    expect(onSeek).toHaveBeenLastCalledWith(110); // 1× = +10
+    act(() => pressArrow("PLAYER_PLAY_PAUSE", "right"));
+    expect(onSeek).toHaveBeenLastCalledWith(110); // still 1× (2 taps in window) = +10
+    act(() => pressArrow("PLAYER_PLAY_PAUSE", "right"));
+    expect(onSeek).toHaveBeenLastCalledWith(130); // 3 taps in window → 3× = +30
   });
 
-  it("holding an arrow does not fire hold ticks on Live (no seekable window)", () => {
+  it("6 rapid ArrowRight taps escalate the sixth to +60s (6× rate)", () => {
+    const onSeek = vi.fn() as Mock;
+    render(<PlayerControls {...makeProps({ kind: "vod", currentTime: 100, onSeek })} />);
+    for (let i = 0; i < 5; i += 1) act(() => pressArrow("PLAYER_PLAY_PAUSE", "right"));
+    act(() => pressArrow("PLAYER_PLAY_PAUSE", "right"));
+    expect(onSeek).toHaveBeenLastCalledWith(160); // 6 taps → 6× = +60
+  });
+
+  it("changing direction (Right→Left) resets the rate to 1× / -10s", () => {
+    const onSeek = vi.fn() as Mock;
+    render(<PlayerControls {...makeProps({ kind: "vod", currentTime: 100, onSeek })} />);
+    for (let i = 0; i < 4; i += 1) act(() => pressArrow("PLAYER_PLAY_PAUSE", "right"));
+    expect(onSeek).toHaveBeenLastCalledWith(130); // 4th tap still 3× = +30
+    act(() => pressArrow("PLAYER_PLAY_PAUSE", "left"));
+    expect(onSeek).toHaveBeenLastCalledWith(90); // direction flip → window cleared, -10
+  });
+
+  it("pause >TAP_WINDOW_MS between taps resets the rate", () => {
+    const onSeek = vi.fn() as Mock;
+    render(<PlayerControls {...makeProps({ kind: "vod", currentTime: 100, onSeek })} />);
+    for (let i = 0; i < 3; i += 1) act(() => pressArrow("PLAYER_PLAY_PAUSE", "right"));
+    expect(onSeek).toHaveBeenLastCalledWith(130); // 3× by the third tap
+    act(() => {
+      vi.advanceTimersByTime(1500); // > 1000ms TAP_WINDOW_MS
+    });
+    act(() => pressArrow("PLAYER_PLAY_PAUSE", "right"));
+    expect(onSeek).toHaveBeenLastCalledWith(110); // back to +10s
+  });
+
+  it("ArrowRight on Live falls through (no seek)", () => {
     const onSeek = vi.fn() as Mock;
     render(<PlayerControls {...makeProps({ kind: "live", currentTime: 100, onSeek })} />);
-    currentFocusKey = "PLAYER_PLAY_PAUSE";
-
-    act(() => {
-      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
-      vi.advanceTimersByTime(2000);
-    });
+    // On live, transportArrowOverrides is empty, so pressArrow returns true
+    // (norigin handles it). We assert no seek fired.
+    pressArrow("PLAYER_PLAY_PAUSE", "right");
     expect(onSeek).not.toHaveBeenCalled();
   });
 
-  it("holding an arrow off the transport row does not fire hold ticks", () => {
+  it("Enter on ▶▶ button feeds the same tap-rate accelerator", () => {
     const onSeek = vi.fn() as Mock;
     render(<PlayerControls {...makeProps({ kind: "vod", currentTime: 100, onSeek })} />);
-    currentFocusKey = "PLAYER_VOLUME";
-
-    act(() => {
-      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
-      vi.advanceTimersByTime(2000);
-    });
-    expect(onSeek).not.toHaveBeenCalled();
+    for (let i = 0; i < 3; i += 1) act(() => pressEnter("PLAYER_SEEK_FORWARD"));
+    expect(onSeek).toHaveBeenLastCalledWith(130);
   });
 
-  // Regression for prod 2026-04-24: arrow-hold did nothing because the first
-  // seek flipped video status playing→seeking, which recreated togglePlayPause,
-  // which re-ran the keydown effect, whose cleanup called clearArrowHold —
-  // killing the 400ms timer before it could fire. Listener is now installed
-  // once with refs for the unstable callbacks so status churn can't tear it down.
-  it("arrow-hold ticks survive a status change between keydown and the first tick", () => {
+  it("rate badge appears at 3× and is hidden at 1×", () => {
+    const onSeek = vi.fn() as Mock;
+    const { queryByTestId } = render(
+      <PlayerControls {...makeProps({ kind: "vod", currentTime: 100, onSeek })} />,
+    );
+    expect(queryByTestId("seek-rate-badge")).toBeNull();
+    act(() => pressArrow("PLAYER_PLAY_PAUSE", "right"));
+    // 1× → badge stays hidden (multiplier === 1)
+    expect(queryByTestId("seek-rate-badge")).toBeNull();
+    act(() => pressArrow("PLAYER_PLAY_PAUSE", "right"));
+    act(() => pressArrow("PLAYER_PLAY_PAUSE", "right"));
+    expect(queryByTestId("seek-rate-badge")?.textContent).toContain("3×");
+  });
+
+  it("rate seek survives a status change mid-burst (no listener teardown)", () => {
     const onSeek = vi.fn() as Mock;
     const { rerender } = render(
       <PlayerControls {...makeProps({ kind: "vod", currentTime: 100, status: "playing", onSeek })} />,
     );
-    currentFocusKey = "PLAYER_PLAY_PAUSE";
-
-    act(() => {
-      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
-    });
-    // Simulate the video element flipping to "seeking" 100ms in (what really
-    // happens when an external seek call fires the seeking event). Pre-fix
-    // this re-render destroyed the hold timer.
-    act(() => {
-      vi.advanceTimersByTime(100);
-      rerender(
-        <PlayerControls {...makeProps({ kind: "vod", currentTime: 100, status: "seeking", onSeek })} />,
-      );
-    });
-    // 400ms hold delay then 500ms first interval tick = 900ms total.
-    act(() => {
-      vi.advanceTimersByTime(800);
-    });
-    expect(onSeek).toHaveBeenCalledWith(130);
-
-    act(() => {
-      window.dispatchEvent(new KeyboardEvent("keyup", { key: "ArrowRight" }));
-    });
+    act(() => pressArrow("PLAYER_PLAY_PAUSE", "right"));
+    rerender(
+      <PlayerControls {...makeProps({ kind: "vod", currentTime: 100, status: "seeking", onSeek })} />,
+    );
+    act(() => pressArrow("PLAYER_PLAY_PAUSE", "right"));
+    rerender(
+      <PlayerControls {...makeProps({ kind: "vod", currentTime: 100, status: "playing", onSeek })} />,
+    );
+    act(() => pressArrow("PLAYER_PLAY_PAUSE", "right"));
+    // 3rd tap should escalate to 30 even with status churn between taps.
+    expect(onSeek).toHaveBeenLastCalledWith(130);
   });
 
   // ─── 6e: Prev/Next moved to top bar (UX option 1) ───────────────────────

--- a/src/player/PlayerControls.test.tsx
+++ b/src/player/PlayerControls.test.tsx
@@ -71,14 +71,8 @@ vi.mock("@noriginmedia/norigin-spatial-navigation", () => {
       Provider: ({ children }: { children: ReactNode }) => children,
     },
     setFocus: vi.fn(),
-    getCurrentFocusKey: () => currentFocusKey,
   };
 });
-
-// The window-level arrow-hold logic calls getCurrentFocusKey to gate on
-// the transport row. Tests that need hold behavior set this before firing
-// the keydown; default is null (off the transport row → hold no-ops).
-let currentFocusKey: string | null = null;
 
 function pressEnter(focusKey: string, count = 1) {
   const h = handlersByKey[focusKey];

--- a/src/player/PlayerControls.tsx
+++ b/src/player/PlayerControls.tsx
@@ -17,9 +17,7 @@ import {
   useFocusable,
   FocusContext,
   setFocus,
-  getCurrentFocusKey,
 } from "@noriginmedia/norigin-spatial-navigation";
-import type { KeyPressDetails } from "@noriginmedia/norigin-spatial-navigation";
 import type {
   HlsLevel,
   HlsAudioTrack,
@@ -48,20 +46,25 @@ export const FK = {
 
 const AUTO_HIDE_MS = 3000;
 const FADE_MS = 300;
-const HOLD_SEEK_STEP_S = 30;
-const HOLD_SEEK_TICK_MS = 500;
-// Delay before the first accelerated tick fires after the user starts
-// holding an arrow key. Short enough that "held down" feels responsive;
-// long enough that a single tap doesn't double-count with the norigin
-// single-press seek (which fires instantly via arrowOverrides).
-const ARROW_HOLD_DELAY_MS = 400;
-const TRANSPORT_FOCUS_KEYS: ReadonlySet<string> = new Set([
-  "PLAYER_PLAY_PAUSE",
-  "PLAYER_SEEK_BACK",
-  "PLAYER_SEEK_FORWARD",
-]);
 const VOLUME_STEP = 0.05;
 const VOLUME_SLIDER_IDLE_MS = 2000;
+
+// Tap-rate accelerator (spec §3.2). Each seek-press is appended to a rolling
+// window; the per-tap delta grows with tap density:
+//   1–2 taps/window → ±10s
+//   3–5 taps/window → ±30s
+//   6+  taps/window → ±60s
+// Direction reset (Right→Left or Left→Right) clears the window so a single
+// over-shoot doesn't snap back N×. The badge over the scrubber visualizes
+// the multiplier so the user feels the gear shift.
+const TAP_WINDOW_MS = 1000;
+const TAP_BADGE_FADE_MS = 1200;
+
+function seekStepFromTaps(taps: number): 10 | 30 | 60 {
+  if (taps >= 6) return 60;
+  if (taps >= 3) return 30;
+  return 10;
+}
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -197,7 +200,6 @@ interface ControlButtonProps {
   ariaExpanded?: boolean;
   ariaHasPopup?: boolean;
   extraStyle?: CSSProperties;
-  onHoldTick?: () => void;
   /**
    * Per-direction arrow overrides. When set, the override runs and norigin
    * nav is blocked. Used by transport buttons (Play/Pause + ±10s) for
@@ -224,31 +226,13 @@ function ControlButton({
   ariaExpanded,
   ariaHasPopup,
   extraStyle,
-  onHoldTick,
   arrowOverrides,
   upTarget = FK.BACK,
 }: ControlButtonProps) {
-  const holdIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  const clearHold = useCallback(() => {
-    if (holdIntervalRef.current) {
-      clearInterval(holdIntervalRef.current);
-      holdIntervalRef.current = null;
-    }
-  }, []);
-
   const { ref, focused } = useFocusable({
     focusKey,
     focusable,
-    onEnterPress: (_: unknown, details: KeyPressDetails) => {
-      if ((details.pressedKeys?.enter ?? 0) > 1) return;
-      onPress();
-      if (onHoldTick) {
-        clearHold();
-        holdIntervalRef.current = setInterval(onHoldTick, HOLD_SEEK_TICK_MS);
-      }
-    },
-    onEnterRelease: clearHold,
+    onEnterPress: onPress,
     onArrowPress: (direction) => {
       const dir = direction as "left" | "right" | "up" | "down";
       const override = arrowOverrides?.[dir];
@@ -266,12 +250,6 @@ function ControlButton({
       return true;
     },
   });
-
-  // Clear any in-flight hold on unmount / focusable-flip to avoid zombie
-  // intervals. (If the user clicks away to another control, onEnterRelease
-  // fires via keyup, but blur without keyup — e.g., programmatic setFocus —
-  // would otherwise leak.)
-  useEffect(() => clearHold, [clearHold]);
 
   return (
     <button
@@ -458,34 +436,23 @@ export function PlayerControls({
   const visibleRef = useRef(visible);
   visibleRef.current = visible;
 
-  // Keep a ref to currentTime so hold-to-scrub ticks can seek from the
-  // latest position instead of the one captured when hold started.
+  // Keep a ref to currentTime so each tap-rate seek reads the latest position
+  // instead of the one captured when the rate window opened.
   const currentTimeRef = useRef(currentTime);
   currentTimeRef.current = currentTime;
 
-  // Arrow-hold acceleration state. norigin fires a single ±10s seek on
-  // first press via arrowOverrides; if the user continues holding the key
-  // past ARROW_HOLD_DELAY_MS, we tick ±HOLD_SEEK_STEP_S every
-  // HOLD_SEEK_TICK_MS until keyup. Fire TV remotes don't emit OS key-repeat,
-  // so we must drive the ticks ourselves.
-  const arrowHoldKeyRef = useRef<"ArrowLeft" | "ArrowRight" | null>(null);
-  const arrowHoldStartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-  const arrowHoldIntervalRef = useRef<ReturnType<typeof setInterval> | null>(
-    null,
-  );
-  const clearArrowHold = useCallback(() => {
-    if (arrowHoldStartTimerRef.current) {
-      clearTimeout(arrowHoldStartTimerRef.current);
-      arrowHoldStartTimerRef.current = null;
-    }
-    if (arrowHoldIntervalRef.current) {
-      clearInterval(arrowHoldIntervalRef.current);
-      arrowHoldIntervalRef.current = null;
-    }
-    arrowHoldKeyRef.current = null;
-  }, []);
+  // Tap-rate accelerator (spec §3.2). Replaced the hold-timer model after
+  // prod 2026-04-24 evidence that Silk on Fire TV emits held d-pad as rapid
+  // keydown+keyup pairs, not a sustained keydown — the user described it as
+  // "click click click for every 10 seconds." Tap density now drives the
+  // per-tap delta: 10s → 30s → 60s. Direction reset (Right→Left) clears the
+  // window so an over-shoot doesn't snap back N×.
+  const recentTapsRef = useRef<{ time: number; dir: -1 | 1 }[]>([]);
+  const [seekBadge, setSeekBadge] = useState<{
+    dir: -1 | 1;
+    multiplier: 1 | 3 | 6;
+  } | null>(null);
+  const seekBadgeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { ref: containerRef, focusKey: containerFocusKey } = useFocusable({
     focusKey: "PLAYER_CONTROLS",
@@ -515,6 +482,46 @@ export function PlayerControls({
       onPlay();
     }
   }, [isPlaying, onPlay, onPause]);
+
+  // Single entry point for every seek-press (Enter on ◀◀/▶▶, Left/Right on
+  // any transport-row button, Fire TV media Rewind/FastForward keys). Each
+  // call appends a tap to the rolling window and seeks by the rate-aware
+  // delta — see the seekStepFromTaps comment block for the schedule.
+  const seekWithRate = useCallback(
+    (direction: -1 | 1) => {
+      const now =
+        typeof performance !== "undefined" ? performance.now() : Date.now();
+      const lastDir = recentTapsRef.current.length
+        ? recentTapsRef.current[recentTapsRef.current.length - 1]!.dir
+        : direction;
+      const sameDirection = lastDir === direction;
+      const trimmed = sameDirection
+        ? recentTapsRef.current.filter((t) => now - t.time < TAP_WINDOW_MS)
+        : [];
+      trimmed.push({ time: now, dir: direction });
+      recentTapsRef.current = trimmed;
+      const step = seekStepFromTaps(trimmed.length);
+      onSeek(currentTimeRef.current + direction * step);
+      const multiplier: 1 | 3 | 6 = step === 60 ? 6 : step === 30 ? 3 : 1;
+      setSeekBadge({ dir: direction, multiplier });
+    },
+    [onSeek],
+  );
+
+  // Auto-clear the badge so a brief over-seek doesn't leave "▶▶ 6×" pinned.
+  // Uses TAP_WINDOW_MS + a 200ms grace so the badge outlives the rolling
+  // window the rate accelerator looks at.
+  useEffect(() => {
+    if (!seekBadge) return;
+    if (seekBadgeTimerRef.current) clearTimeout(seekBadgeTimerRef.current);
+    seekBadgeTimerRef.current = setTimeout(
+      () => setSeekBadge(null),
+      TAP_BADGE_FADE_MS,
+    );
+    return () => {
+      if (seekBadgeTimerRef.current) clearTimeout(seekBadgeTimerRef.current);
+    };
+  }, [seekBadge]);
 
   // Initial focus on Play/Pause when the player opens (spec §4.1).
   // Fire twice: once synchronously for the fast path, then again after a
@@ -546,8 +553,8 @@ export function PlayerControls({
   wakeRef.current = wake;
   const openMenuRef = useRef(openMenu);
   openMenuRef.current = openMenu;
-  const onSeekRef = useRef(onSeek);
-  onSeekRef.current = onSeek;
+  const seekWithRateRef = useRef(seekWithRate);
+  seekWithRateRef.current = seekWithRate;
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
   const onNextRef = useRef(onNext);
@@ -607,7 +614,7 @@ export function PlayerControls({
       const isRewindKey = k === "MediaRewind" || k === "j" || kc === 89;
       if (isRewindKey && !isLiveRef.current) {
         e.preventDefault();
-        onSeekRef.current(currentTimeRef.current - 10);
+        seekWithRateRef.current(-1);
         wakeRef.current();
         return;
       }
@@ -616,7 +623,7 @@ export function PlayerControls({
         k === "MediaFastForward" || k === "l" || kc === 90;
       if (isFfKey && !isLiveRef.current) {
         e.preventDefault();
-        onSeekRef.current(currentTimeRef.current + 10);
+        seekWithRateRef.current(1);
         wakeRef.current();
         return;
       }
@@ -661,57 +668,17 @@ export function PlayerControls({
       } else {
         if (isArrow || isEnter) wakeRef.current();
       }
-
-      // Arm arrow-hold acceleration when ArrowLeft/Right is pressed on a
-      // transport control (Play/Pause, ±10s buttons) on a seekable surface.
-      // The initial ±10s seek is still delivered by norigin's arrowOverrides
-      // on the focused button — this effect only adds the ticking interval
-      // that kicks in once the user has held the key past ARROW_HOLD_DELAY_MS.
-      if (
-        !isLiveRef.current &&
-        !openMenuRef.current &&
-        visibleRef.current &&
-        !e.repeat &&
-        (k === "ArrowLeft" || k === "ArrowRight") &&
-        arrowHoldKeyRef.current === null
-      ) {
-        const focusedKey = getCurrentFocusKey();
-        if (focusedKey && TRANSPORT_FOCUS_KEYS.has(focusedKey)) {
-          const direction = k === "ArrowLeft" ? -1 : 1;
-          arrowHoldKeyRef.current = k;
-          arrowHoldStartTimerRef.current = setTimeout(() => {
-            arrowHoldIntervalRef.current = setInterval(() => {
-              onSeekRef.current(
-                currentTimeRef.current + direction * HOLD_SEEK_STEP_S,
-              );
-              wakeRef.current();
-            }, HOLD_SEEK_TICK_MS);
-          }, ARROW_HOLD_DELAY_MS);
-        }
-      }
-    };
-
-    const onKeyUp = (e: KeyboardEvent) => {
-      if (
-        (e.key === "ArrowLeft" || e.key === "ArrowRight") &&
-        arrowHoldKeyRef.current !== null
-      ) {
-        clearArrowHold();
-      }
     };
 
     const onMouseMove = () => wakeRef.current();
 
     window.addEventListener("keydown", onKeyDown, true);
-    window.addEventListener("keyup", onKeyUp, true);
     window.addEventListener("mousemove", onMouseMove);
     return () => {
-      clearArrowHold();
       window.removeEventListener("keydown", onKeyDown, true);
-      window.removeEventListener("keyup", onKeyUp, true);
       window.removeEventListener("mousemove", onMouseMove);
     };
-  }, [clearArrowHold]);
+  }, []);
 
   const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
 
@@ -780,22 +747,8 @@ export function PlayerControls({
 
   // ── Control bar wire-up ────────────────────────────────────────────────────
 
-  const handleSeekBack = useCallback(
-    () => onSeek(currentTimeRef.current - 10),
-    [onSeek],
-  );
-  const handleSeekForward = useCallback(
-    () => onSeek(currentTimeRef.current + 10),
-    [onSeek],
-  );
-  const holdSeekBack = useCallback(
-    () => onSeek(currentTimeRef.current - HOLD_SEEK_STEP_S),
-    [onSeek],
-  );
-  const holdSeekForward = useCallback(
-    () => onSeek(currentTimeRef.current + HOLD_SEEK_STEP_S),
-    [onSeek],
-  );
+  const handleSeekBack = useCallback(() => seekWithRate(-1), [seekWithRate]);
+  const handleSeekForward = useCallback(() => seekWithRate(1), [seekWithRate]);
 
   const openAudio = useCallback(
     () => setOpenMenu((m) => (m === "audio" ? null : "audio")),
@@ -848,15 +801,16 @@ export function PlayerControls({
   const firstRightSideKey = orderedKeys.find((k) => RIGHT_SIDE_KEYS.includes(k));
 
   // 6d — prod feedback: users expect ArrowLeft/Right to seek (Netflix
-  // convention), not walk the bar. Applied to Play/Pause + ±10s buttons
-  // on VOD/series-episode. Live has no seekable window so arrows fall
-  // through to default nav.
+  // convention), not walk the bar. Both directions route through the
+  // tap-rate accelerator (spec §3.2) so rapid taps escalate from ±10s →
+  // ±30s → ±60s. Live has no seekable window so arrows fall through to
+  // default nav.
   const transportArrowOverrides: Partial<
     Record<"left" | "right" | "up" | "down", () => void>
   > = {};
   if (!isLive) {
-    transportArrowOverrides.left = () => onSeek(currentTimeRef.current - 10);
-    transportArrowOverrides.right = () => onSeek(currentTimeRef.current + 10);
+    transportArrowOverrides.left = () => seekWithRate(-1);
+    transportArrowOverrides.right = () => seekWithRate(1);
   }
   if (firstRightSideKey) {
     transportArrowOverrides.down = () => setFocus(firstRightSideKey);
@@ -1075,44 +1029,69 @@ export function PlayerControls({
           }}
         >
           {!isLive && (
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "var(--space-3)",
-                fontSize: "var(--text-label-size)",
-                color: "var(--text-secondary)",
-                fontVariantNumeric: "tabular-nums",
-              }}
-            >
-              <span>{formatTime(currentTime)}</span>
-              <div
-                role="progressbar"
-                aria-valuemin={0}
-                aria-valuemax={100}
-                aria-valuenow={Math.round(progress)}
-                aria-label="Video progress"
-                style={{
-                  flex: 1,
-                  height: "4px",
-                  background: "rgba(255,255,255,0.2)",
-                  borderRadius: "2px",
-                  position: "relative",
-                }}
-              >
+            <div style={{ position: "relative" }}>
+              {seekBadge && seekBadge.multiplier > 1 && (
                 <div
+                  data-testid="seek-rate-badge"
+                  aria-live="polite"
                   style={{
                     position: "absolute",
-                    left: 0,
-                    top: 0,
-                    height: "100%",
-                    width: `${progress}%`,
+                    bottom: "calc(100% + var(--space-2))",
+                    left: "50%",
+                    transform: "translateX(-50%)",
                     background: "var(--accent-copper)",
-                    borderRadius: "2px",
+                    color: "var(--bg-base)",
+                    padding: "var(--space-1) var(--space-3)",
+                    borderRadius: "var(--radius-sm)",
+                    fontSize: "var(--text-label-size)",
+                    fontWeight: 700,
+                    letterSpacing: "var(--text-label-tracking)",
+                    whiteSpace: "nowrap",
+                    pointerEvents: "none",
                   }}
-                />
+                >
+                  {seekBadge.dir > 0 ? "▶▶" : "◀◀"} {seekBadge.multiplier}×
+                </div>
+              )}
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "var(--space-3)",
+                  fontSize: "var(--text-label-size)",
+                  color: "var(--text-secondary)",
+                  fontVariantNumeric: "tabular-nums",
+                }}
+              >
+                <span>{formatTime(currentTime)}</span>
+                <div
+                  role="progressbar"
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-valuenow={Math.round(progress)}
+                  aria-label="Video progress"
+                  style={{
+                    flex: 1,
+                    height: "4px",
+                    background: "rgba(255,255,255,0.2)",
+                    borderRadius: "2px",
+                    position: "relative",
+                  }}
+                >
+                  <div
+                    style={{
+                      position: "absolute",
+                      left: 0,
+                      top: 0,
+                      height: "100%",
+                      width: `${progress}%`,
+                      background: "var(--accent-copper)",
+                      borderRadius: "2px",
+                    }}
+                  />
+                </div>
+                <span>{duration > 0 ? formatTime(duration) : "—"}</span>
               </div>
-              <span>{duration > 0 ? formatTime(duration) : "—"}</span>
             </div>
           )}
 
@@ -1140,7 +1119,6 @@ export function PlayerControls({
               icon="◀◀"
               focusable={seekable}
               onPress={handleSeekBack}
-              onHoldTick={holdSeekBack}
               isEdgeLeft={leftEdgeKey === FK.SEEK_BACK}
               isEdgeRight={rightEdgeKey === FK.SEEK_BACK}
               arrowOverrides={transportArrowOverrides}
@@ -1151,7 +1129,6 @@ export function PlayerControls({
               icon="▶▶"
               focusable={seekable}
               onPress={handleSeekForward}
-              onHoldTick={holdSeekForward}
               isEdgeLeft={leftEdgeKey === FK.SEEK_FORWARD}
               isEdgeRight={rightEdgeKey === FK.SEEK_FORWARD}
               arrowOverrides={transportArrowOverrides}


### PR DESCRIPTION
## Summary

Third attempt at FF after PRs #110 / #115. User report 2026-04-25:

> "I cannot go fast forward I have to do multiple clicks, click click click, for every 10 seconds."

Each remote button press = +10s seek; hold-to-accelerate never engages.

## What we kept missing

Silk on Fire TV emits held d-pad as **rapid keydown+keyup pairs**, NOT a sustained keydown. Every hold-timer model (armed on keydown, cleared on keyup) gets cancelled by the first auto-tap keyup before its delay can elapse. The user's *"click click click"* phrasing was the smoking gun — the remote IS auto-tapping for them, we just weren't making each tap count for more.

UX lead and UI lead both independently picked this approach: stop trying to detect "hold," measure tap-action frequency instead.

## New model (spec §3.2 rewritten)

| Taps in last 1s | Per-tap delta |
|---|---|
| 1–2 | ±10 s |
| 3–5 | ±30 s |
| 6+  | ±60 s |

- **Direction reset** (Right→Left or Left→Right) clears the window so an over-shoot doesn't snap back N×.
- **Copper "▶▶ 3×" / "◀◀ 6×" badge** appears above the scrubber when the multiplier is above 1× and fades 1.2 s after the last tap. The user *feels* the gear shift.
- **Single entry point** (`seekWithRate`) feeds: arrow-overrides on transport buttons, Enter on ◀◀/▶▶, Fire TV media Rewind/FastForward keys.
- Works identically whether Silk emits sustained keydown, auto-tap pairs, or `e.repeat=true` — only the *action count* matters.

## Code deletions

`arrowHoldKeyRef`, `arrowHoldStartTimerRef`, `arrowHoldIntervalRef`, `clearArrowHold`, `HOLD_SEEK_STEP_S`, `HOLD_SEEK_TICK_MS`, `ARROW_HOLD_DELAY_MS`, `TRANSPORT_FOCUS_KEYS`, `getCurrentFocusKey` import, `ControlButton.onHoldTick` + its hold ref + clearHold, window keyup listener, `holdSeekBack`/`holdSeekForward` callbacks, `pressedKeys.enter > 1` early-return.

## Test plan

- [x] 335/335 unit tests green (replaced 5 hold tests with 9 rate tests covering 1×/3×/6×, direction reset, idle reset, badge visibility, status-change robustness, Enter-on-button, Live no-op)
- [x] Typecheck clean
- [x] Bundle 309.71 KB gzip (no delta)
- [ ] Manual prod verification on Fire TV: tap ▶▶ rapidly on a movie, expect each tap +10s for 1–2 taps, then +30s as taps 3–5, then +60s at 6+. Stop tapping → next tap returns to +10s. Direction reset works. Badge appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)