### PR TITLE
fix(series): derive season rail from episodes when upstream omits seasons[]

### DIFF
--- a/docs/ux/02-series.md
+++ b/docs/ux/02-series.md
@@ -248,6 +248,8 @@ GET /api/series/info/:seriesId
 
 Backend already delivers this ([xtream.adapters.ts:89-137](../../streamvault-backend/src/providers/xtream/xtream.adapters.ts#L89)). Frontend only job: render it.
 
+Frontend tolerates empty `seasons[]` from upstream by deriving the season list from `episodes` keys (union with any provided `seasons[]` for name/icon enrichment).
+
 ### 6.3 Resume derivation
 
 Until `sv_watch_history.series_id` exists (issue #53):

--- a/src/features/series/deriveSortedSeasons.test.ts
+++ b/src/features/series/deriveSortedSeasons.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for `deriveSortedSeasons` — the union helper that powers the
+ * Series Detail season rail.
+ *
+ * Background: some Xtream upstreams return `seasons: []` while still
+ * populating `episodes: { "1": [...], "2": [...] }`. Pre-fix, the rail and
+ * the episode-header row both vanished because they were gated on
+ * `info.seasons.length > 0`. Post-fix, the rail is derived from the union
+ * of `Object.keys(info.episodes)` and `info.seasons[].seasonNumber`, with
+ * `info.seasons[i]` left-joined for `name` / `icon` enrichment.
+ */
+import { describe, it, expect } from "vitest";
+import { deriveSortedSeasons } from "./deriveSortedSeasons";
+import type { SeriesInfo, EpisodeInfo } from "../../api/schemas";
+
+function ep(id: string, episodeNumber: number): EpisodeInfo {
+  return { id, episodeNumber, title: `Ep ${episodeNumber}` };
+}
+
+function makeInfo(
+  partial: Pick<SeriesInfo, "seasons" | "episodes">,
+): SeriesInfo {
+  return {
+    id: "s1",
+    name: "Test Series",
+    categoryId: "0",
+    seasons: partial.seasons,
+    episodes: partial.episodes,
+  } as SeriesInfo;
+}
+
+describe("deriveSortedSeasons", () => {
+  it("returns [] when info is null", () => {
+    expect(deriveSortedSeasons(null)).toEqual([]);
+  });
+
+  it("derives seasons from episodes keys when upstream seasons[] is empty", () => {
+    const info = makeInfo({
+      seasons: [],
+      episodes: {
+        "1": [ep("e1", 1), ep("e2", 2)],
+        "2": [ep("e3", 1)],
+      },
+    });
+
+    const result = deriveSortedSeasons(info);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      seasonNumber: 1,
+      name: "",
+      episodeCount: 2,
+    });
+    expect(result[1]).toMatchObject({
+      seasonNumber: 2,
+      name: "",
+      episodeCount: 1,
+    });
+  });
+
+  it("enriches with provided seasons[] entry when present and synthesizes the rest", () => {
+    const info = makeInfo({
+      seasons: [
+        { seasonNumber: 1, name: "Season 1", episodeCount: 0, icon: "s1.jpg" },
+      ],
+      episodes: {
+        "1": [ep("e1", 1)],
+        "2": [ep("e2", 1), ep("e3", 2)],
+      },
+    });
+
+    const result = deriveSortedSeasons(info);
+
+    expect(result).toHaveLength(2);
+    // Season 1: enriched (keeps name + icon, episodeCount overridden by
+    // actual episodes-map length).
+    expect(result[0]).toMatchObject({
+      seasonNumber: 1,
+      name: "Season 1",
+      icon: "s1.jpg",
+      episodeCount: 1,
+    });
+    // Season 2: synthesized (empty name, episodeCount from episodes map).
+    expect(result[1]).toMatchObject({
+      seasonNumber: 2,
+      name: "",
+      episodeCount: 2,
+    });
+  });
+
+  it("passes through the normal full-data case unchanged in count + ordering", () => {
+    const info = makeInfo({
+      seasons: [
+        { seasonNumber: 1, name: "Season 1", episodeCount: 2 },
+        { seasonNumber: 2, name: "Season 2", episodeCount: 1 },
+      ],
+      episodes: {
+        "1": [ep("e1", 1), ep("e2", 2)],
+        "2": [ep("e3", 1)],
+      },
+    });
+
+    const result = deriveSortedSeasons(info);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((s) => s.seasonNumber)).toEqual([1, 2]);
+    expect(result[0]?.name).toBe("Season 1");
+    expect(result[1]?.name).toBe("Season 2");
+  });
+
+  it("includes a season provided in seasons[] even when episodes is missing the key", () => {
+    // Degenerate but correct: spec calls out that a seasons[] entry without
+    // episodes should still surface (so the user sees the empty-season UI
+    // rather than silently dropping it).
+    const info = makeInfo({
+      seasons: [{ seasonNumber: 3, name: "Season 3", episodeCount: 0 }],
+      episodes: {
+        "1": [ep("e1", 1)],
+      },
+    });
+
+    const result = deriveSortedSeasons(info);
+
+    expect(result.map((s) => s.seasonNumber)).toEqual([1, 3]);
+    expect(result.find((s) => s.seasonNumber === 3)).toMatchObject({
+      name: "Season 3",
+      episodeCount: 0,
+    });
+  });
+
+  it("sorts Specials (season 0) last via existing sortSeasons", () => {
+    const info = makeInfo({
+      seasons: [],
+      episodes: {
+        "0": [ep("sp1", 1)],
+        "1": [ep("e1", 1)],
+        "2": [ep("e2", 1)],
+      },
+    });
+
+    const result = deriveSortedSeasons(info);
+
+    expect(result.map((s) => s.seasonNumber)).toEqual([1, 2, 0]);
+  });
+
+  it("ignores episodes-map keys that don't parse to a finite number", () => {
+    const info = makeInfo({
+      seasons: [],
+      episodes: {
+        "1": [ep("e1", 1)],
+        garbage: [ep("eX", 1)],
+      } as unknown as SeriesInfo["episodes"],
+    });
+
+    const result = deriveSortedSeasons(info);
+
+    expect(result.map((s) => s.seasonNumber)).toEqual([1]);
+  });
+});

--- a/src/features/series/deriveSortedSeasons.ts
+++ b/src/features/series/deriveSortedSeasons.ts
@@ -1,0 +1,68 @@
+/**
+ * deriveSortedSeasons — union helper for the Series Detail season rail.
+ *
+ * Background: some Xtream upstreams return `seasons: []` while still
+ * populating `episodes: { "1": [...], "2": [...] }`. Pre-fix, the rail
+ * and the episode-header row both vanished because they were gated on
+ * `info.seasons.length > 0`.
+ *
+ * Source-of-truth for *which* seasons exist is `Object.keys(info.episodes)`.
+ * For each unique season number we left-join `info.seasons[i]` to enrich
+ * with `name` / `icon`. When absent we synthesize a SeasonInfo with an
+ * empty `name` (so `seasonLabel()` falls through to "Season N") and a
+ * computed `episodeCount` from `info.episodes[String(sn)]?.length`.
+ *
+ * Spec: docs/ux/02-series.md §6.2.
+ */
+import type { SeriesInfo, SeasonInfo } from "../../api/schemas";
+
+export function sortSeasons(seasons: SeasonInfo[]): SeasonInfo[] {
+  return [...seasons].sort((a, b) => {
+    if (a.seasonNumber === 0) return 1;
+    if (b.seasonNumber === 0) return -1;
+    return a.seasonNumber - b.seasonNumber;
+  });
+}
+
+export function deriveSortedSeasons(info: SeriesInfo | null): SeasonInfo[] {
+  if (!info) return [];
+
+  const episodesMap = info.episodes ?? {};
+  const providedSeasons = info.seasons ?? [];
+
+  const byNumber = new Map<number, SeasonInfo>();
+  for (const s of providedSeasons) {
+    byNumber.set(s.seasonNumber, s);
+  }
+
+  const seasonNumbers = new Set<number>();
+  for (const key of Object.keys(episodesMap)) {
+    const n = Number(key);
+    if (Number.isFinite(n)) seasonNumbers.add(n);
+  }
+  for (const s of providedSeasons) {
+    seasonNumbers.add(s.seasonNumber);
+  }
+
+  const merged: SeasonInfo[] = [];
+  for (const sn of seasonNumbers) {
+    const provided = byNumber.get(sn);
+    const epCount = episodesMap[String(sn)]?.length ?? 0;
+    if (provided) {
+      // Trust provided name/icon; prefer episodesMap length when available
+      // (upstream `episodeCount` sometimes lies / is stale).
+      merged.push({
+        ...provided,
+        episodeCount: epCount > 0 ? epCount : provided.episodeCount,
+      });
+    } else {
+      merged.push({
+        seasonNumber: sn,
+        name: "",
+        episodeCount: epCount,
+      });
+    }
+  }
+
+  return sortSeasons(merged);
+}

--- a/src/routes/SeriesDetailRoute.tsx
+++ b/src/routes/SeriesDetailRoute.tsx
@@ -43,6 +43,7 @@ import {
 } from "../api/favorites";
 import { usePlayerOpener } from "../player/usePlayerOpener";
 import { usePlayerStore } from "../player/PlayerProvider";
+import { deriveSortedSeasons } from "../features/series/deriveSortedSeasons";
 import type {
   SeriesInfo,
   EpisodeInfo,
@@ -76,13 +77,9 @@ function formatProgress(progress: number, duration: number): string {
   return `${formatDuration(progress)} / ${formatDuration(duration)}`;
 }
 
-function sortSeasons(seasons: SeasonInfo[]): SeasonInfo[] {
-  return [...seasons].sort((a, b) => {
-    if (a.seasonNumber === 0) return 1;
-    if (b.seasonNumber === 0) return -1;
-    return a.seasonNumber - b.seasonNumber;
-  });
-}
+// Season rail derivation (union of `info.episodes` keys + `info.seasons[]`)
+// lives in `features/series/deriveSortedSeasons.ts` so it can be unit-tested
+// and re-used outside this large component file.
 
 function seasonLabel(s: SeasonInfo): string {
   if (s.seasonNumber === 0) return "Specials";
@@ -770,7 +767,10 @@ export function SeriesDetailRoute() {
         setHistory(hist);
 
         // Seed active season: stored pref → in-progress season → first sorted.
-        const sorted = sortSeasons(seriesInfo.seasons ?? []);
+        // Use the union helper (not raw `seriesInfo.seasons`) so we still
+        // seed correctly when upstream returns `seasons: []` but populates
+        // `episodes` — see deriveSortedSeasons() docstring.
+        const sorted = deriveSortedSeasons(seriesInfo);
         const defaultSeason = sorted[0]?.seasonNumber ?? 1;
         const stored = readLastSeason(seriesId);
         if (
@@ -824,10 +824,9 @@ export function SeriesDetailRoute() {
   }, [seriesId, historyGeneration]);
 
   // ─── Derived ────────────────────────────────────────────────────────────
-  const sortedSeasons = useMemo(
-    () => sortSeasons(info?.seasons ?? []),
-    [info],
-  );
+  // Union of `info.episodes` keys and `info.seasons[]` — see
+  // deriveSortedSeasons() at module scope.
+  const sortedSeasons = useMemo(() => deriveSortedSeasons(info), [info]);
 
   const allEpisodes = useMemo<{ season: number; ep: EpisodeInfo }[]>(() => {
     if (!info?.episodes) return [];


### PR DESCRIPTION
## Summary
- **Bug:** Series Detail page hides the Season rail and episode header row when the upstream Xtream API returns `seasons: []` but `episodes` is populated (a documented, common upstream shape). User saw a flat episode list with no way to switch seasons.
- **Fix (Option C, union):** Source-of-truth for which seasons exist is `Object.keys(info.episodes)`. Left-join `info.seasons[i]` to enrich with `name` / `icon` when provided; synthesize a `SeasonInfo` (`name: ""` so `seasonLabel()` falls through to "Season N") otherwise. Provided seasons without matching episodes still surface (degenerate but correct).
- Helper extracted to `src/features/series/deriveSortedSeasons.ts` (kept route file fast-refresh-clean) and used by both the season-seeding effect and the `sortedSeasons` useMemo.
- Spec note added under §6.2 in `docs/ux/02-series.md`.

## Files changed
- `src/features/series/deriveSortedSeasons.ts` (new)
- `src/features/series/deriveSortedSeasons.test.ts` (new, 7 cases)
- `src/routes/SeriesDetailRoute.tsx`
- `docs/ux/02-series.md`

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 342 passed (335 → 342, +7 union-helper cases)
- [x] `npm run build` (tsc -b + vite build) green
- [ ] Prod smoke: open a Series whose upstream returns `seasons: []` + populated `episodes`. Confirm Season tabs render labeled `Season 1` / `Season 2` etc. and the active-season indicator works.
- [ ] Prod smoke: open a Series with full normal data. Confirm no regression in tab labels, ordering, or Specials placement.

## Render-gate behavior (unchanged)
- `sortedSeasons.length > 0` gates at lines 1303 / 1329 just-work — `sortedSeasons` is non-empty whenever episodes exist.
- `seasonLabel()` and `sortSeasons()` (specials handling) are untouched.
- Header season-count display (`{sortedSeasons.length} Season(s)`) now correctly reflects the actual number of seasons present in either source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)