### PR TITLE
fix(player): show "Channel offline" overlay for live HTTP 503

### DIFF
--- a/src/player/PlayerShell.tsx
+++ b/src/player/PlayerShell.tsx
@@ -18,10 +18,10 @@ import {
   setFocus,
 } from "@noriginmedia/norigin-spatial-navigation";
 import { usePlayerStore } from "./PlayerProvider";
-import type { PlayerKind } from "./PlayerProvider";
 import { useHlsPlayer } from "./useHlsPlayer";
 import { PlayerControls } from "./PlayerControls";
 import { useReducedMotion } from "./useReducedMotion";
+import { classifyFailure, type FailureClass } from "./classifyFailure";
 import { markTierLocked } from "../features/movies/tierLockCache";
 import { recordHistory } from "../api/history";
 import { getLangPref } from "../lib/langPref";
@@ -30,26 +30,6 @@ import { pickAudioTrackForLang } from "../lib/inferLanguage";
 // Failure-overlay focus keys — kept local, only the overlay reads them.
 const FK_RETRY = "PLAYER_FAIL_RETRY";
 const FK_BACK = "PLAYER_FAIL_BACK";
-
-/**
- * Classify a playback error so the overlay can render the right copy and
- * decide whether to memo a tier-lock hit (spec §9.2 / §9.3).
- *
- * Heuristic: VOD/series-episode that errors with zero duration + zero
- * playhead — before any frame ever arrived — is almost always the Xtream
- * account plan refusing the container extension. Live errors are treated
- * as generic (tier-lock doesn't apply to Live channels).
- */
-function classifyFailure(
-  kind: PlayerKind,
-  duration: number,
-  currentTime: number,
-): "tier-lock" | "generic" {
-  if (kind !== "live" && duration === 0 && currentTime === 0) {
-    return "tier-lock";
-  }
-  return "generic";
-}
 
 export function PlayerShell() {
   const { state, close } = usePlayerStore();
@@ -65,6 +45,7 @@ export function PlayerShell() {
 
   const {
     status,
+    error,
     duration,
     currentTime,
     levels,
@@ -165,7 +146,9 @@ export function PlayerShell() {
   );
 
   const failureClass =
-    status === "error" ? classifyFailure(kind, duration, currentTime) : null;
+    status === "error"
+      ? classifyFailure(kind, duration, currentTime, error?.message)
+      : null;
 
   // Memo the tier-lock so MovieCard/EpisodeRow can badge the card on return.
   useEffect(() => {
@@ -275,7 +258,7 @@ export function PlayerShell() {
 
         {showFailure && (
           <FailureOverlay
-            kind={failureClass === "tier-lock" ? "tier-lock" : "generic"}
+            kind={failureClass ?? "generic"}
             onRetry={retry}
             onClose={close}
           />
@@ -325,7 +308,7 @@ export function PlayerShell() {
 // ─── FailureOverlay ──────────────────────────────────────────────────────────
 
 interface FailureOverlayProps {
-  kind: "tier-lock" | "generic";
+  kind: FailureClass;
   onRetry: () => void;
   onClose: () => void;
 }
@@ -333,15 +316,18 @@ interface FailureOverlayProps {
 /**
  * Amber glass overlay per spec §9. Never red, never auto-retry.
  *
- *   tier-lock → specific "format not supported by plan" copy, no Try again
- *   generic   → Try again + Back to browse
+ *   tier-lock     → "format not supported by plan", no Try again button
+ *   live-offline  → "Channel offline", Try again still available (provider
+ *                   may come back; user can retry)
+ *   generic       → Try again + Back to browse
  *
  * Focus: auto-seeds on the most-useful action for the class.
  */
 function FailureOverlay({ kind, onRetry, onClose }: FailureOverlayProps) {
+  const showRetry = kind !== "tier-lock";
   const { ref: retryRef, focused: retryFocused } = useFocusable({
     focusKey: FK_RETRY,
-    focusable: kind !== "tier-lock",
+    focusable: showRetry,
     onEnterPress: onRetry,
     onArrowPress: (direction) => {
       if (direction === "right") {
@@ -356,7 +342,7 @@ function FailureOverlay({ kind, onRetry, onClose }: FailureOverlayProps) {
     focusKey: FK_BACK,
     onEnterPress: onClose,
     onArrowPress: (direction) => {
-      if (direction === "left" && kind !== "tier-lock") {
+      if (direction === "left" && showRetry) {
         setFocus(FK_RETRY);
         return false;
       }
@@ -415,7 +401,7 @@ function FailureOverlay({ kind, onRetry, onClose }: FailureOverlayProps) {
       >
         <span style={{ fontSize: "32px" }} aria-hidden="true">⚠</span>
         <p style={{ fontSize: "var(--text-title-size)", fontWeight: 600, margin: 0 }}>
-          Playback failed
+          {kind === "live-offline" ? "Channel offline" : "Playback failed"}
         </p>
         <p
           style={{
@@ -427,6 +413,8 @@ function FailureOverlay({ kind, onRetry, onClose }: FailureOverlayProps) {
         >
           {kind === "tier-lock"
             ? "This title is delivered in a format your Xtream plan doesn't support. Try a different title or see if a similar one is available."
+            : kind === "live-offline"
+            ? "This channel is offline upstream right now. Try a different channel, or hit Try again in a moment."
             : "This title couldn't be played right now. It may be a format your plan doesn't support, or the provider is temporarily unavailable."}
         </p>
         <div

--- a/src/player/classifyFailure.test.ts
+++ b/src/player/classifyFailure.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { classifyFailure } from "./classifyFailure";
+
+describe("classifyFailure", () => {
+  it("flags VOD with zero duration + zero playhead as tier-lock", () => {
+    expect(classifyFailure("vod", 0, 0, "MEDIA_ERR_DECODE")).toBe("tier-lock");
+  });
+
+  it("does not flag VOD as tier-lock once duration loaded", () => {
+    expect(classifyFailure("vod", 120, 0, "any")).toBe("generic");
+  });
+
+  it("flags live HTTP 503 as live-offline", () => {
+    expect(
+      classifyFailure(
+        "live",
+        0,
+        0,
+        "NetworkError: Unrecoverable HTTP code: 503",
+      ),
+    ).toBe("live-offline");
+  });
+
+  it("falls back to generic for live without 503 in message", () => {
+    expect(classifyFailure("live", 0, 0, "NetworkError")).toBe("generic");
+  });
+
+  it("does not match '503' as a substring (e.g. inside another number)", () => {
+    expect(classifyFailure("live", 0, 0, "code 5031")).toBe("generic");
+  });
+
+  it("returns generic when error message is undefined", () => {
+    expect(classifyFailure("live", 0, 0, undefined)).toBe("generic");
+  });
+});

--- a/src/player/classifyFailure.ts
+++ b/src/player/classifyFailure.ts
@@ -1,0 +1,33 @@
+import type { PlayerKind } from "./PlayerProvider";
+
+/**
+ * Classify a playback error so the failure overlay can render the right copy
+ * and decide whether to memo a tier-lock hit (spec §9.2 / §9.3).
+ *
+ * Heuristics:
+ *  - VOD/series-episode that errors with zero duration + zero playhead, before
+ *    any frame ever arrived, is almost always the Xtream account plan refusing
+ *    the container extension → "tier-lock".
+ *  - Live channels: backend returns HTTP 503 + X-Stream-Status: offline when
+ *    the upstream provider redirects to its "channel offline" placeholder
+ *    (a 6 MB looped MPEG-TS splash). mpegts.js surfaces that as an error
+ *    string containing "503" — match on it so the overlay can say
+ *    "Channel offline" instead of generic "couldn't be played right now".
+ *  - Everything else → "generic".
+ */
+export type FailureClass = "tier-lock" | "live-offline" | "generic";
+
+export function classifyFailure(
+  kind: PlayerKind,
+  duration: number,
+  currentTime: number,
+  errorMessage: string | undefined,
+): FailureClass {
+  if (kind !== "live" && duration === 0 && currentTime === 0) {
+    return "tier-lock";
+  }
+  if (kind === "live" && errorMessage && /\b503\b/.test(errorMessage)) {
+    return "live-offline";
+  }
+  return "generic";
+}


### PR DESCRIPTION
## Summary

- Pairs with [streamvault-backend #48](https://github.com/srinivas-kotha/streamvault-backend/pull/48). Backend now returns **HTTP 503 + `X-Stream-Status: offline`** when Xtream redirects a live channel to its 6 MB MPEG-TS \"FFmpeg Service\" splash. Without the frontend half, the player would just sit on a generic \"Playback failed\" overlay.
- New `classifyFailure` branch detects live + error message containing \"503\" → \"live-offline\" class.
- FailureOverlay copy: **\"Channel offline\"** title + body asking to try a different channel or retry. Try again button stays (provider may come back).
- `classifyFailure` moved to its own module — react-refresh lint disallows mixing component + helper exports from the same file.

## Why this matters

User reported \"most live channels not working — each channel has different output type from backend.\" Investigation showed ~30% of sampled live channels (Telugu / Hindi / English / Sports / News / Kids) hit the upstream offline placeholder. The placeholder bytes are valid MPEG-TS, so the player wasn't erroring — it was happily playing 6 MB of \"FFmpeg Service\" splash and then silently stalling. With the backend 503 + this overlay, users now see a clear \"Channel offline\" message immediately.

## Test plan

- [x] \`npx vitest run src/player\` — 54 tests pass (was 48, +6 new in `classifyFailure.test.ts`)
- [x] \`npx vitest run\` — full suite 348 pass
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` clean
- [ ] Post-merge: with backend #48 deployed, open a known-offline channel → confirm \"Channel offline\" overlay (not \"Playback failed\")
- [ ] Post-merge: open a known-working channel → confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)