### PR TITLE
feat(search): LanguageRail filter on results (spec §5)

### DIFF
--- a/src/routes/SearchRoute.test.tsx
+++ b/src/routes/SearchRoute.test.tsx
@@ -115,6 +115,10 @@ describe("SearchRoute", () => {
     useFocusableSpy.mockClear();
     fetchSearchMock.mockReset();
     navigateMock.mockReset();
+    // Default lang pref is "telugu"; pin to "all" so the existing
+    // result-render tests don't get filtered out by the LanguageRail.
+    // Per-test cases override this localStorage key as needed.
+    window.localStorage.setItem("sv_lang_pref", "all");
   });
 
   it("registers CONTENT_AREA_SEARCH and SEARCH_INPUT with useFocusable", () => {
@@ -268,5 +272,141 @@ describe("SearchRoute", () => {
     expect(keys).toContain("SEARCH_RESULT_LIVE_l1");
     expect(keys).toContain("SEARCH_RESULT_VOD_v1");
     expect(keys).toContain("SEARCH_RESULT_SERIES_s1");
+  });
+
+  // ─── LanguageRail (PR — Search §5) ────────────────────────────────────────
+
+  describe("LanguageRail", () => {
+    const langTaggedResults: SearchResults = {
+      live: [
+        {
+          id: "l1",
+          name: "CNN Live",
+          type: "live",
+          categoryId: "news",
+          icon: null,
+          added: null,
+          isAdult: false,
+          inferredLang: "english",
+        },
+      ],
+      vod: [
+        {
+          id: "v1",
+          name: "Inception",
+          type: "vod",
+          categoryId: "movies",
+          icon: null,
+          added: null,
+          isAdult: false,
+          inferredLang: "english",
+        },
+        {
+          id: "v2",
+          name: "Vikram",
+          type: "vod",
+          categoryId: "telugu-movies",
+          icon: null,
+          added: null,
+          isAdult: false,
+          inferredLang: "telugu",
+        },
+      ],
+      series: [
+        {
+          id: "s1",
+          name: "Breaking Bad",
+          type: "series",
+          categoryId: "drama",
+          icon: null,
+          added: null,
+          isAdult: false,
+          inferredLang: "english",
+        },
+      ],
+    };
+
+    it("renders LANG_TELUGU/HINDI/ENGLISH/ALL chip focus keys after results land", async () => {
+      fetchSearchMock.mockResolvedValue(langTaggedResults);
+      render(<SearchRoute />);
+      const input = screen.getByRole("searchbox");
+      await user.type(input, "vk");
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Inception" })).toBeInTheDocument();
+      });
+
+      const keys = useFocusableSpy.mock.calls
+        .map((call) => call[0]?.focusKey)
+        .filter(Boolean);
+      expect(keys).toContain("LANG_TELUGU");
+      expect(keys).toContain("LANG_HINDI");
+      expect(keys).toContain("LANG_ENGLISH");
+      expect(keys).toContain("LANG_ALL");
+    });
+
+    it("does NOT render the rail before any results have landed", () => {
+      fetchSearchMock.mockResolvedValue(emptyResults);
+      render(<SearchRoute />);
+
+      const keys = useFocusableSpy.mock.calls
+        .map((call) => call[0]?.focusKey)
+        .filter(Boolean);
+      expect(keys).not.toContain("LANG_TELUGU");
+    });
+
+    it("filters result cards by inferredLang when a language is active", async () => {
+      // Persist Telugu pref before mount so the rail starts there.
+      window.localStorage.setItem("sv_lang_pref", "telugu");
+      fetchSearchMock.mockResolvedValue(langTaggedResults);
+      render(<SearchRoute />);
+      const input = screen.getByRole("searchbox");
+      await user.type(input, "vk");
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Vikram" })).toBeInTheDocument();
+      });
+
+      // Telugu items present, English items hidden.
+      expect(screen.queryByRole("button", { name: "Inception" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "CNN Live" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Breaking Bad" })).not.toBeInTheDocument();
+    });
+
+    it("renders the lang-zero empty state with a Show all button when filter hides every hit", async () => {
+      window.localStorage.setItem("sv_lang_pref", "hindi");
+      fetchSearchMock.mockResolvedValue(langTaggedResults);
+      render(<SearchRoute />);
+      const input = screen.getByRole("searchbox");
+      await user.type(input, "vk");
+
+      await waitFor(() => {
+        expect(screen.getByText(/No Hindi results for/i)).toBeInTheDocument();
+      });
+      expect(
+        screen.getByRole("button", { name: /Show all 4 results/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("Show all button switches lang back to All and re-reveals results", async () => {
+      window.localStorage.setItem("sv_lang_pref", "hindi");
+      fetchSearchMock.mockResolvedValue(langTaggedResults);
+      render(<SearchRoute />);
+      const input = screen.getByRole("searchbox");
+      await user.type(input, "vk");
+
+      await waitFor(() => {
+        expect(screen.getByText(/No Hindi results for/i)).toBeInTheDocument();
+      });
+
+      const showAll = screen.getByRole("button", { name: /Show all 4 results/i });
+      await user.click(showAll);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Inception" })).toBeInTheDocument();
+      });
+      expect(screen.getByRole("button", { name: "Vikram" })).toBeInTheDocument();
+      expect(screen.queryByText(/No Hindi results for/i)).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/routes/SearchRoute.tsx
+++ b/src/routes/SearchRoute.tsx
@@ -33,12 +33,15 @@ import {
 } from "@noriginmedia/norigin-spatial-navigation";
 import { Skeleton } from "../primitives/Skeleton";
 import { fetchSearch } from "../api/search";
-import type { SearchResults } from "../api/schemas";
+import type { CatalogItem, SearchResults } from "../api/schemas";
 import { SearchInput } from "../features/search/SearchInput";
 import { SearchResultsSection } from "../features/search/SearchResultsSection";
 import { SearchKindChips, type SearchKind } from "../features/search/SearchKindChips";
 import { useDebounce } from "../features/search/useDebounce";
 import { consumeOriginator } from "../nav/backStack";
+import { LanguageRail } from "../components/LanguageRail";
+import { useLangPref } from "../lib/useLangPref";
+import type { LangId } from "../lib/langPref";
 import { logEvent } from "../telemetry";
 
 // ─── useSearchQuery — encapsulates fetch + state management ─────────────────
@@ -137,10 +140,40 @@ export function SearchRoute() {
 
   const [query, setQuery] = useState(initialQuery);
   const [kind, setKind] = useState<SearchKind>("all");
+  const [lang, setLang] = useLangPref({ excludeSports: true });
   const debouncedQuery = useDebounce(query, 250);
 
   const { results, loading, error, lastSearchedQuery, clearResults, runSearch } =
     useSearchQuery(debouncedQuery);
+
+  // Apply the current language filter to each bucket. When `lang === "all"`,
+  // no filtering — return the raw results. When a specific language is
+  // active, include only items whose server-annotated `inferredLang` matches.
+  // Items with `inferredLang === null/undefined` (e.g. multi-language OTT
+  // categories) are excluded from any specific language and surface only
+  // under "All" — same safe-degradation behavior as Live/Movies/Series.
+  const filteredResults = useMemo<SearchResults | null>(() => {
+    if (results === null) return null;
+    if (lang === "all") return results;
+    const filterByLang = (items: CatalogItem[]): CatalogItem[] =>
+      items.filter((it) => it.inferredLang === lang);
+    return {
+      live: filterByLang(results.live),
+      vod: filterByLang(results.vod),
+      series: filterByLang(results.series),
+    };
+  }, [results, lang]);
+
+  const totalRawHits =
+    results === null
+      ? 0
+      : results.live.length + results.vod.length + results.series.length;
+  const totalFilteredHits =
+    filteredResults === null
+      ? 0
+      : filteredResults.live.length +
+        filteredResults.vod.length +
+        filteredResults.series.length;
 
   const handleQueryChange = useCallback(
     (value: string) => {
@@ -155,6 +188,36 @@ export function SearchRoute() {
   const handleSubmit = useCallback(() => {
     runSearch(query);
   }, [query, runSearch]);
+
+  const handleLangChange = useCallback(
+    (next: LangId) => {
+      setLang(next);
+      logEvent("search_lang_filter_change", {
+        lang: next,
+        query: lastSearchedQuery,
+        total_hits: totalRawHits,
+      });
+    },
+    [setLang, lastSearchedQuery, totalRawHits],
+  );
+
+  // Fire `search_results_lang_zero` exactly when the active filter has
+  // hidden every hit. Guarded so it only fires on transition into zero,
+  // not on every render of the same zero state.
+  useEffect(() => {
+    if (
+      lang !== "all" &&
+      results !== null &&
+      totalRawHits > 0 &&
+      totalFilteredHits === 0
+    ) {
+      logEvent("search_results_lang_zero", {
+        lang,
+        query: lastSearchedQuery,
+        total_hits: totalRawHits,
+      });
+    }
+  }, [lang, results, totalRawHits, totalFilteredHits, lastSearchedQuery]);
 
   useEffect(() => {
     // If the user is returning from a detail route they opened from a
@@ -173,11 +236,8 @@ export function SearchRoute() {
     setFocus("SEARCH_INPUT");
   }, []);
 
-  const hasResults =
-    results !== null &&
-    (results.live.length > 0 ||
-      results.vod.length > 0 ||
-      results.series.length > 0);
+  const hasResults = results !== null && totalRawHits > 0;
+  const hasFilteredResults = filteredResults !== null && totalFilteredHits > 0;
 
   const showHelp = query.length > 0 && query.length < 2;
   const showEmpty =
@@ -187,9 +247,31 @@ export function SearchRoute() {
     !hasResults &&
     lastSearchedQuery.length >= 2;
 
+  const showLangZeroEmpty =
+    !loading &&
+    !error &&
+    hasResults &&
+    !hasFilteredResults &&
+    lang !== "all";
+
   const showMovies = kind === "all" || kind === "vod";
   const showSeries = kind === "all" || kind === "series";
   const showLive = kind === "all" || kind === "live";
+
+  const handleShowAllLanguages = useCallback(() => {
+    handleLangChange("all");
+  }, [handleLangChange]);
+
+  const langLabel =
+    lang === "telugu"
+      ? "Telugu"
+      : lang === "hindi"
+        ? "Hindi"
+        : lang === "english"
+          ? "English"
+          : lang === "sports"
+            ? "Sports"
+            : "";
 
   return (
     <FocusContext.Provider value={focusKey}>
@@ -231,6 +313,10 @@ export function SearchRoute() {
               library, use FIND on Movies or Series instead.
             </p>
           </div>
+        )}
+
+        {hasResults && !loading && !error && (
+          <LanguageRail value={lang} onChange={handleLangChange} />
         )}
 
         {hasResults && !loading && !error && (
@@ -284,16 +370,45 @@ export function SearchRoute() {
           </p>
         )}
 
-        {!loading && hasResults && results !== null && (
+        {showLangZeroEmpty && (
+          <p
+            role="status"
+            style={{
+              color: "var(--text-secondary)",
+              fontSize: "var(--text-body-size)",
+              padding: "var(--space-4) var(--space-6)",
+            }}
+          >
+            No {langLabel} results for &ldquo;{lastSearchedQuery}&rdquo;.{" "}
+            <button
+              type="button"
+              onClick={handleShowAllLanguages}
+              style={{
+                background: "transparent",
+                border: "none",
+                color: "var(--accent-copper)",
+                cursor: "pointer",
+                font: "inherit",
+                padding: 0,
+                textDecoration: "underline",
+              }}
+            >
+              Show all {totalRawHits} result{totalRawHits === 1 ? "" : "s"}
+            </button>
+            .
+          </p>
+        )}
+
+        {!loading && hasFilteredResults && filteredResults !== null && (
           <div>
             {showMovies && (
-              <SearchResultsSection title="Movies" items={results.vod} />
+              <SearchResultsSection title="Movies" items={filteredResults.vod} />
             )}
             {showSeries && (
-              <SearchResultsSection title="Series" items={results.series} />
+              <SearchResultsSection title="Series" items={filteredResults.series} />
             )}
             {showLive && (
-              <SearchResultsSection title="Live" items={results.live} />
+              <SearchResultsSection title="Live" items={filteredResults.live} />
             )}
           </div>
         )}

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -12,7 +12,9 @@
 export type TelemetryEventName =
   | "back_pressed"
   | "nav_originator_restored"
-  | "dock_navigated";
+  | "dock_navigated"
+  | "search_lang_filter_change"
+  | "search_results_lang_zero";
 
 export interface TelemetryEventProps {
   [key: string]: string | number | boolean | null | undefined;


### PR DESCRIPTION
## Summary
- Mounts the global LanguageRail on `/search` between input and kind chips, visible only after results land.
- Filters the in-memory result set by server-annotated `inferredLang` (unblocked by backend PR #51).
- Empty-state for "no results match selected language" with inline "Show all" reset.
- Telemetry: `search_lang_filter_change` + `search_results_lang_zero`.

## Why
The 4 surfaces that already use `sv_lang_pref` (Live, Movies, Series — and now Search) finally agree. Pick Telugu anywhere → applies everywhere. Closes spec §5 from `docs/ux/04-search-and-language-rail.md`.

## Backend dependency
This relies on backend PR #51 (`feat(search): annotate inferredLang on FTS hits`). When the backend ships, search results carry `inferredLang` and the filter activates.

Today (before PR #51): `inferredLang` is undefined on every search hit → only "All" surfaces results, every other chip shows the lang-zero empty state. Acceptable forward-compat — UX still works, just more aggressively empty until BE catches up.

## Test plan
- [x] `npm test src/routes/SearchRoute.test.tsx` — 17/17 (12 existing + 5 new)
- [x] `npm test` — full suite: 353/353 pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [ ] After BE PR #51 ships: prod smoke — search "vikram", confirm Telugu chip surfaces Telugu hits and English/Hindi chips filter them out
- [ ] D-pad: input → ArrowDown → Telugu chip; Telugu chip → ArrowDown → first result card
- [ ] Lang-zero state → Tab/D-pad to Show-all button → activate → results re-appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)