### PR TITLE
feat(favorites): bulk delete-all with confirm modal + undo toast

### DIFF
--- a/src/api/favorites.ts
+++ b/src/api/favorites.ts
@@ -147,3 +147,42 @@ export function isFavorited(
     (f) => f.content_type === contentType && f.content_id === contentId,
   );
 }
+
+/**
+ * Delete every favorite. Returns the pre-clear snapshot so the caller can
+ * pass it to `restoreAllFavorites()` if the user undoes within the toast
+ * window. localStorage is cleared synchronously; per-item DELETEs are fired
+ * in parallel and resolved best-effort. A partial server failure leaves the
+ * server slightly out of sync until the next reload — acceptable for a bulk
+ * destructive action that the user has already confirmed.
+ */
+export async function clearAllFavorites(): Promise<FavoriteItem[]> {
+  const snapshot = lsRead();
+  lsWrite([]);
+  await Promise.allSettled(
+    snapshot.map((f) => removeFavorite(f.content_id, f.content_type)),
+  );
+  return snapshot;
+}
+
+/**
+ * Restore a snapshot returned by `clearAllFavorites()`. Writes the snapshot
+ * back to localStorage synchronously, then issues per-item POSTs in
+ * parallel. The frontend state is correct immediately; the server catches
+ * up in the background.
+ */
+export async function restoreAllFavorites(
+  snapshot: FavoriteItem[],
+): Promise<void> {
+  lsWrite(snapshot);
+  await Promise.allSettled(
+    snapshot.map((f) =>
+      addFavorite(f.content_id, {
+        content_type: f.content_type,
+        ...(f.content_name ? { content_name: f.content_name } : {}),
+        ...(f.content_icon ? { content_icon: f.content_icon } : {}),
+        ...(f.category_name ? { category_name: f.category_name } : {}),
+      }),
+    ),
+  );
+}

--- a/src/features/favorites/ConfirmDeleteAllModal.tsx
+++ b/src/features/favorites/ConfirmDeleteAllModal.tsx
@@ -1,0 +1,159 @@
+/**
+ * ConfirmDeleteAllModal — destructive confirm for "Delete all favorites".
+ *
+ * D-pad rules (per UX spec):
+ *  - Default focus = Cancel (FAV_DELETE_ALL_CANCEL). Destructive action
+ *    requires a deliberate Left to reach Delete all.
+ *  - Escape / Backspace = Cancel.
+ *  - Stop propagation on the dismiss key so it doesn't bubble to the
+ *    BottomDock route handler.
+ */
+import type { RefObject } from "react";
+import { useEffect, useRef } from "react";
+import {
+  useFocusable,
+  setFocus,
+} from "@noriginmedia/norigin-spatial-navigation";
+
+interface Props {
+  count: number;
+  onConfirm: () => void;
+  onCancel: (trigger: "button" | "back") => void;
+}
+
+export function ConfirmDeleteAllModal({ count, onConfirm, onCancel }: Props) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  const { ref: cancelRef } = useFocusable<HTMLButtonElement>({
+    focusKey: "FAV_DELETE_ALL_CANCEL",
+    onEnterPress: () => onCancel("button"),
+  });
+  const { ref: confirmRef } = useFocusable<HTMLButtonElement>({
+    focusKey: "FAV_DELETE_ALL_CONFIRM",
+    onEnterPress: onConfirm,
+  });
+
+  useEffect(() => {
+    setFocus("FAV_DELETE_ALL_CANCEL");
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape" || e.key === "Backspace") {
+        e.stopPropagation();
+        e.preventDefault();
+        onCancel("back");
+      }
+    };
+    document.addEventListener("keydown", handler, true);
+    return () => document.removeEventListener("keydown", handler, true);
+  }, [onCancel]);
+
+  return (
+    <div
+      role="presentation"
+      onClick={(e) => {
+        // Only dismiss when the bare scrim is clicked, not its children.
+        if (e.target === e.currentTarget) onCancel("button");
+      }}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.72)",
+        zIndex: 1000,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="fav-del-all-title"
+        aria-describedby="fav-del-all-body"
+        style={{
+          background: "var(--bg-elevated)",
+          border: "1px solid var(--glass-popover-border, var(--border-subtle))",
+          borderRadius: "var(--radius-md)",
+          width: "min(480px, 90vw)",
+          padding: "var(--space-6)",
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--space-4)",
+        }}
+      >
+        <h2
+          id="fav-del-all-title"
+          style={{
+            margin: 0,
+            fontSize: "var(--text-title-size)",
+            color: "var(--text-primary)",
+            fontWeight: 600,
+          }}
+        >
+          Delete all favorites?
+        </h2>
+        <p
+          id="fav-del-all-body"
+          style={{
+            margin: 0,
+            fontSize: "var(--text-body-size)",
+            color: "var(--text-secondary)",
+          }}
+        >
+          This will remove all {count} item{count === 1 ? "" : "s"} from your
+          favorites list. You&apos;ll have a few seconds to undo.
+        </p>
+        <div
+          style={{
+            display: "flex",
+            gap: "var(--space-3)",
+            justifyContent: "flex-end",
+            marginTop: "var(--space-2)",
+          }}
+        >
+          <button
+            ref={confirmRef as RefObject<HTMLButtonElement>}
+            type="button"
+            onClick={onConfirm}
+            className="focus-ring"
+            style={{
+              padding: "var(--space-2) var(--space-5)",
+              borderRadius: "var(--radius-sm)",
+              border: "none",
+              background: "var(--danger, #d84343)",
+              color: "var(--text-primary)",
+              fontSize: "var(--text-label-size)",
+              letterSpacing: "var(--text-label-tracking)",
+              textTransform: "uppercase",
+              cursor: "pointer",
+              fontWeight: 600,
+            }}
+          >
+            Delete all
+          </button>
+          <button
+            ref={cancelRef as RefObject<HTMLButtonElement>}
+            type="button"
+            onClick={() => onCancel("button")}
+            className="focus-ring"
+            style={{
+              padding: "var(--space-2) var(--space-5)",
+              borderRadius: "var(--radius-sm)",
+              border: "1px solid var(--accent-copper)",
+              background: "transparent",
+              color: "var(--text-primary)",
+              fontSize: "var(--text-label-size)",
+              letterSpacing: "var(--text-label-tracking)",
+              textTransform: "uppercase",
+              cursor: "pointer",
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/favorites/FavoritesUndoToast.tsx
+++ b/src/features/favorites/FavoritesUndoToast.tsx
@@ -1,0 +1,126 @@
+/**
+ * FavoritesUndoToast — bottom-center toast with countdown progress + Undo.
+ *
+ * Auto-dismisses after `durationMs`. Pressing Back/Escape during the
+ * window dismisses the toast WITHOUT triggering undo (per UX spec — Back
+ * during the undo window means "I'm leaving, don't undo").
+ */
+import type { RefObject } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useFocusable } from "@noriginmedia/norigin-spatial-navigation";
+
+interface Props {
+  onUndo: () => void;
+  onExpire: () => void;
+  durationMs?: number;
+}
+
+export function FavoritesUndoToast({
+  onUndo,
+  onExpire,
+  durationMs = 6000,
+}: Props) {
+  const [progress, setProgress] = useState(1);
+  const expiredRef = useRef(false);
+  const onExpireRef = useRef(onExpire);
+
+  useEffect(() => {
+    onExpireRef.current = onExpire;
+  }, [onExpire]);
+
+  const { ref: undoRef } = useFocusable<HTMLButtonElement>({
+    focusKey: "FAV_UNDO_TOAST",
+    onEnterPress: onUndo,
+  });
+
+  useEffect(() => {
+    const start = Date.now();
+    const tick = () => {
+      const elapsed = Date.now() - start;
+      const ratio = Math.max(0, 1 - elapsed / durationMs);
+      setProgress(ratio);
+      if (ratio <= 0 && !expiredRef.current) {
+        expiredRef.current = true;
+        onExpireRef.current();
+      }
+    };
+    const interval = setInterval(tick, 100);
+    return () => clearInterval(interval);
+  }, [durationMs]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape" || e.key === "Backspace") {
+        e.stopPropagation();
+        e.preventDefault();
+        if (!expiredRef.current) {
+          expiredRef.current = true;
+          onExpireRef.current();
+        }
+      }
+    };
+    document.addEventListener("keydown", handler, true);
+    return () => document.removeEventListener("keydown", handler, true);
+  }, []);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        position: "fixed",
+        bottom:
+          "calc(var(--dock-height, 80px) + var(--dock-bottom-offset, 0px) + var(--space-4))",
+        left: "50%",
+        transform: "translateX(-50%)",
+        background: "var(--bg-elevated)",
+        border: "1px solid var(--border-subtle)",
+        borderRadius: "var(--radius-sm)",
+        padding: "var(--space-3) var(--space-5)",
+        display: "flex",
+        alignItems: "center",
+        gap: "var(--space-4)",
+        zIndex: 1100,
+        minWidth: 280,
+        boxShadow: "0 8px 32px rgba(0,0,0,0.4)",
+      }}
+    >
+      <span style={{ color: "var(--text-primary)", fontSize: "var(--text-body-size)" }}>
+        Favorites cleared
+      </span>
+      <button
+        ref={undoRef as RefObject<HTMLButtonElement>}
+        type="button"
+        onClick={onUndo}
+        className="focus-ring"
+        style={{
+          padding: "var(--space-1) var(--space-3)",
+          borderRadius: "var(--radius-sm)",
+          border: "none",
+          background: "transparent",
+          color: "var(--accent-copper)",
+          fontSize: "var(--text-label-size)",
+          letterSpacing: "var(--text-label-tracking)",
+          textTransform: "uppercase",
+          cursor: "pointer",
+          fontWeight: 600,
+        }}
+      >
+        Undo
+      </button>
+      <div
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          left: 0,
+          bottom: 0,
+          height: 3,
+          width: `${progress * 100}%`,
+          background: "var(--accent-copper)",
+          transition: "width 0.1s linear",
+          borderRadius: "0 0 var(--radius-sm) var(--radius-sm)",
+        }}
+      />
+    </div>
+  );
+}

--- a/src/features/favorites/useFavorites.ts
+++ b/src/features/favorites/useFavorites.ts
@@ -14,6 +14,8 @@ import {
   addFavorite,
   removeFavorite,
   isFavorited,
+  clearAllFavorites,
+  restoreAllFavorites,
 } from "../../api/favorites";
 import type { FavoriteItem, AddFavoriteBody, ContentType } from "../../api/schemas";
 
@@ -28,6 +30,8 @@ export interface UseFavoritesReturn {
     meta: Omit<AddFavoriteBody, "content_type">,
   ) => Promise<void>;
   reload: () => Promise<void>;
+  clearAll: () => Promise<FavoriteItem[]>;
+  restoreAll: (snapshot: FavoriteItem[]) => Promise<void>;
 }
 
 export function useFavorites(): UseFavoritesReturn {
@@ -109,5 +113,24 @@ export function useFavorites(): UseFavoritesReturn {
     [favorites, isFav],
   );
 
-  return { favorites, loading, error, isFav, toggle, reload };
+  const clearAll = useCallback(async (): Promise<FavoriteItem[]> => {
+    const snapshot = favorites;
+    setFavorites([]);
+    void clearAllFavorites().catch(() => {
+      // Best-effort; localStorage is already empty. Server may lag.
+    });
+    return snapshot;
+  }, [favorites]);
+
+  const restoreAll = useCallback(
+    async (snapshot: FavoriteItem[]): Promise<void> => {
+      setFavorites(snapshot);
+      void restoreAllFavorites(snapshot).catch(() => {
+        // Best-effort; localStorage already restored.
+      });
+    },
+    [],
+  );
+
+  return { favorites, loading, error, isFav, toggle, reload, clearAll, restoreAll };
 }

--- a/src/routes/FavoritesRoute.test.tsx
+++ b/src/routes/FavoritesRoute.test.tsx
@@ -9,7 +9,7 @@
  *  - Sort toolbar renders when not empty
  *  - Remove-from-favorites path fires toggle
  */
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import React from "react";
 import type { FavoriteItem } from "../api/schemas";
@@ -35,6 +35,8 @@ vi.mock("@noriginmedia/norigin-spatial-navigation", () => ({
 }));
 
 const mockToggle = vi.hoisted(() => vi.fn());
+const mockClearAll = vi.hoisted(() => vi.fn());
+const mockRestoreAll = vi.hoisted(() => vi.fn());
 const mockUseFavorites = vi.hoisted(() =>
   vi.fn(() => ({
     favorites: [] as FavoriteItem[],
@@ -43,6 +45,8 @@ const mockUseFavorites = vi.hoisted(() =>
     isFav: vi.fn(() => true),
     toggle: mockToggle,
     reload: vi.fn(),
+    clearAll: mockClearAll,
+    restoreAll: mockRestoreAll,
   })),
 );
 
@@ -94,6 +98,8 @@ describe("FavoritesRoute", () => {
       isFav: vi.fn(() => true),
       toggle: mockToggle,
       reload: vi.fn(),
+      clearAll: mockClearAll,
+      restoreAll: mockRestoreAll,
     });
   });
 
@@ -105,6 +111,8 @@ describe("FavoritesRoute", () => {
       isFav: vi.fn(() => false),
       toggle: mockToggle,
       reload: vi.fn(),
+      clearAll: mockClearAll,
+      restoreAll: mockRestoreAll,
     });
 
     render(<FavoritesRoute />);
@@ -126,6 +134,8 @@ describe("FavoritesRoute", () => {
       isFav: vi.fn(() => true),
       toggle: mockToggle,
       reload: vi.fn(),
+      clearAll: mockClearAll,
+      restoreAll: mockRestoreAll,
     });
 
     render(<FavoritesRoute />);
@@ -147,6 +157,8 @@ describe("FavoritesRoute", () => {
       isFav: vi.fn(() => true),
       toggle: mockToggle,
       reload: vi.fn(),
+      clearAll: mockClearAll,
+      restoreAll: mockRestoreAll,
     });
 
     render(<FavoritesRoute />);
@@ -170,6 +182,8 @@ describe("FavoritesRoute", () => {
       isFav: vi.fn(() => true),
       toggle: mockToggle,
       reload: vi.fn(),
+      clearAll: mockClearAll,
+      restoreAll: mockRestoreAll,
     });
 
     render(<FavoritesRoute />);
@@ -202,11 +216,128 @@ describe("FavoritesRoute", () => {
       isFav: vi.fn(() => true),
       toggle: mockToggle,
       reload: vi.fn(),
+      clearAll: mockClearAll,
+      restoreAll: mockRestoreAll,
     });
 
     render(<FavoritesRoute />);
     const azBtn = screen.getByRole("button", { name: /a–z/i });
     fireEvent.click(azBtn);
     expect(azBtn.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  // ─── Delete all ───────────────────────────────────────────────────────────
+
+  describe("Delete all", () => {
+    beforeEach(() => {
+      mockClearAll.mockReset();
+      mockRestoreAll.mockReset();
+    });
+
+    it("Delete all button renders in toolbar when not empty", () => {
+      mockUseFavorites.mockReturnValue({
+        favorites: [mockMovie],
+        loading: false,
+        error: null,
+        isFav: vi.fn(() => true),
+        toggle: mockToggle,
+        reload: vi.fn(),
+        clearAll: mockClearAll,
+        restoreAll: mockRestoreAll,
+      });
+      render(<FavoritesRoute />);
+      expect(screen.getByRole("button", { name: /delete all/i })).toBeInTheDocument();
+    });
+
+    it("Delete all button is absent on whole-page empty state", () => {
+      render(<FavoritesRoute />);
+      expect(screen.queryByRole("button", { name: /delete all/i })).not.toBeInTheDocument();
+    });
+
+    it("clicking Delete all opens the confirm modal", () => {
+      mockUseFavorites.mockReturnValue({
+        favorites: [mockChannel, mockMovie],
+        loading: false,
+        error: null,
+        isFav: vi.fn(() => true),
+        toggle: mockToggle,
+        reload: vi.fn(),
+        clearAll: mockClearAll,
+        restoreAll: mockRestoreAll,
+      });
+      render(<FavoritesRoute />);
+      fireEvent.click(screen.getByRole("button", { name: /delete all/i }));
+      expect(screen.getByRole("dialog", { name: /delete all favorites/i })).toBeInTheDocument();
+      expect(screen.getByText(/2 items/i)).toBeInTheDocument();
+    });
+
+    it("Cancel closes the modal without calling clearAll", () => {
+      mockUseFavorites.mockReturnValue({
+        favorites: [mockMovie],
+        loading: false,
+        error: null,
+        isFav: vi.fn(() => true),
+        toggle: mockToggle,
+        reload: vi.fn(),
+        clearAll: mockClearAll,
+        restoreAll: mockRestoreAll,
+      });
+      render(<FavoritesRoute />);
+      fireEvent.click(screen.getByRole("button", { name: /delete all/i }));
+      fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(mockClearAll).not.toHaveBeenCalled();
+    });
+
+    it("Confirm fires clearAll and shows the undo toast", async () => {
+      mockClearAll.mockResolvedValue([mockMovie]);
+      mockUseFavorites.mockReturnValue({
+        favorites: [mockMovie],
+        loading: false,
+        error: null,
+        isFav: vi.fn(() => true),
+        toggle: mockToggle,
+        reload: vi.fn(),
+        clearAll: mockClearAll,
+        restoreAll: mockRestoreAll,
+      });
+      render(<FavoritesRoute />);
+      fireEvent.click(screen.getByRole("button", { name: /delete all/i }));
+      const dialog = screen.getByRole("dialog", { name: /delete all favorites/i });
+      fireEvent.click(within(dialog).getByRole("button", { name: /^delete all$/i }));
+      await waitFor(() => {
+        expect(mockClearAll).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(screen.getByText(/favorites cleared/i)).toBeInTheDocument();
+      });
+      expect(screen.getByRole("button", { name: /^undo$/i })).toBeInTheDocument();
+    });
+
+    it("Undo calls restoreAll with the snapshot", async () => {
+      mockClearAll.mockResolvedValue([mockMovie, mockChannel]);
+      mockRestoreAll.mockResolvedValue(undefined);
+      mockUseFavorites.mockReturnValue({
+        favorites: [mockMovie, mockChannel],
+        loading: false,
+        error: null,
+        isFav: vi.fn(() => true),
+        toggle: mockToggle,
+        reload: vi.fn(),
+        clearAll: mockClearAll,
+        restoreAll: mockRestoreAll,
+      });
+      render(<FavoritesRoute />);
+      fireEvent.click(screen.getByRole("button", { name: /delete all/i }));
+      const dialog = screen.getByRole("dialog", { name: /delete all favorites/i });
+      fireEvent.click(within(dialog).getByRole("button", { name: /^delete all$/i }));
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /^undo$/i })).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByRole("button", { name: /^undo$/i }));
+      await waitFor(() => {
+        expect(mockRestoreAll).toHaveBeenCalledWith([mockMovie, mockChannel]);
+      });
+    });
   });
 });

--- a/src/routes/FavoritesRoute.tsx
+++ b/src/routes/FavoritesRoute.tsx
@@ -15,13 +15,16 @@
  * for BottomDock's setFocus("CONTENT_AREA_FAVORITES") on Esc routing.
  */
 import type { RefObject } from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import {
   useFocusable,
   FocusContext,
+  setFocus,
 } from "@noriginmedia/norigin-spatial-navigation";
 import { useFavorites } from "../features/favorites/useFavorites";
 import { FavoritePosterCard } from "../features/favorites/FavoritePosterCard";
+import { ConfirmDeleteAllModal } from "../features/favorites/ConfirmDeleteAllModal";
+import { FavoritesUndoToast } from "../features/favorites/FavoritesUndoToast";
 import { MovieDetailSheet } from "../features/movies/MovieDetailSheet";
 import { usePlayerOpener } from "../player";
 import {
@@ -32,6 +35,7 @@ import {
 } from "../features/favorites/sortFavorites";
 import { Skeleton } from "../primitives/Skeleton";
 import { ErrorShell } from "../primitives/ErrorShell";
+import { logEvent } from "../telemetry";
 import type { FavoriteItem, ContentType, VodStream } from "../api/schemas";
 
 const SORT_OPTIONS: { id: FavoriteSortKey; label: string }[] = [
@@ -178,10 +182,14 @@ export function FavoritesRoute() {
     focusBoundaryDirections: ["left", "right", "up"],
   });
 
-  const { favorites, loading, error, toggle, reload } = useFavorites();
+  const { favorites, loading, error, toggle, reload, clearAll, restoreAll } =
+    useFavorites();
   const { openPlayer } = usePlayerOpener();
   const [sort, setSort] = useState<FavoriteSortKey>(() => getFavoriteSortPref());
   const [sheetItem, setSheetItem] = useState<FavoriteItem | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [undoSnapshot, setUndoSnapshot] = useState<FavoriteItem[] | null>(null);
+  const deleteAtRef = useRef<number>(0);
 
   const handleRemove = useCallback(
     async (id: number, type: ContentType) => {
@@ -199,6 +207,46 @@ export function FavoritesRoute() {
     if (item.content_type !== "vod") return;
     setSheetItem(item);
   }, []);
+
+  const handleDeleteAllTrigger = useCallback(() => {
+    logEvent("favorites_delete_all_triggered", { count: favorites.length });
+    setConfirmOpen(true);
+  }, [favorites.length]);
+
+  const handleConfirmDelete = useCallback(async () => {
+    const count = favorites.length;
+    logEvent("favorites_delete_all_confirmed", { count });
+    setConfirmOpen(false);
+    deleteAtRef.current = Date.now();
+    const snapshot = await clearAll();
+    setUndoSnapshot(snapshot);
+    setFocus("FAV_UNDO_TOAST");
+  }, [favorites.length, clearAll]);
+
+  const handleCancelDelete = useCallback((trigger: "button" | "back") => {
+    logEvent("favorites_delete_all_cancelled", { trigger });
+    setConfirmOpen(false);
+    setFocus("FAV_DELETE_ALL_TRIGGER");
+  }, []);
+
+  const handleUndo = useCallback(async () => {
+    if (!undoSnapshot) return;
+    const elapsed = Date.now() - deleteAtRef.current;
+    logEvent("favorites_delete_all_undone", {
+      count: undoSnapshot.length,
+      elapsed_ms: elapsed,
+    });
+    await restoreAll(undoSnapshot);
+    setUndoSnapshot(null);
+    setFocus("FAV_DELETE_ALL_TRIGGER");
+  }, [undoSnapshot, restoreAll]);
+
+  const handleUndoExpire = useCallback(() => {
+    if (!undoSnapshot) return;
+    logEvent("favorites_delete_all_committed", { count: undoSnapshot.length });
+    setUndoSnapshot(null);
+    setFocus("CONTENT_AREA_FAVORITES");
+  }, [undoSnapshot]);
 
   const { channels, movies, series } = useMemo(() => {
     const sorted = sortFavorites(favorites, sort);
@@ -279,6 +327,8 @@ export function FavoritesRoute() {
                 onSelect={() => handleSortChange(opt.id)}
               />
             ))}
+            <span style={{ flex: 1 }} />
+            <DeleteAllTrigger onSelect={handleDeleteAllTrigger} />
           </div>
         )}
 
@@ -349,8 +399,53 @@ export function FavoritesRoute() {
             }}
           />
         ) : null}
+
+        {confirmOpen && (
+          <ConfirmDeleteAllModal
+            count={favorites.length}
+            onConfirm={() => void handleConfirmDelete()}
+            onCancel={handleCancelDelete}
+          />
+        )}
+
+        {undoSnapshot !== null && (
+          <FavoritesUndoToast
+            onUndo={() => void handleUndo()}
+            onExpire={handleUndoExpire}
+          />
+        )}
       </main>
     </FocusContext.Provider>
+  );
+}
+
+function DeleteAllTrigger({ onSelect }: { onSelect: () => void }) {
+  const { ref, focused } = useFocusable<HTMLButtonElement>({
+    focusKey: "FAV_DELETE_ALL_TRIGGER",
+    onEnterPress: onSelect,
+  });
+  return (
+    <button
+      ref={ref as RefObject<HTMLButtonElement>}
+      type="button"
+      onClick={onSelect}
+      className="focus-ring"
+      style={{
+        padding: "var(--space-2) var(--space-4)",
+        borderRadius: "var(--radius-sm)",
+        border: focused ? "1px solid var(--accent-copper)" : "1px solid transparent",
+        background: "transparent",
+        color: focused ? "var(--text-primary)" : "var(--text-secondary)",
+        fontSize: "var(--text-label-size)",
+        letterSpacing: "var(--text-label-tracking)",
+        textTransform: "uppercase",
+        cursor: "pointer",
+        transition:
+          "color var(--motion-focus), border-color var(--motion-focus)",
+      }}
+    >
+      Delete all
+    </button>
   );
 }
 

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -14,7 +14,12 @@ export type TelemetryEventName =
   | "nav_originator_restored"
   | "dock_navigated"
   | "search_lang_filter_change"
-  | "search_results_lang_zero";
+  | "search_results_lang_zero"
+  | "favorites_delete_all_triggered"
+  | "favorites_delete_all_confirmed"
+  | "favorites_delete_all_cancelled"
+  | "favorites_delete_all_undone"
+  | "favorites_delete_all_committed";
 
 export interface TelemetryEventProps {
   [key: string]: string | number | boolean | null | undefined;


### PR DESCRIPTION
## Summary
- "Delete all" button at the right end of the Favorites toolbar (auto-hides on whole-page empty).
- Centered confirm modal — default focus on **Cancel** so the destructive button needs a deliberate D-pad Left to reach.
- 6-second Undo toast with progress bar; pressing Undo restores from an in-memory snapshot. Letting it expire commits the delete.
- Back-key handling: Back in modal = Cancel; Back during undo window = dismiss WITHOUT undo (user is leaving — don't surprise them).
- 5 telemetry events covering trigger / confirm / cancel / undo / commit.

## D-pad flow
```
Toolbar Sort | A–Z | <spacer> | Delete all
                                    ↓ Enter
                         Modal: [Delete all] [Cancel]   ← focus starts on Cancel
                                    ↓ Confirm
                         Toast: Favorites cleared [Undo]
                                    ↓ Undo (or expire)
                         Focus → Delete all (or CONTENT_AREA_FAVORITES on expire)
```

## Why
Per design memo: bulk clear had been deferred for months because it needed a confirm + undo affordance. Single-item ✕ was the only path; users with 50+ favorites had no way to reset.

## Files
- New: `ConfirmDeleteAllModal.tsx`, `FavoritesUndoToast.tsx`
- Edits: `FavoritesRoute.tsx`, `useFavorites.ts`, `api/favorites.ts` (+ `clearAllFavorites`, `restoreAllFavorites`), `telemetry/index.ts`

## Test plan
- [x] `npm test src/routes/FavoritesRoute.test.tsx` — 14/14 (8 existing + 6 new)
- [x] `npm test` — full suite: 354/354 pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [ ] Prod smoke: D-pad to Delete all → confirm → see toast → Undo → favorites restored, focus on Delete all
- [ ] Back during modal closes without delete
- [ ] Back during toast dismisses toast without undo

🤖 Generated with [Claude Code](https://claude.com/claude-code)