### PR TITLE
feat(adaptive): PlayerGestureLayer — mobile tap-to-toggle player controls (PR-FE-2)

### DIFF
--- a/src/player/PlayerControls.tsx
+++ b/src/player/PlayerControls.tsx
@@ -11,7 +11,7 @@
  * opens, and Left/Right on any popover item dismisses it and advances
  * to the next sibling control (spec §5).
  */
-import type { RefObject, CSSProperties } from "react";
+import type { MutableRefObject, RefObject, CSSProperties } from "react";
 import { useEffect, useRef, useState, useCallback } from "react";
 import {
   useFocusable,
@@ -118,6 +118,12 @@ export interface PlayerControlsProps {
    */
   onPrev?: () => void;
   onNext?: () => void;
+  /**
+   * When set, PlayerControls exposes a toggle() fn via this ref (show↔hide).
+   * Also wires "tap on empty controls area → hide" for mobile touch UX
+   * (master plan §5 PR-FE-2).
+   */
+  toggleRef?: MutableRefObject<(() => void) | null>;
 }
 
 type MenuName = "audio" | "subtitles" | "quality" | "volume";
@@ -166,12 +172,15 @@ function MenuItem({
         ref={ref as RefObject<HTMLButtonElement>}
         type="button"
         className="focus-ring"
+        data-player-control
         onClick={onSelect}
         style={{
           display: "block",
           width: "100%",
           padding: "var(--space-2) var(--space-4)",
-          background: highlighted ? "var(--accent-copper)" : "var(--bg-elevated)",
+          background: highlighted
+            ? "var(--accent-copper)"
+            : "var(--bg-elevated)",
           color: highlighted ? "var(--bg-base)" : "var(--text-primary)",
           border: "none",
           borderRadius: "var(--radius-sm)",
@@ -205,7 +214,9 @@ interface ControlButtonProps {
    * nav is blocked. Used by transport buttons (Play/Pause + ±10s) for
    * arrow-seek + ArrowDown-to-settings-row (6d prod feedback).
    */
-  arrowOverrides?: Partial<Record<"left" | "right" | "up" | "down", () => void>>;
+  arrowOverrides?: Partial<
+    Record<"left" | "right" | "up" | "down", () => void>
+  >;
   /**
    * Where ArrowUp lands. Defaults to FK.BACK per spec §4.2. Right-side
    * settings (Volume/Audio/Subs/Quality) override this to FK.PLAY_PAUSE
@@ -260,6 +271,7 @@ function ControlButton({
       aria-disabled={!focusable}
       aria-expanded={ariaExpanded}
       aria-haspopup={ariaHasPopup}
+      data-player-control
       onClick={focusable ? onPress : undefined}
       tabIndex={focusable ? 0 : -1}
       style={{
@@ -346,6 +358,7 @@ function VolumeSlider({
       aria-valuemax={100}
       aria-live="polite"
       tabIndex={0}
+      data-player-control
       style={{
         position: "absolute",
         bottom: "calc(100% + var(--space-2))",
@@ -426,6 +439,7 @@ export function PlayerControls({
   onSelectSubtitleTrack,
   onPrev,
   onNext,
+  toggleRef,
 }: PlayerControlsProps) {
   const reducedMotion = useReducedMotion();
 
@@ -474,6 +488,26 @@ export function PlayerControls({
     setVisible(true);
     scheduleHide();
   }, [scheduleHide]);
+
+  // toggle() is the single entry point for touch-tap show↔hide (PR-FE-2).
+  const toggle = useCallback(() => {
+    if (visibleRef.current) {
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+      setVisible(false);
+      setOpenMenu(null);
+    } else {
+      wake();
+    }
+  }, [wake]);
+
+  // Expose toggle via toggleRef so PlayerShell can wire the gesture layer.
+  useEffect(() => {
+    if (!toggleRef) return;
+    toggleRef.current = toggle;
+    return () => {
+      toggleRef.current = null;
+    };
+  }, [toggle, toggleRef]);
 
   const togglePlayPause = useCallback(() => {
     if (isPlaying) {
@@ -581,10 +615,7 @@ export function PlayerControls({
       const kc = e.keyCode;
 
       const isBack =
-        k === "Escape" ||
-        k === "Back" ||
-        k === "GoBack" ||
-        kc === 4;
+        k === "Escape" || k === "Back" || k === "GoBack" || kc === 4;
       if (isBack) {
         e.preventDefault();
         if (openMenuRef.current) {
@@ -619,8 +650,7 @@ export function PlayerControls({
         return;
       }
 
-      const isFfKey =
-        k === "MediaFastForward" || k === "l" || kc === 90;
+      const isFfKey = k === "MediaFastForward" || k === "l" || kc === 90;
       if (isFfKey && !isLiveRef.current) {
         e.preventDefault();
         seekWithRateRef.current(1);
@@ -798,7 +828,9 @@ export function PlayerControls({
     FK.SUBTITLES,
     FK.QUALITY,
   ];
-  const firstRightSideKey = orderedKeys.find((k) => RIGHT_SIDE_KEYS.includes(k));
+  const firstRightSideKey = orderedKeys.find((k) =>
+    RIGHT_SIDE_KEYS.includes(k),
+  );
 
   // 6d — prod feedback: users expect ArrowLeft/Right to seek (Netflix
   // convention), not walk the bar. Both directions route through the
@@ -897,6 +929,21 @@ export function PlayerControls({
         ref={containerRef as RefObject<HTMLDivElement>}
         data-testid="player-controls"
         aria-hidden={!visible}
+        // "Visible → hide" path for mobile tap-toggle (PR-FE-2): when the user
+        // taps on the empty area of the controls overlay (not on a button), hide
+        // the controls. Control buttons carry [data-player-control] so we can
+        // distinguish background taps from button taps.
+        onTouchEnd={
+          toggleRef
+            ? (e) => {
+                const target = e.target as Element;
+                if (!target.closest("[data-player-control]")) {
+                  e.preventDefault();
+                  toggle();
+                }
+              }
+            : undefined
+        }
         style={{
           position: "absolute",
           inset: 0,
@@ -907,6 +954,7 @@ export function PlayerControls({
           display: "flex",
           flexDirection: "column",
           justifyContent: "space-between",
+          zIndex: 2,
         }}
       >
         {/* ─── TOP BAR ─────────────────────────────────────────────────── */}
@@ -925,10 +973,13 @@ export function PlayerControls({
             type="button"
             className="focus-ring"
             aria-label="Back"
+            data-player-control
             onClick={onClose}
             style={{
               ...controlButtonStyle,
-              outline: backFocused ? "2px solid var(--accent-copper)" : undefined,
+              outline: backFocused
+                ? "2px solid var(--accent-copper)"
+                : undefined,
             }}
           >
             ←
@@ -952,10 +1003,13 @@ export function PlayerControls({
               type="button"
               className="focus-ring"
               aria-label="Previous episode"
+              data-player-control
               onClick={() => onPrev?.()}
               style={{
                 ...controlButtonStyle,
-                outline: prevFocused ? "2px solid var(--accent-copper)" : undefined,
+                outline: prevFocused
+                  ? "2px solid var(--accent-copper)"
+                  : undefined,
               }}
             >
               ⏮
@@ -967,10 +1021,13 @@ export function PlayerControls({
               type="button"
               className="focus-ring"
               aria-label="Next episode"
+              data-player-control
               onClick={() => onNext?.()}
               style={{
                 ...controlButtonStyle,
-                outline: nextFocused ? "2px solid var(--accent-copper)" : undefined,
+                outline: nextFocused
+                  ? "2px solid var(--accent-copper)"
+                  : undefined,
               }}
             >
               ⏭
@@ -1177,11 +1234,17 @@ export function PlayerControls({
                 />
                 {openMenu === "audio" && (
                   // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role -- intentional listbox pattern
-                  <ul style={menuStyle} role="listbox" aria-label="Audio tracks">
+                  <ul
+                    style={menuStyle}
+                    role="listbox"
+                    aria-label="Audio tracks"
+                  >
                     {audioTracks.map((track) => (
                       <MenuItem
                         key={track.index}
-                        label={track.name || track.lang || `Audio ${track.index}`}
+                        label={
+                          track.name || track.lang || `Audio ${track.index}`
+                        }
                         isActive={currentAudioTrack === track.index}
                         focusKey={`PLAYER_AUDIO_${track.index}`}
                         onSelect={() => {
@@ -1202,7 +1265,8 @@ export function PlayerControls({
                   focusKey={FK.SUBTITLES}
                   label="Subtitles"
                   icon={`CC ${
-                    currentSubtitleTrack >= 0 && subtitleTracks[currentSubtitleTrack]
+                    currentSubtitleTrack >= 0 &&
+                    subtitleTracks[currentSubtitleTrack]
                       ? subtitleTracks[currentSubtitleTrack]!.name
                       : "Off"
                   }`}

--- a/src/player/PlayerGestureLayer.test.tsx
+++ b/src/player/PlayerGestureLayer.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * PlayerGestureLayer unit tests (master plan §5 PR-FE-2).
+ *
+ * The jsdom test environment does not support TouchEvent by default; we
+ * polyfill it in the same way as the existing inputMode tests (create Events
+ * directly rather than using the constructor).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PlayerGestureLayer } from "./PlayerGestureLayer";
+import * as inputMode from "../nav/inputMode";
+
+// ─── TouchEvent polyfill ─────────────────────────────────────────────────────
+
+function makeTouch(overrides: Partial<Touch> = {}): Touch {
+  return {
+    identifier: 0,
+    target: document.body,
+    clientX: 100,
+    clientY: 100,
+    screenX: 100,
+    screenY: 100,
+    pageX: 100,
+    pageY: 100,
+    radiusX: 0,
+    radiusY: 0,
+    rotationAngle: 0,
+    force: 1,
+    altitudeAngle: 0,
+    azimuthAngle: 0,
+    touchType: "direct",
+    ...overrides,
+  } as Touch;
+}
+
+function makeTouchList(touches: Touch[]): TouchList {
+  const list = {
+    length: touches.length,
+    item: (i: number) => touches[i] ?? null,
+    [Symbol.iterator]: function* () {
+      yield* touches;
+    },
+  } as unknown as TouchList;
+  // Allow indexed access (0, 1, …)
+  touches.forEach((t, i) => {
+    (list as unknown as Record<number, Touch>)[i] = t;
+  });
+  return list;
+}
+
+function fireTouchStart(el: Element, touch: Touch) {
+  const event = new Event("touchstart", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "changedTouches", {
+    value: makeTouchList([touch]),
+  });
+  el.dispatchEvent(event);
+}
+
+function fireTouchEnd(el: Element, touch: Touch) {
+  const event = new Event("touchend", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "changedTouches", {
+    value: makeTouchList([touch]),
+  });
+  el.dispatchEvent(event);
+  return event;
+}
+
+function fireTouchCancel(el: Element, touch: Touch) {
+  const event = new Event("touchcancel", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "changedTouches", {
+    value: makeTouchList([touch]),
+  });
+  el.dispatchEvent(event);
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("PlayerGestureLayer", () => {
+  let getInputModeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    getInputModeSpy = vi
+      .spyOn(inputMode, "getInputMode")
+      .mockReturnValue("touch");
+  });
+
+  afterEach(() => {
+    getInputModeSpy.mockRestore();
+  });
+
+  it("renders the overlay when not on TV", () => {
+    const onTapToggle = vi.fn();
+    render(<PlayerGestureLayer onTapToggle={onTapToggle} />);
+    expect(screen.getByTestId("player-gesture-layer")).toBeTruthy();
+  });
+
+  it("returns null on TV (dpad mode)", () => {
+    getInputModeSpy.mockReturnValue("dpad");
+    const onTapToggle = vi.fn();
+    const { container } = render(
+      <PlayerGestureLayer onTapToggle={onTapToggle} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("calls onTapToggle on a clean tap (< 300ms, < 10px)", () => {
+    const onTapToggle = vi.fn();
+    render(<PlayerGestureLayer onTapToggle={onTapToggle} />);
+    const overlay = screen.getByTestId("player-gesture-layer");
+
+    const touch = makeTouch({ identifier: 1, clientX: 200, clientY: 200 });
+    fireTouchStart(overlay, touch);
+    fireTouchEnd(overlay, touch);
+
+    expect(onTapToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call onTapToggle when displacement exceeds 10px", () => {
+    const onTapToggle = vi.fn();
+    render(<PlayerGestureLayer onTapToggle={onTapToggle} />);
+    const overlay = screen.getByTestId("player-gesture-layer");
+
+    const start = makeTouch({ identifier: 2, clientX: 100, clientY: 100 });
+    const end = makeTouch({ identifier: 2, clientX: 115, clientY: 100 });
+    fireTouchStart(overlay, start);
+    fireTouchEnd(overlay, end);
+
+    expect(onTapToggle).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call onTapToggle after touchcancel", () => {
+    const onTapToggle = vi.fn();
+    render(<PlayerGestureLayer onTapToggle={onTapToggle} />);
+    const overlay = screen.getByTestId("player-gesture-layer");
+
+    const touch = makeTouch({ identifier: 3 });
+    fireTouchStart(overlay, touch);
+    fireTouchCancel(overlay, touch);
+    fireTouchEnd(overlay, touch);
+
+    expect(onTapToggle).not.toHaveBeenCalled();
+  });
+
+  it("ignores touch on [data-player-control] elements", () => {
+    const onTapToggle = vi.fn();
+    const { container } = render(
+      <div>
+        <button data-player-control>Play</button>
+        <PlayerGestureLayer onTapToggle={onTapToggle} />
+      </div>,
+    );
+    const btn = container.querySelector("button[data-player-control]")!;
+    const touch = makeTouch({ identifier: 4, target: btn });
+
+    // Simulate touch on the button (target is the button)
+    const startEvent = new Event("touchstart", {
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(startEvent, "changedTouches", {
+      value: makeTouchList([touch]),
+    });
+    btn.dispatchEvent(startEvent);
+
+    const endEvent = new Event("touchend", { bubbles: true, cancelable: true });
+    Object.defineProperty(endEvent, "changedTouches", {
+      value: makeTouchList([touch]),
+    });
+    // target of endEvent is button (has [data-player-control])
+    Object.defineProperty(endEvent, "target", { value: btn });
+    const overlay = screen.getByTestId("player-gesture-layer");
+    overlay.dispatchEvent(endEvent);
+
+    expect(onTapToggle).not.toHaveBeenCalled();
+  });
+
+  it("calls preventDefault on touchend for a valid tap (ghost-click prevention)", () => {
+    const onTapToggle = vi.fn();
+    render(<PlayerGestureLayer onTapToggle={onTapToggle} />);
+    const overlay = screen.getByTestId("player-gesture-layer");
+
+    const touch = makeTouch({ identifier: 5, clientX: 50, clientY: 50 });
+    fireTouchStart(overlay, touch);
+    const endEvent = fireTouchEnd(overlay, touch);
+
+    // preventDefault should have been called on the touchend event.
+    expect(endEvent.defaultPrevented).toBe(true);
+  });
+
+  it("handles mismatched touch identifier gracefully (no crash, no toggle)", () => {
+    const onTapToggle = vi.fn();
+    render(<PlayerGestureLayer onTapToggle={onTapToggle} />);
+    const overlay = screen.getByTestId("player-gesture-layer");
+
+    const start = makeTouch({ identifier: 6, clientX: 10, clientY: 10 });
+    const endDifferentId = makeTouch({
+      identifier: 99,
+      clientX: 10,
+      clientY: 10,
+    });
+    fireTouchStart(overlay, start);
+    fireTouchEnd(overlay, endDifferentId);
+
+    expect(onTapToggle).not.toHaveBeenCalled();
+  });
+});

--- a/src/player/PlayerGestureLayer.tsx
+++ b/src/player/PlayerGestureLayer.tsx
@@ -1,0 +1,142 @@
+/**
+ * PlayerGestureLayer — transparent touch surface that sits BELOW the control
+ * overlay (z=1 vs controls z=2). (Master plan §5 PR-FE-2, spec §2.)
+ *
+ * Two-path tap-toggle design:
+ *   hidden → show  Controls have pointerEvents:none so touches fall through to
+ *                  this layer (pointerEvents:auto). We detect the tap and call
+ *                  onTapToggle, which wakes the controls via the toggleRef.
+ *   visible → hide The controls themselves (z=2, pointerEvents:auto) intercept
+ *                  the touch. PlayerControls' root div handles "tap on empty
+ *                  area" via its own touchend handler and calls the same
+ *                  toggleRef. The gesture layer never fires in this path.
+ *
+ * Tap definition (spec §2 — gesture grammar):
+ *   - touchstart → touchend (no cancel)
+ *   - displacement < 10 px
+ *   - duration < 300 ms
+ *
+ * Hard guards (all return null / ignore):
+ *   - TV mode (data-tv="true") — d-pad only, no gesture layer needed
+ *   - Flag adaptive.player.tap_toggle is false
+ *   - Tap target has a [data-player-control] ancestor
+ *
+ * Ghost-click prevention: e.preventDefault() on touchend stops the browser's
+ * synthetic 300ms mousedown+click from firing after the touch.
+ */
+import { useRef, useCallback, useEffect } from "react";
+import { getInputMode } from "../nav/inputMode";
+
+const TAP_MAX_DURATION_MS = 300;
+const TAP_MAX_DISPLACEMENT_PX = 10;
+
+interface PlayerGestureLayerProps {
+  onTapToggle: () => void;
+}
+
+export function PlayerGestureLayer({ onTapToggle }: PlayerGestureLayerProps) {
+  const isTV = getInputMode() === "dpad";
+
+  const touchStartRef = useRef<{
+    x: number;
+    y: number;
+    t: number;
+    identifier: number;
+  } | null>(null);
+
+  const handleTouchStart = useCallback((e: TouchEvent) => {
+    const touch = e.changedTouches[0];
+    if (!touch) return;
+    touchStartRef.current = {
+      x: touch.clientX,
+      y: touch.clientY,
+      t: Date.now(),
+      identifier: touch.identifier,
+    };
+  }, []);
+
+  const handleTouchEnd = useCallback(
+    (e: TouchEvent) => {
+      const start = touchStartRef.current;
+      if (!start) return;
+
+      let end: Touch | null = null;
+      for (let i = 0; i < e.changedTouches.length; i++) {
+        const t = e.changedTouches[i];
+        if (t && t.identifier === start.identifier) {
+          end = t;
+          break;
+        }
+      }
+      touchStartRef.current = null;
+      if (!end) return;
+
+      const duration = Date.now() - start.t;
+      const dx = end.clientX - start.x;
+      const dy = end.clientY - start.y;
+      const displacement = Math.sqrt(dx * dx + dy * dy);
+
+      if (duration > TAP_MAX_DURATION_MS) return;
+      if (displacement > TAP_MAX_DISPLACEMENT_PX) return;
+
+      // Control buttons sit at z=2 (above this layer) with pointerEvents:auto
+      // when visible — they intercept touches before this layer fires. This
+      // check is a belt-and-suspenders guard in case any control element leaks
+      // through (e.g., absolutely-positioned tooltips with lower z-index).
+      const target = e.target as Element | null;
+      if (target?.closest("[data-player-control]")) return;
+
+      // Prevent ghost click (browser 300ms touch-to-click delay).
+      e.preventDefault();
+
+      onTapToggle();
+    },
+    [onTapToggle],
+  );
+
+  const handleTouchCancel = useCallback(() => {
+    touchStartRef.current = null;
+  }, []);
+
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = overlayRef.current;
+    if (!el) return;
+    // touchstart can be passive (no preventDefault needed).
+    // touchend must be non-passive so we can call preventDefault.
+    el.addEventListener("touchstart", handleTouchStart, { passive: true });
+    el.addEventListener("touchend", handleTouchEnd, { passive: false });
+    el.addEventListener("touchcancel", handleTouchCancel, { passive: true });
+    return () => {
+      el.removeEventListener("touchstart", handleTouchStart);
+      el.removeEventListener("touchend", handleTouchEnd);
+      el.removeEventListener("touchcancel", handleTouchCancel);
+    };
+  }, [handleTouchStart, handleTouchEnd, handleTouchCancel]);
+
+  if (isTV) return null;
+
+  return (
+    <div
+      ref={overlayRef}
+      data-testid="player-gesture-layer"
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        inset: 0,
+        // z=1: above the video (no z-index) but below the controls (z=2).
+        // pointerEvents:auto so this div receives touch events that fall
+        // through from the controls layer when controls are hidden
+        // (controls have pointerEvents:none when not visible).
+        // This layer only renders when tap_toggle flag is on (parent gates it),
+        // which is a touch-device-only flag, so capturing mouse events here
+        // does not degrade desktop UX.
+        zIndex: 1,
+        pointerEvents: "auto",
+        touchAction: "none",
+        background: "transparent",
+      }}
+    />
+  );
+}

--- a/src/player/PlayerShell.tsx
+++ b/src/player/PlayerShell.tsx
@@ -20,12 +20,15 @@ import {
 import { usePlayerStore, type PlayerKind } from "./PlayerProvider";
 import { useHlsPlayer } from "./useHlsPlayer";
 import { PlayerControls } from "./PlayerControls";
+import { PlayerGestureLayer } from "./PlayerGestureLayer";
 import { useReducedMotion } from "./useReducedMotion";
 import { classifyFailure, type FailureClass } from "./classifyFailure";
 import { markTierLocked } from "../features/movies/tierLockCache";
 import { recordHistory } from "../api/history";
 import { getLangPref } from "../lib/langPref";
 import { pickAudioTrackForLang } from "../lib/inferLanguage";
+import { getFlag } from "../config/featureFlags";
+import { getInputMode } from "../nav/inputMode";
 
 // Failure-overlay focus keys — kept local, only the overlay reads them.
 const FK_RETRY = "PLAYER_FAIL_RETRY";
@@ -65,6 +68,12 @@ export function PlayerShell() {
   const [currentAudioTrack, setCurrentAudioTrack] = useState(-1);
   const [currentSubtitleTrack, setCurrentSubtitleTrack] = useState(-1);
   const [volume, setVolumeState] = useState(1);
+
+  // PR-FE-2: tap-toggle controls visibility on mobile touch.
+  // Evaluated once at render (flag cache is synchronous); re-renders update it.
+  const tapToggleEnabled =
+    getFlag("adaptive.player.tap_toggle", false) && getInputMode() !== "dpad";
+  const controlsToggleRef = useRef<(() => void) | null>(null);
 
   const { ref: shellRef, focusKey } = useFocusable({
     focusKey: "PLAYER_SHELL",
@@ -265,6 +274,12 @@ export function PlayerShell() {
           />
         )}
 
+        {!showFailure && tapToggleEnabled && (
+          <PlayerGestureLayer
+            onTapToggle={() => controlsToggleRef.current?.()}
+          />
+        )}
+
         {!showFailure && (
           <PlayerControls
             title={title}
@@ -289,6 +304,7 @@ export function PlayerShell() {
             onSelectSubtitleTrack={handleSelectSubtitleTrack}
             {...(onPrev && { onPrev })}
             {...(onNext && { onNext })}
+            {...(tapToggleEnabled ? { toggleRef: controlsToggleRef } : {})}
           />
         )}
       </div>
@@ -409,8 +425,16 @@ function FailureOverlay({
           color: "var(--text-primary)",
         }}
       >
-        <span style={{ fontSize: "32px" }} aria-hidden="true">⚠</span>
-        <p style={{ fontSize: "var(--text-title-size)", fontWeight: 600, margin: 0 }}>
+        <span style={{ fontSize: "32px" }} aria-hidden="true">
+          ⚠
+        </span>
+        <p
+          style={{
+            fontSize: "var(--text-title-size)",
+            fontWeight: 600,
+            margin: 0,
+          }}
+        >
           {kind === "stream-offline"
             ? playerKind === "live"
               ? "Channel offline"
@@ -428,10 +452,10 @@ function FailureOverlay({
           {kind === "tier-lock"
             ? "This title is delivered in a format your Xtream plan doesn't support. Try a different title or see if a similar one is available."
             : kind === "stream-offline"
-            ? playerKind === "live"
-              ? "This channel is offline upstream right now. Try a different channel, or hit Try again in a moment."
-              : "This title is offline upstream right now. Try another episode or title, or hit Try again in a moment."
-            : "This title couldn't be played right now. It may be a format your plan doesn't support, or the provider is temporarily unavailable."}
+              ? playerKind === "live"
+                ? "This channel is offline upstream right now. Try a different channel, or hit Try again in a moment."
+                : "This title is offline upstream right now. Try another episode or title, or hit Try again in a moment."
+              : "This title couldn't be played right now. It may be a format your plan doesn't support, or the provider is temporarily unavailable."}
         </p>
         <div
           style={{
@@ -447,7 +471,9 @@ function FailureOverlay({
               className="focus-ring"
               onClick={onRetry}
               style={{
-                background: retryFocused ? "var(--accent-copper)" : "rgba(255,255,255,0.15)",
+                background: retryFocused
+                  ? "var(--accent-copper)"
+                  : "rgba(255,255,255,0.15)",
                 color: retryFocused ? "var(--bg-base)" : "var(--text-primary)",
                 border: "none",
                 borderRadius: "var(--radius-sm)",
@@ -465,7 +491,9 @@ function FailureOverlay({
             className="focus-ring"
             onClick={onClose}
             style={{
-              background: backFocused ? "var(--accent-copper)" : "rgba(255,255,255,0.15)",
+              background: backFocused
+                ? "var(--accent-copper)"
+                : "rgba(255,255,255,0.15)",
               color: backFocused ? "var(--bg-base)" : "var(--text-primary)",
               border: "none",
               borderRadius: "var(--radius-sm)",

--- a/tests/e2e/mobile-tap-toggle.spec.ts
+++ b/tests/e2e/mobile-tap-toggle.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * Mobile tap-to-toggle player controls E2E (master plan §5 PR-FE-2, §7 R4).
+ *
+ * Strategy:
+ *   - Mobile Portrait viewport (390×844) + touch UA
+ *   - Stub /api/config/flags to enable adaptive.player.tap_toggle
+ *   - Uses the existing e2e test user (SV_TEST_* secrets)
+ *   - Opens a VOD player via URL param and verifies:
+ *       1. PlayerGestureLayer renders (flag on, not TV)
+ *       2. Tapping video area hides controls (visible → hidden)
+ *       3. Tapping again shows controls (hidden → visible)
+ *
+ * NOTE: These tests are skipped when SV_TEST_* env vars are absent (same
+ * skip-guard pattern as auth.spec.ts). CI runs them with real-backend secrets.
+ */
+import { test, expect } from "@playwright/test";
+import { helpers } from "./helpers";
+
+const MOBILE_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+
+test.use({
+  userAgent: MOBILE_UA,
+  viewport: { width: 390, height: 844 },
+  hasTouch: true,
+});
+
+// Skip guard: tests require seeded backend credentials.
+const SKIP =
+  !process.env.SV_TEST_USER || !process.env.SV_TEST_PASS
+    ? "SV_TEST_USER / SV_TEST_PASS not set — skipping mobile tap-toggle E2E"
+    : null;
+
+test.beforeEach(async ({ page }) => {
+  // Enable tap-toggle flag for all tests in this suite.
+  await page.route("**/api/config/flags", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        flags: {
+          "adaptive.gestures.enabled": false,
+          "adaptive.mobile.enabled": true,
+          "adaptive.desktop.enabled": false,
+          "adaptive.player.tap_toggle": true,
+        },
+        scope: "global",
+        ttl_seconds: 5,
+        fetchedAt: new Date().toISOString(),
+      }),
+    });
+  });
+});
+
+test.describe("mobile tap-to-toggle controls", () => {
+  test("gesture layer is present when flag is on and UA is mobile", async ({
+    page,
+  }) => {
+    if (SKIP) {
+      test.skip(true, SKIP);
+      return;
+    }
+    await helpers.seedFakeAuth(page);
+    await page.goto("/live");
+    await page.waitForLoadState("networkidle");
+
+    // Open a channel — click the first channel card if present.
+    const firstCard = page.locator('[data-testid="channel-card"]').first();
+    if ((await firstCard.count()) === 0) {
+      test.skip(true, "No channel cards — backend may not have live channels");
+      return;
+    }
+    await firstCard.click();
+    await page.waitForSelector('[data-testid="player-shell"]', {
+      timeout: 5000,
+    });
+
+    // Gesture layer should exist (flag on + mobile UA → not TV dpad mode).
+    await expect(
+      page.locator('[data-testid="player-gesture-layer"]'),
+    ).toBeVisible();
+  });
+
+  test("tap on video area toggles controls visibility", async ({ page }) => {
+    if (SKIP) {
+      test.skip(true, SKIP);
+      return;
+    }
+    await helpers.seedFakeAuth(page);
+    await page.goto("/live");
+    await page.waitForLoadState("networkidle");
+
+    const firstCard = page.locator('[data-testid="channel-card"]').first();
+    if ((await firstCard.count()) === 0) {
+      test.skip(true, "No channel cards");
+      return;
+    }
+    await firstCard.click();
+    await page.waitForSelector('[data-testid="player-controls"]', {
+      timeout: 5000,
+    });
+
+    const controls = page.locator('[data-testid="player-controls"]');
+    const gestureLayer = page.locator('[data-testid="player-gesture-layer"]');
+
+    // Controls start visible (spec §4.1 — open visible).
+    await expect(controls).toBeVisible();
+
+    // Tap the gesture layer centre to hide the controls.
+    const box = await gestureLayer.boundingBox();
+    if (!box) throw new Error("gesture layer has no bounding box");
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    await page.touchscreen.tap(cx, cy);
+
+    // Controls should now be hidden (opacity 0 + aria-hidden).
+    await expect(controls).toHaveAttribute("aria-hidden", "true");
+
+    // Tap again to restore controls.
+    await page.touchscreen.tap(cx, cy);
+    await expect(controls).not.toHaveAttribute("aria-hidden", "true");
+  });
+
+  test("tapping a control button does NOT hide controls", async ({ page }) => {
+    if (SKIP) {
+      test.skip(true, SKIP);
+      return;
+    }
+    await helpers.seedFakeAuth(page);
+    await page.goto("/live");
+    await page.waitForLoadState("networkidle");
+
+    const firstCard = page.locator('[data-testid="channel-card"]').first();
+    if ((await firstCard.count()) === 0) {
+      test.skip(true, "No channel cards");
+      return;
+    }
+    await firstCard.click();
+    await page.waitForSelector('[data-testid="player-controls"]', {
+      timeout: 5000,
+    });
+
+    const controls = page.locator('[data-testid="player-controls"]');
+    await expect(controls).toBeVisible();
+
+    // Tap the Back button (a [data-player-control] element).
+    const backBtn = page.locator('button[aria-label="Back"]').first();
+    if ((await backBtn.count()) === 0) {
+      test.skip(true, "No Back button found in player");
+      return;
+    }
+    const btnBox = await backBtn.boundingBox();
+    if (!btnBox) throw new Error("back button has no bounding box");
+    await page.touchscreen.tap(
+      btnBox.x + btnBox.width / 2,
+      btnBox.y + btnBox.height / 2,
+    );
+
+    // Controls should remain visible — the tap was on a control element.
+    // (Back navigates away so we check the controls weren't hidden right
+    // before navigation. The test just asserts aria-hidden is not set.)
+    // Because Back closes the player, simply verify controls were not hidden
+    // before the navigation completed.
+    await expect(controls).not.toHaveAttribute("aria-hidden", "true");
+  });
+});


### PR DESCRIPTION
## Summary

- **PlayerGestureLayer** (new) — transparent overlay at z=1 between video and controls; detects taps (< 300ms, < 10px displacement) and calls `onTapToggle`; returns null on TV (dpad mode)
- **PlayerControls** — adds `toggleRef` prop that exposes an internal `toggle()` fn (show↔hide); `data-player-control` attr on all interactive elements; `onTouchEnd` on root div handles visible→hide when tap lands on empty area
- **PlayerShell** — mounts `PlayerGestureLayer` gated by `adaptive.player.tap_toggle` flag + non-TV; wires `controlsToggleRef` to both

Two-path tap-toggle design (master plan §5):
- `hidden → show`: GestureLayer catches taps that fall through the invisible controls layer → calls `controlsToggleRef.current()`
- `visible → hide`: Controls root `onTouchEnd` fires when tap target is not `[data-player-control]` → calls `toggle()`

## Test plan

- [ ] 8 new unit tests in `PlayerGestureLayer.test.tsx` — all passing locally
- [ ] 3 Playwright E2E tests in `mobile-tap-toggle.spec.ts` — skip-guarded on missing `SV_TEST_*` env; will run in CI with secrets
- [ ] 389/389 unit tests pass (`npm test -- --run`)
- [ ] Bundle 374 KB gzip (limit 600 KB)
- [ ] `npm run typecheck` clean
- [ ] Depends on PR #123 (v3-adaptive/input-mode-foundation) — `useFeatureFlag`, `getFlag`, `getInputMode` all come from that branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)