### PR TITLE
feat(phase-3-fe): content_uid schemas + DormantContentOverlay + revived_at sort

### DIFF
--- a/src/api/schemas.test.ts
+++ b/src/api/schemas.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { LoginResponseSchema, ChannelSchema } from "./schemas";
+import {
+  LoginResponseSchema,
+  ChannelSchema,
+  VodItemSchema,
+  SeriesPreviewSchema,
+  HistoryItemSchema,
+  FavoriteItemSchema,
+  EpgEntrySchema,
+  CatalogItemSchema,
+  ContentUidSchema,
+} from "./schemas";
 
 describe("API Zod schemas", () => {
   it("parses valid login response (cookie-based backend shape)", () => {
@@ -52,5 +62,177 @@ describe("API Zod schemas", () => {
       rating: 3.8,
     };
     expect(() => ChannelSchema.parse(raw)).not.toThrow();
+  });
+});
+
+// ─── Phase 3 FE: ContentUidSchema + optional content_uid on all data schemas ─
+
+describe("ContentUidSchema", () => {
+  it("accepts a valid 16-char lowercase hex string", () => {
+    expect(() => ContentUidSchema.parse("a1b2c3d4e5f60718")).not.toThrow();
+  });
+  it("accepts all lowercase hex digits", () => {
+    expect(() => ContentUidSchema.parse("abcdef0123456789")).not.toThrow();
+  });
+  it("rejects uppercase hex", () => {
+    expect(() => ContentUidSchema.parse("A1B2C3D4E5F60718")).toThrow();
+  });
+  it("rejects a string shorter than 16 chars", () => {
+    expect(() => ContentUidSchema.parse("a1b2c3d4e5f607")).toThrow();
+  });
+  it("rejects a string longer than 16 chars", () => {
+    expect(() => ContentUidSchema.parse("a1b2c3d4e5f607180")).toThrow();
+  });
+  it("rejects non-hex characters", () => {
+    expect(() => ContentUidSchema.parse("a1b2c3d4e5g60718")).toThrow();
+  });
+});
+
+describe("content_uid optional field on data schemas", () => {
+  it("ChannelSchema accepts content_uid when present", () => {
+    const raw = {
+      id: "1",
+      name: "BBC News",
+      categoryId: "5",
+      content_uid: "a1b2c3d4e5f60718",
+    };
+    expect(() => ChannelSchema.parse(raw)).not.toThrow();
+    expect(ChannelSchema.parse(raw).content_uid).toBe("a1b2c3d4e5f60718");
+  });
+  it("ChannelSchema remains valid without content_uid (optional)", () => {
+    const raw = { id: "1", name: "BBC News", categoryId: "5" };
+    expect(() => ChannelSchema.parse(raw)).not.toThrow();
+    expect(ChannelSchema.parse(raw).content_uid).toBeUndefined();
+  });
+  it("VodItemSchema accepts content_uid when present", () => {
+    const raw = {
+      id: "42",
+      name: "RRR",
+      categoryId: "10",
+      streamUrl: "http://host/vod/42.mkv",
+      content_uid: "b2c3d4e5f6071819",
+    };
+    expect(() => VodItemSchema.parse(raw)).not.toThrow();
+    expect(VodItemSchema.parse(raw).content_uid).toBe("b2c3d4e5f6071819");
+  });
+  it("VodItemSchema remains valid without content_uid", () => {
+    const raw = {
+      id: "42",
+      name: "RRR",
+      categoryId: "10",
+      streamUrl: "http://host/vod/42.mkv",
+    };
+    expect(() => VodItemSchema.parse(raw)).not.toThrow();
+  });
+  it("SeriesPreviewSchema accepts content_uid when present", () => {
+    const raw = {
+      id: "9",
+      name: "Breaking Bad",
+      categoryId: "7",
+      content_uid: "c3d4e5f607181920",
+    };
+    expect(() => SeriesPreviewSchema.parse(raw)).not.toThrow();
+  });
+  it("HistoryItemSchema accepts content_uid when present", () => {
+    const raw = {
+      id: 1,
+      content_type: "vod" as const,
+      content_id: 42,
+      content_name: "RRR",
+      content_icon: null,
+      progress_seconds: 300,
+      duration_seconds: 9000,
+      watched_at: "2026-05-01T10:00:00Z",
+      content_uid: "d4e5f60718192021",
+    };
+    expect(() => HistoryItemSchema.parse(raw)).not.toThrow();
+    expect(HistoryItemSchema.parse(raw).content_uid).toBe("d4e5f60718192021");
+  });
+  it("HistoryItemSchema remains valid without content_uid", () => {
+    const raw = {
+      id: 1,
+      content_type: "vod" as const,
+      content_id: 42,
+      content_name: null,
+      content_icon: null,
+      progress_seconds: 300,
+      duration_seconds: 9000,
+      watched_at: "2026-05-01T10:00:00Z",
+    };
+    expect(() => HistoryItemSchema.parse(raw)).not.toThrow();
+  });
+  it("FavoriteItemSchema accepts content_uid when present", () => {
+    const raw = {
+      id: 5,
+      content_type: "series" as const,
+      content_id: 9,
+      content_name: "Breaking Bad",
+      content_icon: null,
+      category_name: "Drama",
+      sort_order: 1,
+      added_at: "2026-05-01T10:00:00Z",
+      content_uid: "e5f6071819202122",
+    };
+    expect(() => FavoriteItemSchema.parse(raw)).not.toThrow();
+  });
+  it("EpgEntrySchema accepts content_uid when present", () => {
+    const raw = {
+      id: "e1",
+      channelId: "ch1",
+      title: "News",
+      start: "2026-05-01T10:00:00Z",
+      end: "2026-05-01T11:00:00Z",
+      content_uid: "f60718192021222a",
+    };
+    expect(() => EpgEntrySchema.parse(raw)).not.toThrow();
+  });
+  it("CatalogItemSchema (search results) accepts content_uid when present", () => {
+    const raw = {
+      id: "10",
+      name: "RRR",
+      type: "vod" as const,
+      categoryId: "5",
+      content_uid: "07181920212223ab",
+    };
+    expect(() => CatalogItemSchema.parse(raw)).not.toThrow();
+    expect(CatalogItemSchema.parse(raw).content_uid).toBe("07181920212223ab");
+  });
+  it("rejects invalid content_uid format on a schema", () => {
+    const raw = {
+      id: "1",
+      name: "BBC News",
+      categoryId: "5",
+      content_uid: "NOT-VALID-HEX-!!",
+    };
+    expect(() => ChannelSchema.parse(raw)).toThrow();
+  });
+});
+
+// ─── fetchStreamUrl uses content_uid when present ────────────────────────────
+
+describe("fetchStreamUrl — content_uid routing", () => {
+  it("uses content_uid as the path id when item has a content_uid", async () => {
+    // Dynamic import so the test stays in module scope.
+    const { buildStreamPath } = await import("./stream");
+    const uid = "a1b2c3d4e5f60718";
+    const path = buildStreamPath({ kind: "vod", id: "42", content_uid: uid });
+    expect(path).toContain(uid);
+    expect(path).not.toContain("42");
+  });
+  it("falls back to the numeric id when content_uid is absent", async () => {
+    const { buildStreamPath } = await import("./stream");
+    const path = buildStreamPath({ kind: "vod", id: "42" });
+    expect(path).toContain("42");
+  });
+  it("uses content_uid for live channels too", async () => {
+    const { buildStreamPath } = await import("./stream");
+    const uid = "b1c2d3e4f5061718";
+    const path = buildStreamPath({
+      kind: "live",
+      id: "705131",
+      content_uid: uid,
+    });
+    expect(path).toContain(uid);
+    expect(path).not.toContain("705131");
   });
 });

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -1,6 +1,15 @@
 import { z } from "zod";
 
 /**
+ * ContentUidSchema — 16-char lowercase hex string produced by sha1[:16] of the
+ * canonical content title (see backend content-identity.service.ts).
+ * Optional on all catalog/history/favorites shapes in Phase 3; becomes required
+ * in Phase 4 after 30-day clean observation.
+ */
+export const ContentUidSchema = z.string().regex(/^[a-f0-9]{16}$/);
+export type ContentUid = z.infer<typeof ContentUidSchema>;
+
+/**
  * RatingSchema — the Xtream provider returns `rating` as any of:
  *   - a string ("3.8", "0")
  *   - a number (3.8, 0)
@@ -74,6 +83,8 @@ export const ChannelSchema = z.object({
   epgChannelId: z.string().optional(),
   /** Language inferred server-side from category name (backend PR #45 / frontend issue #52). */
   inferredLang: InferredLangSchema,
+  /** Phase 3 content-identity: provider-stable content uid (optional until Phase 4). */
+  content_uid: ContentUidSchema.optional(),
 });
 export type Channel = z.infer<typeof ChannelSchema>;
 
@@ -84,6 +95,8 @@ export const EpgEntrySchema = z.object({
   start: z.string().datetime(),
   end: z.string().datetime(),
   description: z.string().optional(),
+  /** Phase 3 content-identity: provider-stable content uid (optional until Phase 4). */
+  content_uid: ContentUidSchema.optional(),
 });
 export type EpgEntry = z.infer<typeof EpgEntrySchema>;
 
@@ -95,6 +108,8 @@ export const VodItemSchema = z.object({
   posterUrl: z.string().optional(),
   rating: z.number().optional(),
   addedAt: z.string().datetime().optional(),
+  /** Phase 3 content-identity: provider-stable content uid (optional until Phase 4). */
+  content_uid: ContentUidSchema.optional(),
 });
 export type VodItem = z.infer<typeof VodItemSchema>;
 
@@ -106,6 +121,8 @@ export const SeriesPreviewSchema = z.object({
   categoryId: z.string(),
   posterUrl: z.string().optional(),
   seasons: z.number().optional(),
+  /** Phase 3 content-identity: provider-stable content uid (optional until Phase 4). */
+  content_uid: ContentUidSchema.optional(),
 });
 export type SeriesPreview = z.infer<typeof SeriesPreviewSchema>;
 
@@ -227,6 +244,8 @@ export const CatalogItemSchema = z.object({
   year: z.string().optional(),
   /** Language inferred server-side from category name (backend PR #45 / frontend issue #52). */
   inferredLang: InferredLangSchema,
+  /** Phase 3 content-identity: provider-stable content uid (optional until Phase 4). */
+  content_uid: ContentUidSchema.optional(),
 });
 export type CatalogItem = z.infer<typeof CatalogItemSchema>;
 
@@ -313,6 +332,8 @@ export const FavoriteItemSchema = z.object({
   category_name: z.string().nullable(),
   sort_order: z.number(),
   added_at: z.string(),
+  /** Phase 3 content-identity: provider-stable content uid (optional until Phase 4). */
+  content_uid: ContentUidSchema.optional(),
 });
 export type FavoriteItem = z.infer<typeof FavoriteItemSchema>;
 
@@ -335,6 +356,15 @@ export const HistoryItemSchema = z.object({
   progress_seconds: z.number(),
   duration_seconds: z.number(),
   watched_at: z.string(),
+  /**
+   * Phase 3 content-identity: set by a DB trigger when content_uid transitions
+   * NULL→non-NULL (i.e. when a dormant history item's content is found on the
+   * new provider). Used as a sort key in Continue Watching to re-surface revived
+   * content above older items (optional until Phase 4).
+   */
+  revived_at: z.string().optional(),
+  /** Phase 3 content-identity: provider-stable content uid (optional until Phase 4). */
+  content_uid: ContentUidSchema.optional(),
 });
 export type HistoryItem = z.infer<typeof HistoryItemSchema>;
 

--- a/src/api/stream.ts
+++ b/src/api/stream.ts
@@ -11,8 +11,13 @@
  * We construct the URL directly — no extra fetch needed, the backend
  * streams the content at this URL.
  *
- * NOTE: The backend stream.router.ts at /:type/:id expects a numeric ID.
- * The URL is constructed here and fed directly to hls.js / <video src>.
+ * Phase 3 content-identity update:
+ *  When a content item carries a `content_uid` (16-char hex), we send it as
+ *  the path id. The backend stream.router.ts discriminates via isContentUid()
+ *  and routes to resolveStreamUrl() directly, bypassing the legacy provider
+ *  numeric-id lookup. This fixes episode plays (synthetic episode keys) and
+ *  movies not in sv_content_provider_map under SV_USE_CONTENT_UID=1.
+ *  Legacy numeric ids are still sent as a fallback when content_uid is absent.
  *
  * For series episodes with season/episode, we encode them as query params
  * (the backend provider uses the stream ID from the database, so season/episode
@@ -26,29 +31,52 @@ import type { PlayerKind } from "../player/PlayerProvider";
 
 const BASE_URL = import.meta.env.DEV ? "http://localhost:3001" : "";
 
-interface FetchStreamUrlOptions {
+interface BuildStreamPathOptions {
   kind: PlayerKind;
+  /** Legacy numeric id (fallback when content_uid is absent). */
   id: string;
+  /** Phase 3: 16-char hex content_uid. Preferred over numeric id. */
+  content_uid?: string;
   season?: number;
   episode?: number;
 }
 
+// Keep backwards-compatible alias.
+type FetchStreamUrlOptions = BuildStreamPathOptions;
+
+const TYPE_MAP: Record<PlayerKind, string> = {
+  live: "live",
+  vod: "vod",
+  "series-episode": "series",
+};
+
 /**
- * Builds the proxied stream URL for a given content item.
- * Returns a URL string that can be passed directly to hls.js or <video>.
+ * buildStreamPath — returns just the path portion `/api/stream/<type>/<id>`.
+ * Exported for unit testing without the BASE_URL prefix.
  *
- * The backend streams the content (no redirect, no JSON) at this URL,
- * so we return the URL for the player to load directly.
+ * Prefers `content_uid` when present; falls back to legacy `id`.
+ */
+export function buildStreamPath({
+  kind,
+  id,
+  content_uid,
+}: BuildStreamPathOptions): string {
+  const type = TYPE_MAP[kind];
+  const resolvedId = content_uid ?? id;
+  return `/api/stream/${type}/${encodeURIComponent(resolvedId)}`;
+}
+
+/**
+ * fetchStreamUrl — full URL including BASE_URL, ready for hls.js / <video src>.
+ *
+ * Prefers `content_uid` when present; falls back to legacy numeric `id`.
+ * The backend streams the content (no redirect, no JSON) at this URL.
  */
 export function fetchStreamUrl({
   kind,
   id,
+  content_uid,
 }: FetchStreamUrlOptions): string {
-  const typeMap: Record<PlayerKind, string> = {
-    live: "live",
-    vod: "vod",
-    "series-episode": "series",
-  };
-  const type = typeMap[kind];
-  return `${BASE_URL}/api/stream/${type}/${encodeURIComponent(id)}`;
+  // exactOptionalPropertyTypes: only spread content_uid when defined.
+  return `${BASE_URL}${buildStreamPath({ kind, id, ...(content_uid ? { content_uid } : {}) })}`;
 }

--- a/src/components/DormantContentOverlay.test.tsx
+++ b/src/components/DormantContentOverlay.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * DormantContentOverlay tests — TDD RED phase.
+ * Tests written before implementation exists.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DormantContentOverlay } from "./DormantContentOverlay";
+
+// Stub norigin spatial navigation (not needed for overlay unit tests)
+vi.mock("@noriginmedia/norigin-spatial-navigation", () => ({
+  useFocusable: () => ({
+    ref: { current: null },
+    focused: false,
+    focusSelf: vi.fn(),
+  }),
+  setFocus: vi.fn(),
+}));
+
+describe("DormantContentOverlay", () => {
+  it("renders the dormant-content message", () => {
+    render(<DormantContentOverlay onDismiss={vi.fn()} />);
+    expect(
+      screen.getByText(/isn't on your current provider/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a dismiss button", () => {
+    render(<DormantContentOverlay onDismiss={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: /back to browse/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onDismiss when the dismiss button is clicked", async () => {
+    const user = userEvent.setup();
+    const onDismiss = vi.fn();
+    render(<DormantContentOverlay onDismiss={onDismiss} />);
+    await user.click(screen.getByRole("button", { name: /back to browse/i }));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("has role=alertdialog for screen-reader accessibility", () => {
+    render(<DormantContentOverlay onDismiss={vi.fn()} />);
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+  });
+
+  it("shows the full spec copy about provider returning", () => {
+    render(<DormantContentOverlay onDismiss={vi.fn()} />);
+    expect(
+      screen.getByText(/bring it back when the source returns/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/DormantContentOverlay.tsx
+++ b/src/components/DormantContentOverlay.tsx
@@ -1,0 +1,156 @@
+/**
+ * DormantContentOverlay — shown when the backend returns HTTP 410 DORMANT.
+ *
+ * A 410 from stream.router.ts means: the master content_uid record exists in
+ * sv_content_master, but there is no matching row in sv_content_provider_map for
+ * the active provider (xtream:8027e2a2). The title exists in the library but the
+ * current provider doesn't carry it.
+ *
+ * Design intent (matches FailureOverlay visual language from PlayerShell):
+ *  - Full-screen dark overlay over the player area
+ *  - Teal/indigo glow icon (brand Ambient Depth palette)
+ *  - Copper accent on the dismiss button hover/focus state
+ *  - D-pad focusable dismiss button via norigin useFocusable
+ *  - role=alertdialog for screen-reader accessibility
+ *  - NO retry button — the content isn't a transient error, it's a library gap
+ */
+import type { RefObject } from "react";
+import { useEffect } from "react";
+import {
+  useFocusable,
+  setFocus,
+} from "@noriginmedia/norigin-spatial-navigation";
+
+const FK_DORMANT_DISMISS = "DORMANT_OVERLAY_DISMISS";
+
+interface DormantContentOverlayProps {
+  onDismiss: () => void;
+}
+
+export function DormantContentOverlay({
+  onDismiss,
+}: DormantContentOverlayProps) {
+  const { ref, focused } = useFocusable({
+    focusKey: FK_DORMANT_DISMISS,
+    onEnterPress: onDismiss,
+  });
+
+  // Auto-focus the dismiss button on mount.
+  useEffect(() => {
+    setFocus(FK_DORMANT_DISMISS);
+  }, []);
+
+  // Escape/Back dismisses.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" || e.key === "Back" || e.key === "GoBack") {
+        e.preventDefault();
+        onDismiss();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [onDismiss]);
+
+  return (
+    <div
+      data-testid="dormant-content-overlay"
+      role="alertdialog"
+      aria-modal="true"
+      aria-label="Content unavailable on current provider"
+      style={{
+        position: "absolute",
+        inset: 0,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "rgba(0,0,0,0.82)",
+        padding: "var(--space-6)",
+        zIndex: 10,
+      }}
+    >
+      <div
+        style={{
+          maxWidth: "520px",
+          width: "100%",
+          background:
+            "color-mix(in srgb, var(--accent-teal, #2DD4A8) 8%, var(--bg-card, #1a1a2e))",
+          border:
+            "1px solid color-mix(in srgb, var(--accent-teal, #2DD4A8) 40%, transparent)",
+          borderRadius: "var(--radius-md, 12px)",
+          padding: "var(--space-8, 2rem) var(--space-6, 1.5rem)",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: "var(--space-4, 1rem)",
+          textAlign: "center",
+          color: "var(--text-primary, #EDE4D3)",
+          boxShadow:
+            "0 0 32px color-mix(in srgb, var(--accent-teal, #2DD4A8) 15%, transparent)",
+        }}
+      >
+        {/* Teal library / content icon */}
+        <span
+          aria-hidden="true"
+          style={{
+            fontSize: "40px",
+            lineHeight: 1,
+            filter:
+              "drop-shadow(0 0 8px color-mix(in srgb, var(--accent-teal, #2DD4A8) 60%, transparent))",
+          }}
+        >
+          📚
+        </span>
+
+        <p
+          style={{
+            fontSize: "var(--text-title-size, 1.125rem)",
+            fontWeight: 600,
+            margin: 0,
+            lineHeight: 1.3,
+          }}
+        >
+          This title isn't on your current provider yet.
+        </p>
+
+        <p
+          style={{
+            color: "var(--text-secondary, rgba(237,228,211,0.7))",
+            fontSize: "var(--text-body-size, 0.9375rem)",
+            margin: 0,
+            lineHeight: 1.6,
+            maxWidth: "400px",
+          }}
+        >
+          We'll bring it back when the source returns. In the meantime, try
+          exploring other titles you might enjoy.
+        </p>
+
+        <button
+          ref={ref as RefObject<HTMLButtonElement>}
+          type="button"
+          className="focus-ring"
+          onClick={onDismiss}
+          style={{
+            marginTop: "var(--space-2, 0.5rem)",
+            background: focused
+              ? "var(--accent-copper, #C87941)"
+              : "rgba(255,255,255,0.12)",
+            color: focused
+              ? "var(--bg-base, #12100e)"
+              : "var(--text-primary, #EDE4D3)",
+            border: "none",
+            borderRadius: "var(--radius-sm, 8px)",
+            padding: "var(--space-2, 0.5rem) var(--space-6, 1.5rem)",
+            cursor: "pointer",
+            fontSize: "var(--text-body-size, 0.9375rem)",
+            fontWeight: 500,
+            transition: "background 0.15s, color 0.15s",
+          }}
+        >
+          Back to browse
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/history/sortByActivity.test.ts
+++ b/src/features/history/sortByActivity.test.ts
@@ -1,0 +1,91 @@
+/**
+ * sortByActivity tests — TDD RED phase.
+ * Tests the revived_at sort key for Continue Watching.
+ * Written before implementation exists.
+ */
+import { describe, it, expect } from "vitest";
+import { sortByActivity } from "./sortByActivity";
+import type { HistoryItem } from "../../api/schemas";
+
+function makeItem(
+  overrides: Partial<HistoryItem> & { id: number },
+): HistoryItem {
+  return {
+    content_type: "vod",
+    content_id: overrides.id,
+    content_name: `Title ${overrides.id}`,
+    content_icon: null,
+    progress_seconds: 100,
+    duration_seconds: 9000,
+    watched_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("sortByActivity", () => {
+  it("sorts by watched_at descending when revived_at is absent", () => {
+    const items = [
+      makeItem({ id: 1, watched_at: "2026-01-01T00:00:00Z" }),
+      makeItem({ id: 2, watched_at: "2026-01-03T00:00:00Z" }),
+      makeItem({ id: 3, watched_at: "2026-01-02T00:00:00Z" }),
+    ];
+    const sorted = sortByActivity(items);
+    expect(sorted.map((i) => i.content_id)).toEqual([2, 3, 1]);
+  });
+
+  it("a revived item with revived_at > watched_at sorts above items with later watched_at", () => {
+    // Item A: watched 3 days ago, revived yesterday
+    // Item B: watched yesterday (but not revived)
+    // A's effective sort key = revived_at (yesterday), same as B's watched_at
+    // When equal, insertion order wins — but revived_at should put A higher
+    const itemA = makeItem({
+      id: 1,
+      watched_at: "2026-05-01T00:00:00Z", // 3 days ago
+      revived_at: "2026-05-04T10:00:00Z", // today → should rank high
+    });
+    const itemB = makeItem({
+      id: 2,
+      watched_at: "2026-05-02T00:00:00Z", // 2 days ago, no revived_at
+    });
+    const sorted = sortByActivity([itemB, itemA]);
+    // itemA's effective key (revived_at=2026-05-04) beats itemB (watched_at=2026-05-02)
+    expect(sorted[0]!.content_id).toBe(1);
+  });
+
+  it("uses MAX(watched_at, revived_at) — watched_at is used when it is more recent than revived_at", () => {
+    const itemA = makeItem({
+      id: 1,
+      watched_at: "2026-05-04T00:00:00Z", // today
+      revived_at: "2026-04-01T00:00:00Z", // old revive
+    });
+    const itemB = makeItem({
+      id: 2,
+      watched_at: "2026-05-03T00:00:00Z", // yesterday
+    });
+    const sorted = sortByActivity([itemB, itemA]);
+    // A's effective key = MAX(2026-05-04, 2026-04-01) = 2026-05-04 → ranks #1
+    expect(sorted[0]!.content_id).toBe(1);
+  });
+
+  it("handles undefined revived_at gracefully (no crash)", () => {
+    const items = [
+      makeItem({ id: 1, watched_at: "2026-01-02T00:00:00Z" }),
+      makeItem({
+        id: 2,
+        watched_at: "2026-01-01T00:00:00Z",
+        revived_at: undefined,
+      }),
+    ];
+    expect(() => sortByActivity(items)).not.toThrow();
+    expect(sortByActivity(items)[0]!.content_id).toBe(1);
+  });
+
+  it("returns an empty array unchanged", () => {
+    expect(sortByActivity([])).toEqual([]);
+  });
+
+  it("single item returns it unchanged", () => {
+    const items = [makeItem({ id: 1 })];
+    expect(sortByActivity(items)).toHaveLength(1);
+  });
+});

--- a/src/features/history/sortByActivity.ts
+++ b/src/features/history/sortByActivity.ts
@@ -1,0 +1,36 @@
+/**
+ * sortByActivity — sort key for Continue Watching (Phase 3 content-identity).
+ *
+ * Sort key: MAX(watched_at, revived_at ?? watched_at)
+ *
+ * Why: When a dormant history row has its content_uid matched by the Phase 2
+ * backfill trigger, `revived_at` is stamped with NOW(). This means a title the
+ * user watched months ago can "come back" to the top of Continue Watching when
+ * it reappears on the provider — exactly the "library analogy" the spec describes.
+ *
+ * Without this, a revived item (watched_at = old, revived_at = today) would stay
+ * buried below items the user watched yesterday, and the revival would be invisible.
+ */
+import type { HistoryItem } from "../../api/schemas";
+
+/**
+ * Returns the effective activity timestamp for a history item.
+ * Uses MAX(watched_at, revived_at) so revived items surface above old items.
+ */
+function effectiveActivityAt(item: HistoryItem): number {
+  const watchedMs = new Date(item.watched_at).getTime();
+  const revivedMs = item.revived_at
+    ? new Date(item.revived_at).getTime()
+    : -Infinity;
+  return Math.max(watchedMs, revivedMs);
+}
+
+/**
+ * Sort history items by effective activity descending (most recent first).
+ * Does NOT mutate the input array.
+ */
+export function sortByActivity(items: HistoryItem[]): HistoryItem[] {
+  return [...items].sort(
+    (a, b) => effectiveActivityAt(b) - effectiveActivityAt(a),
+  );
+}

--- a/src/features/history/useWatchHistory.ts
+++ b/src/features/history/useWatchHistory.ts
@@ -5,8 +5,17 @@
  * on mount. Exposes `record()` for playback components to log progress.
  */
 import { useState, useEffect, useCallback } from "react";
-import { fetchHistory, recordHistory, removeHistoryItem } from "../../api/history";
-import type { HistoryItem, RecordHistoryBody, ContentType } from "../../api/schemas";
+import {
+  fetchHistory,
+  recordHistory,
+  removeHistoryItem,
+} from "../../api/history";
+import type {
+  HistoryItem,
+  RecordHistoryBody,
+  ContentType,
+} from "../../api/schemas";
+import { sortByActivity } from "./sortByActivity";
 
 export interface UseWatchHistoryReturn {
   history: HistoryItem[];
@@ -27,7 +36,9 @@ export function useWatchHistory(): UseWatchHistoryReturn {
     setError(null);
     try {
       const items = await fetchHistory();
-      setHistory(items);
+      // Phase 3 content-identity: sort by MAX(watched_at, revived_at) so
+      // dormant rows revived by the backend trigger surface back to the top.
+      setHistory(sortByActivity(items));
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Failed to load watch history",

--- a/src/player/PlayerShell.tsx
+++ b/src/player/PlayerShell.tsx
@@ -23,6 +23,7 @@ import { PlayerControls } from "./PlayerControls";
 import { PlayerGestureLayer } from "./PlayerGestureLayer";
 import { useReducedMotion } from "./useReducedMotion";
 import { classifyFailure, type FailureClass } from "./classifyFailure";
+import { DormantContentOverlay } from "../components/DormantContentOverlay";
 import { markTierLocked } from "../features/movies/tierLockCache";
 import { recordHistory } from "../api/history";
 import { getLangPref } from "../lib/langPref";
@@ -265,7 +266,11 @@ export function PlayerShell() {
           </div>
         )}
 
-        {showFailure && (
+        {showFailure && failureClass === "dormant" && (
+          <DormantContentOverlay onDismiss={close} />
+        )}
+
+        {showFailure && failureClass !== "dormant" && (
           <FailureOverlay
             kind={failureClass ?? "generic"}
             playerKind={kind}

--- a/src/player/classifyFailure.ts
+++ b/src/player/classifyFailure.ts
@@ -5,6 +5,11 @@ import type { PlayerKind } from "./PlayerProvider";
  * and decide whether to memo a tier-lock hit (spec §9.2 / §9.3).
  *
  * Heuristics:
+ *  - Backend returns HTTP 410 + `{ error: "DORMANT" }` when a content_uid is
+ *    found in sv_content_master but has no row in sv_content_provider_map for
+ *    the active provider. The useHlsPlayer HEAD probe detects 410 and sets
+ *    the error message to include `"dormant:"` so this classifier picks it up.
+ *    PlayerShell renders DormantContentOverlay instead of FailureOverlay.
  *  - VOD/series-episode that errors with zero duration + zero playhead, before
  *    any frame ever arrived, is almost always the Xtream account plan refusing
  *    the container extension → "tier-lock".
@@ -22,7 +27,11 @@ import type { PlayerKind } from "./PlayerProvider";
  *    wording.
  *  - Everything else → "generic".
  */
-export type FailureClass = "tier-lock" | "stream-offline" | "generic";
+export type FailureClass =
+  | "dormant"
+  | "tier-lock"
+  | "stream-offline"
+  | "generic";
 
 export function classifyFailure(
   kind: PlayerKind,
@@ -30,6 +39,9 @@ export function classifyFailure(
   currentTime: number,
   errorMessage: string | undefined,
 ): FailureClass {
+  if (errorMessage && errorMessage.includes("dormant:")) {
+    return "dormant";
+  }
   if (errorMessage && errorMessage.includes("stream-offline:")) {
     return "stream-offline";
   }

--- a/src/player/useHlsPlayer.ts
+++ b/src/player/useHlsPlayer.ts
@@ -273,19 +273,22 @@ export function useHlsPlayer(
       setError(new Error(err?.message ?? "Video playback error"));
       setStatus("error");
       // The browser swallows HTTP status into a generic MediaError on the
-      // native VOD/series path, so a backend 503 + X-Stream-Status: offline
-      // (placeholder substitution) would otherwise surface as the misleading
-      // "tier-lock" overlay. Probe the URL with HEAD and rewrite the error
-      // message to include the "stream-offline:" marker that classifyFailure
-      // recognises. Fire-and-forget — happy path pays no extra latency, and
-      // probe failures fall through to the existing generic copy.
+      // native VOD/series path. Probe the URL with HEAD to detect:
+      //  • 503 + X-Stream-Status: offline → "stream-offline:" marker
+      //  • 410 (DORMANT) → "dormant:" marker (Phase 3 content-identity)
+      // Fire-and-forget — happy path pays no extra latency, and probe
+      // failures fall through to the existing generic copy.
       if (src) {
         void fetch(src, {
           method: "HEAD",
           credentials: "include",
         })
           .then((res) => {
-            if (
+            if (res.status === 410) {
+              setError(
+                new Error("dormant: title not on current provider (HTTP 410)"),
+              );
+            } else if (
               res.status === 503 &&
               res.headers.get("X-Stream-Status") === "offline"
             ) {


### PR DESCRIPTION
## Summary

Phase 3 frontend half of the StreamVault content-identity layer (Tasks 3.4, 3.5, 3.6 from `docs/superpowers/plans/2026-05-03-streamvault-content-identity-implementation.md`).

- **Task 3.4** — `ContentUidSchema` + optional `content_uid` on Channel / VodItem / SeriesPreview / HistoryItem / Favorite / EpgEntry / CatalogItem; `revived_at` added to HistoryItem; `buildStreamPath()` prefers content_uid over legacy numeric id.
- **Task 3.5** — `DormantContentOverlay` (role=alertdialog, D-pad focusable, brand-aligned teal glow + copper accent). Wired into `PlayerShell` via new `"dormant"` `FailureClass`. `useHlsPlayer` HEAD probe now detects HTTP 410 in addition to 503.
- **Task 3.6** — `sortByActivity` using `MAX(watched_at, revived_at)`; applied in `useWatchHistory.reload()`.

## Why this unblocks playback under flag-on

Backend Phase 3 episode item_ids in `sv_content_provider_map` use synthetic keys (`<seriesId>:S<n>E<m>`) that don't match upstream stream_ids. ~9% of catalog VOD rows aren't in `sv_content_provider_map`. Under `SV_USE_CONTENT_UID=1`, sending numeric ids 404s; sending `content_uid` resolves via master row.

Backend (PR #82/#83) already wires content_uid LEFT JOIN into searchCatalog and surfaces content_uid on favorites/history/search responses. Production currently runs with `SV_USE_CONTENT_UID=0` and stays OFF until this PR merges + flag-on playback is verified.

## Verification

- **Tests:** 420 passed (was 389 baseline; +31 new tests across 3 files)
- **Lint:** 0 errors
- **Typecheck:** clean (under exactOptionalPropertyTypes)
- **Bundle:** 313.71 KB gzip main chunk (under 600 KB budget)

## Test plan

- [ ] CI green (lint + typecheck + unit tests + Playwright E2E)
- [ ] Merge with `SV_USE_CONTENT_UID=0` (default) — frontend changes are forward-compatible (legacy numeric id fallback intact when content_uid absent)
- [ ] Flip `SV_USE_CONTENT_UID=1` in `ai-orchestration/.env` + restart backend
- [ ] Smoke test on prod: play a Telugu series episode (was 404'ing under flag-on with synthetic episode keys) — should resolve via content_uid
- [ ] Smoke test: play a movie not in `sv_content_provider_map` — should surface DormantContentOverlay, not crash
- [ ] Verify Continue Watching: a row with `revived_at > watched_at` ranks above older rows
- [ ] 24h soak with flag on; monitor 410 rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)